### PR TITLE
Use Hypothesis to test serializers and deserializers

### DIFF
--- a/contrib/ingest_botocore.py
+++ b/contrib/ingest_botocore.py
@@ -65,6 +65,8 @@ def process_service_2(path, model):
     for name, shape in service.get("shapes", {}).items():
         s = shapes[name] = collections.OrderedDict()
         s['type'] = shape['type']
+        if 'documentation' in shape:
+            s['documentation'] = shape['documentation']
         if s['type'] == 'structure':
             s['members'] = []
             for k, v in shape['members'].items():
@@ -73,6 +75,9 @@ def process_service_2(path, model):
                 s['members'].append(m)
         elif s['type'] == 'list':
             s['of'] = shape['member']['shape']
+        elif s['type'] == 'map':
+            s['key'] = shape['key']['shape']
+            s['value'] = shape['value']['shape']
 
     operations = model['operations']
     for name, operation in service.get("operations", {}).items():
@@ -90,6 +95,10 @@ def process_service(name, path, output_path):
     model['endpoints'] = []
     model['operations'] = collections.OrderedDict()
     model['shapes'] = collections.OrderedDict()
+
+    model['metadata']["request-pipeline"] = [
+        "libcloudcore.serializers.xml:XmlSerializer"
+    ]
 
     process_endpoints(os.path.join(path, "../../_endpoints.json"), name, model)
     process_service_2(path, model)

--- a/libcloudcore/auth/basic_auth.py
+++ b/libcloudcore/auth/basic_auth.py
@@ -18,7 +18,7 @@ from libcloudcore.layer import Layer
 
 class BasicAuth(Layer):
 
-    def __init__(self, username, password):
+    def __init__(self, username=None, password=None):
         self.username = username
         self.password = password
 

--- a/libcloudcore/auth/token.py
+++ b/libcloudcore/auth/token.py
@@ -18,7 +18,7 @@ from libcloudcore.layer import Layer
 
 class TokenAuth(Layer):
 
-    def __init__(self, token):
+    def __init__(self, token=None):
         self.token = token
 
     def before_call(self, request, operation, **params):

--- a/libcloudcore/data/aws/autoscaling/service.json
+++ b/libcloudcore/data/aws/autoscaling/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://autoscaling.amazonaws.com/doc/2011-01-01/"
         }
@@ -405,6 +408,7 @@
         },
         "Activity": {
             "type": "structure",
+            "documentation": "<p>Describes scaling activity, which is a long-running process that represents a change to your Auto Scaling group, such as changing its size or replacing an instance.</p>",
             "members": [
                 {
                     "name": "ActivityId",
@@ -474,6 +478,7 @@
         },
         "AdjustmentType": {
             "type": "structure",
+            "documentation": "<p>Describes a policy adjustment type.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html\">Dynamic Scaling</a> in the <i>Auto Scaling Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "AdjustmentType",
@@ -488,6 +493,7 @@
         },
         "Alarm": {
             "type": "structure",
+            "documentation": "<p>Describes an alarm.</p>",
             "members": [
                 {
                     "name": "AlarmName",
@@ -507,6 +513,7 @@
         },
         "AlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>You already have an Auto Scaling group or launch configuration with this name.</p>",
             "members": [
                 {
                     "name": "message",
@@ -556,6 +563,7 @@
         },
         "AutoScalingGroup": {
             "type": "structure",
+            "documentation": "<p>Describes an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "AutoScalingGroupName",
@@ -713,6 +721,7 @@
         },
         "AutoScalingInstanceDetails": {
             "type": "structure",
+            "documentation": "<p>Describes an EC2 instance associated with an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -787,6 +796,7 @@
         },
         "BlockDeviceMapping": {
             "type": "structure",
+            "documentation": "<p>Describes a block device mapping.</p>",
             "members": [
                 {
                     "name": "VirtualName",
@@ -1086,6 +1096,7 @@
         },
         "DeletePolicyType": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "AutoScalingGroupName",
@@ -1485,6 +1496,7 @@
         },
         "Ebs": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon EBS volume.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -1538,6 +1550,7 @@
         },
         "EnabledMetric": {
             "type": "structure",
+            "documentation": "<p>Describes an enabled metric.</p>",
             "members": [
                 {
                     "name": "Metric",
@@ -1645,6 +1658,7 @@
         },
         "Filter": {
             "type": "structure",
+            "documentation": "<p>Describes a filter.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1679,6 +1693,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>Describes an EC2 instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -1713,6 +1728,7 @@
         },
         "InstanceMonitoring": {
             "type": "structure",
+            "documentation": "<p>Describes whether instance monitoring is enabled.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -1727,6 +1743,7 @@
         },
         "InvalidNextToken": {
             "type": "structure",
+            "documentation": "<p>The <code>NextToken</code> value is not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1736,6 +1753,7 @@
         },
         "LaunchConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes a launch configuration.</p>",
             "members": [
                 {
                     "name": "LaunchConfigurationName",
@@ -1895,6 +1913,7 @@
         },
         "LifecycleHook": {
             "type": "structure",
+            "documentation": "<p>Describes a lifecycle hook, which tells Auto Scaling that you want to perform an action when an instance launches or terminates. When you have a lifecycle hook in place, the Auto Scaling group will either:</p> <ul> <li>Pause the instance after it launches, but before it is put into service</li> <li>Pause the instance as it terminates, but before it is fully terminated</li> </ul> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingPendingState.html\">Auto Scaling Pending State</a> and <a href=\"http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/AutoScalingTerminatingState.html\">Auto Scaling Terminating State</a> in the <i>Auto Scaling Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "LifecycleHookName",
@@ -1959,6 +1978,7 @@
         },
         "LimitExceededFault": {
             "type": "structure",
+            "documentation": "<p>You have already reached a limit for your Auto Scaling resources (for example, groups, launch configurations, or lifecycle hooks). For more information, see <a>DescribeAccountLimits</a>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1972,6 +1992,7 @@
         },
         "LoadBalancerState": {
             "type": "structure",
+            "documentation": "<p>Describes the state of a load balancer.</p>",
             "members": [
                 {
                     "name": "LoadBalancerName",
@@ -2000,6 +2021,7 @@
         },
         "MetricCollectionType": {
             "type": "structure",
+            "documentation": "<p>Describes a metric.</p>",
             "members": [
                 {
                     "name": "Metric",
@@ -2014,6 +2036,7 @@
         },
         "MetricGranularityType": {
             "type": "structure",
+            "documentation": "<p>Describes a granularity of a metric.</p>",
             "members": [
                 {
                     "name": "Granularity",
@@ -2047,6 +2070,7 @@
         },
         "NotificationConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes a notification.</p>",
             "members": [
                 {
                     "name": "AutoScalingGroupName",
@@ -2111,6 +2135,7 @@
         },
         "ProcessType": {
             "type": "structure",
+            "documentation": "<p>Describes a process type.</p> <p>For more information, see <a href=\"http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/US_SuspendResume.html#process-types\">Auto Scaling Processes</a> in the <i>Auto Scaling Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "ProcessName",
@@ -2344,6 +2369,7 @@
         },
         "ResourceContentionFault": {
             "type": "structure",
+            "documentation": "<p>You already have a pending update to an Auto Scaling resource (for example, a group, instance, or load balancer).</p>",
             "members": [
                 {
                     "name": "message",
@@ -2353,6 +2379,7 @@
         },
         "ResourceInUseFault": {
             "type": "structure",
+            "documentation": "<p>The Auto Scaling group or launch configuration can't be deleted because it is in use.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2365,6 +2392,7 @@
         },
         "ScalingActivityInProgressFault": {
             "type": "structure",
+            "documentation": "<p>The Auto Scaling group can't be deleted because there are scaling activities in progress.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2381,6 +2409,7 @@
         },
         "ScalingPolicy": {
             "type": "structure",
+            "documentation": "<p>Describes a scaling policy.</p>",
             "members": [
                 {
                     "name": "AutoScalingGroupName",
@@ -2485,6 +2514,7 @@
         },
         "ScheduledUpdateGroupAction": {
             "type": "structure",
+            "documentation": "<p>Describes a scheduled update to an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "AutoScalingGroupName",
@@ -2597,6 +2627,7 @@
         },
         "StepAdjustment": {
             "type": "structure",
+            "documentation": "<p>Describes an adjustment based on the difference between the value of the aggregated CloudWatch metric and the breach threshold that you've defined for the alarm.</p> <p>For the following examples, suppose that you have an alarm with a breach threshold of 50:</p> <ul> <li> <p>If you want the adjustment to be triggered when the metric is greater than or equal to 50 and less than 60, specify a lower bound of 0 and an upper bound of 10.</p> </li> <li> <p>If you want the adjustment to be triggered when the metric is greater than 40 and less than or equal to 50, specify a lower bound of -10 and an upper bound of 0.</p> </li> </ul> <p>There are a few rules for the step adjustments for your step policy:</p> <ul> <li> <p>The ranges of your step adjustments can't overlap or have a gap.</p> </li> <li> <p>At most one step adjustment can have a null lower bound. If one step adjustment has a negative lower bound, then there must be a step adjustment with a null lower bound.</p> </li> <li> <p>At most one step adjustment can have a null upper bound. If one step adjustment has a positive upper bound, then there must be a step adjustment with a null upper bound.</p> </li> <li> <p>The upper and lower bound can't be null in the same step adjustment.</p> </li> </ul>",
             "members": [
                 {
                     "name": "MetricIntervalLowerBound",
@@ -2621,6 +2652,7 @@
         },
         "SuspendedProcess": {
             "type": "structure",
+            "documentation": "<p>Describes an Auto Scaling process that has been suspended. For more information, see <a>ProcessType</a>.</p>",
             "members": [
                 {
                     "name": "ProcessName",
@@ -2640,6 +2672,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Describes a tag for an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "ResourceId",
@@ -2670,6 +2703,7 @@
         },
         "TagDescription": {
             "type": "structure",
+            "documentation": "<p>Describes a tag for an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "ResourceId",

--- a/libcloudcore/data/aws/cloudformation/service.json
+++ b/libcloudcore/data/aws/cloudformation/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://cloudformation.amazonaws.com/doc/2010-05-15/"
         }
@@ -183,10 +186,12 @@
         },
         "AlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>Resource with the name requested already exists.</p>",
             "members": []
         },
         "CancelUpdateStackInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>CancelUpdateStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -207,6 +212,7 @@
         },
         "CreateStackInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>CreateStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -272,6 +278,7 @@
         },
         "CreateStackOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>CreateStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -285,6 +292,7 @@
         },
         "DeleteStackInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>DeleteStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -298,6 +306,7 @@
         },
         "DescribeStackEventsInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>DescribeStackEvents</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -313,6 +322,7 @@
         },
         "DescribeStackEventsOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>DescribeStackEvents</a> action.</p>",
             "members": [
                 {
                     "name": "StackEvents",
@@ -328,6 +338,7 @@
         },
         "DescribeStackResourceInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>DescribeStackResource</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -343,6 +354,7 @@
         },
         "DescribeStackResourceOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>DescribeStackResource</a> action.</p>",
             "members": [
                 {
                     "name": "StackResourceDetail",
@@ -353,6 +365,7 @@
         },
         "DescribeStackResourcesInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>DescribeStackResources</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -373,6 +386,7 @@
         },
         "DescribeStackResourcesOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>DescribeStackResources</a> action.</p>",
             "members": [
                 {
                     "name": "StackResources",
@@ -383,6 +397,7 @@
         },
         "DescribeStacksInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>DescribeStacks</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -398,6 +413,7 @@
         },
         "DescribeStacksOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>DescribeStacks</a> action.</p>",
             "members": [
                 {
                     "name": "Stacks",
@@ -439,6 +455,7 @@
         },
         "EstimateTemplateCostOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>EstimateTemplateCost</a> action.</p>",
             "members": [
                 {
                     "name": "Url",
@@ -452,6 +469,7 @@
         },
         "GetStackPolicyInput": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>GetStackPolicy</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -462,6 +480,7 @@
         },
         "GetStackPolicyOutput": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>GetStackPolicy</a> action.</p>",
             "members": [
                 {
                     "name": "StackPolicyBody",
@@ -472,6 +491,7 @@
         },
         "GetTemplateInput": {
             "type": "structure",
+            "documentation": "<p>The input for a <a>GetTemplate</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -482,6 +502,7 @@
         },
         "GetTemplateOutput": {
             "type": "structure",
+            "documentation": "<p>The output for <a>GetTemplate</a> action.</p>",
             "members": [
                 {
                     "name": "TemplateBody",
@@ -492,6 +513,7 @@
         },
         "GetTemplateSummaryInput": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>GetTemplateSummary</a> action.</p>",
             "members": [
                 {
                     "name": "TemplateBody",
@@ -512,6 +534,7 @@
         },
         "GetTemplateSummaryOutput": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>GetTemplateSummary</a> action.</p>",
             "members": [
                 {
                     "name": "Parameters",
@@ -547,6 +570,7 @@
         },
         "InsufficientCapabilitiesException": {
             "type": "structure",
+            "documentation": "<p>The template contains resources with capabilities that were not specified in the Capabilities parameter.</p>",
             "members": []
         },
         "LastUpdatedTime": {
@@ -554,10 +578,12 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Quota for the resource has already been reached.</p>",
             "members": []
         },
         "ListStackResourcesInput": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>ListStackResource</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -573,6 +599,7 @@
         },
         "ListStackResourcesOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>ListStackResources</a> action.</p>",
             "members": [
                 {
                     "name": "StackResourceSummaries",
@@ -588,6 +615,7 @@
         },
         "ListStacksInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>ListStacks</a> action.</p>",
             "members": [
                 {
                     "name": "NextToken",
@@ -603,6 +631,7 @@
         },
         "ListStacksOutput": {
             "type": "structure",
+            "documentation": "<p>The output for <a>ListStacks</a> action.</p>",
             "members": [
                 {
                     "name": "StackSummaries",
@@ -640,6 +669,7 @@
         },
         "Output": {
             "type": "structure",
+            "documentation": "<p>The Output data type.</p>",
             "members": [
                 {
                     "name": "OutputKey",
@@ -670,6 +700,7 @@
         },
         "Parameter": {
             "type": "structure",
+            "documentation": "<p>The Parameter data type.</p>",
             "members": [
                 {
                     "name": "ParameterKey",
@@ -690,6 +721,7 @@
         },
         "ParameterConstraints": {
             "type": "structure",
+            "documentation": "<p>A set of criteria that AWS CloudFormation uses to validate parameter values. Although other constraints might be defined in the stack template, AWS CloudFormation returns only the <code>AllowedValues</code> property.</p>",
             "members": [
                 {
                     "name": "AllowedValues",
@@ -700,6 +732,7 @@
         },
         "ParameterDeclaration": {
             "type": "structure",
+            "documentation": "<p>The ParameterDeclaration data type.</p>",
             "members": [
                 {
                     "name": "ParameterKey",
@@ -773,6 +806,7 @@
         },
         "SetStackPolicyInput": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>SetStackPolicy</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -793,6 +827,7 @@
         },
         "SignalResourceInput": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>SignalResource</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -818,6 +853,7 @@
         },
         "Stack": {
             "type": "structure",
+            "documentation": "<p>The Stack data type.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -893,6 +929,7 @@
         },
         "StackEvent": {
             "type": "structure",
+            "documentation": "<p>The StackEvent data type.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -973,6 +1010,7 @@
         },
         "StackResource": {
             "type": "structure",
+            "documentation": "<p>The StackResource data type.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -1023,6 +1061,7 @@
         },
         "StackResourceDetail": {
             "type": "structure",
+            "documentation": "<p>Contains detailed information about the specified stack resource.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -1082,6 +1121,7 @@
         },
         "StackResourceSummary": {
             "type": "structure",
+            "documentation": "<p>Contains high-level information about the specified stack resource.</p>",
             "members": [
                 {
                     "name": "LogicalResourceId",
@@ -1135,6 +1175,7 @@
         },
         "StackSummary": {
             "type": "structure",
+            "documentation": "<p>The StackSummary Data Type</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -1184,6 +1225,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>The Tag type is used by <code>CreateStack</code> in the <code>Tags</code> parameter. It allows you to specify a key/value pair that can be used to store information related to cost allocation for an AWS CloudFormation stack.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1215,6 +1257,7 @@
         },
         "TemplateParameter": {
             "type": "structure",
+            "documentation": "<p>The TemplateParameter data type.</p>",
             "members": [
                 {
                     "name": "ParameterKey",
@@ -1253,6 +1296,7 @@
         },
         "UpdateStackInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>UpdateStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackName",
@@ -1313,6 +1357,7 @@
         },
         "UpdateStackOutput": {
             "type": "structure",
+            "documentation": "<p>The output for a <a>UpdateStack</a> action.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -1332,6 +1377,7 @@
         },
         "ValidateTemplateInput": {
             "type": "structure",
+            "documentation": "<p>The input for <a>ValidateTemplate</a> action.</p>",
             "members": [
                 {
                     "name": "TemplateBody",
@@ -1347,6 +1393,7 @@
         },
         "ValidateTemplateOutput": {
             "type": "structure",
+            "documentation": "<p>The output for <a>ValidateTemplate</a> action.</p>",
             "members": [
                 {
                     "name": "Parameters",

--- a/libcloudcore/data/aws/cloudfront/service.json
+++ b/libcloudcore/data/aws/cloudfront/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -223,6 +227,7 @@
     "shapes": {
         "AccessDenied": {
             "type": "structure",
+            "documentation": "Access denied.",
             "members": [
                 {
                     "name": "Message",
@@ -232,6 +237,7 @@
         },
         "ActiveTrustedSigners": {
             "type": "structure",
+            "documentation": "A complex type that lists the AWS accounts, if any, that you included in the TrustedSigners complex type for the default cache behavior or for any of the other cache behaviors for this distribution. These are accounts that you want to allow to create signed URLs for private content.",
             "members": [
                 {
                     "name": "Enabled",
@@ -256,6 +262,7 @@
         },
         "Aliases": {
             "type": "structure",
+            "documentation": "A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.",
             "members": [
                 {
                     "name": "Quantity",
@@ -271,6 +278,7 @@
         },
         "AllowedMethods": {
             "type": "structure",
+            "documentation": "A complex type that controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. There are three choices: - CloudFront forwards only GET and HEAD requests. - CloudFront forwards only GET, HEAD and OPTIONS requests. - CloudFront forwards GET, HEAD, OPTIONS, PUT, PATCH, POST, and DELETE requests. If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or to your custom origin so users can't perform operations that you don't want them to. For example, you may not want users to have permission to delete objects from your origin.",
             "members": [
                 {
                     "name": "Quantity",
@@ -312,6 +320,7 @@
         },
         "CacheBehavior": {
             "type": "structure",
+            "documentation": "A complex type that describes how CloudFront processes requests. You can create up to 10 cache behaviors.You must create at least as many cache behaviors (including the default cache behavior) as you have origins if you want CloudFront to distribute objects from all of the origins. Each cache behavior specifies the one origin from which you want CloudFront to get objects. If you have two origins and only the default cache behavior, the default cache behavior will cause CloudFront to get objects from one of the origins, but the other origin will never be used. If you don't want to specify any cache behaviors, include only an empty CacheBehaviors element. Don't include an empty CacheBehavior element, or CloudFront returns a MalformedXML error. To delete all cache behaviors in an existing distribution, update the distribution configuration and include only an empty CacheBehaviors element. To add, change, or remove one or more cache behaviors, update the distribution configuration and specify all of the cache behaviors that you want to include in the updated distribution.",
             "members": [
                 {
                     "name": "PathPattern",
@@ -370,6 +379,7 @@
         },
         "CacheBehaviors": {
             "type": "structure",
+            "documentation": "A complex type that contains zero or more CacheBehavior elements.",
             "members": [
                 {
                     "name": "Quantity",
@@ -385,6 +395,7 @@
         },
         "CachedMethods": {
             "type": "structure",
+            "documentation": "A complex type that controls whether CloudFront caches the response to requests using the specified HTTP methods. There are two choices: - CloudFront caches responses to GET and HEAD requests. - CloudFront caches responses to GET, HEAD, and OPTIONS requests. If you pick the second choice for your S3 Origin, you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers and Origin headers for the responses to be cached correctly.",
             "members": [
                 {
                     "name": "Quantity",
@@ -400,6 +411,7 @@
         },
         "CloudFrontOriginAccessIdentity": {
             "type": "structure",
+            "documentation": "CloudFront origin access identity.",
             "members": [
                 {
                     "name": "Id",
@@ -420,6 +432,7 @@
         },
         "CloudFrontOriginAccessIdentityAlreadyExists": {
             "type": "structure",
+            "documentation": "If the CallerReference is a value you already sent in a previous request to create an identity but the content of the CloudFrontOriginAccessIdentityConfig is different from the original request, CloudFront returns a CloudFrontOriginAccessIdentityAlreadyExists error.",
             "members": [
                 {
                     "name": "Message",
@@ -429,6 +442,7 @@
         },
         "CloudFrontOriginAccessIdentityConfig": {
             "type": "structure",
+            "documentation": "Origin access identity configuration.",
             "members": [
                 {
                     "name": "CallerReference",
@@ -453,6 +467,7 @@
         },
         "CloudFrontOriginAccessIdentityList": {
             "type": "structure",
+            "documentation": "The CloudFrontOriginAccessIdentityList type.",
             "members": [
                 {
                     "name": "Marker",
@@ -488,6 +503,7 @@
         },
         "CloudFrontOriginAccessIdentitySummary": {
             "type": "structure",
+            "documentation": "Summary of the information about a CloudFront origin access identity.",
             "members": [
                 {
                     "name": "Id",
@@ -516,6 +532,7 @@
         },
         "CookieNames": {
             "type": "structure",
+            "documentation": "A complex type that specifies the whitelisted cookies, if any, that you want CloudFront to forward to your origin that is associated with this cache behavior.",
             "members": [
                 {
                     "name": "Quantity",
@@ -531,6 +548,7 @@
         },
         "CookiePreference": {
             "type": "structure",
+            "documentation": "A complex type that specifies the cookie preferences associated with this cache behavior.",
             "members": [
                 {
                     "name": "Forward",
@@ -546,6 +564,7 @@
         },
         "CreateCloudFrontOriginAccessIdentityRequest": {
             "type": "structure",
+            "documentation": "The request to create a new origin access identity.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentityConfig",
@@ -560,6 +579,7 @@
         },
         "CreateCloudFrontOriginAccessIdentityResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentity",
@@ -584,6 +604,7 @@
         },
         "CreateDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to create a new distribution.",
             "members": [
                 {
                     "name": "DistributionConfig",
@@ -598,6 +619,7 @@
         },
         "CreateDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "Distribution",
@@ -622,6 +644,7 @@
         },
         "CreateInvalidationRequest": {
             "type": "structure",
+            "documentation": "The request to create an invalidation.",
             "members": [
                 {
                     "name": "DistributionId",
@@ -643,6 +666,7 @@
         },
         "CreateInvalidationResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "Location",
@@ -660,6 +684,7 @@
         },
         "CreateStreamingDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to create a new streaming distribution.",
             "members": [
                 {
                     "name": "StreamingDistributionConfig",
@@ -674,6 +699,7 @@
         },
         "CreateStreamingDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "StreamingDistribution",
@@ -698,6 +724,7 @@
         },
         "CustomErrorResponse": {
             "type": "structure",
+            "documentation": "A complex type that describes how you'd prefer CloudFront to respond to requests that result in either a 4xx or 5xx response. You can control whether a custom error page should be displayed, what the desired response code should be for this error page and how long should the error response be cached by CloudFront. If you don't want to specify any custom error responses, include only an empty CustomErrorResponses element. To delete all custom error responses in an existing distribution, update the distribution configuration and include only an empty CustomErrorResponses element. To add, change, or remove one or more custom error responses, update the distribution configuration and specify all of the custom error responses that you want to include in the updated distribution.",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -727,6 +754,7 @@
         },
         "CustomErrorResponses": {
             "type": "structure",
+            "documentation": "A complex type that contains zero or more CustomErrorResponse elements.",
             "members": [
                 {
                     "name": "Quantity",
@@ -742,6 +770,7 @@
         },
         "CustomOriginConfig": {
             "type": "structure",
+            "documentation": "A customer origin.",
             "members": [
                 {
                     "name": "HTTPPort",
@@ -762,6 +791,7 @@
         },
         "DefaultCacheBehavior": {
             "type": "structure",
+            "documentation": "A complex type that describes the default cache behavior if you do not specify a CacheBehavior element or if files don't match any of the values of PathPattern in CacheBehavior elements.You must create exactly one default cache behavior.",
             "members": [
                 {
                     "name": "TargetOriginId",
@@ -811,6 +841,7 @@
         },
         "DeleteCloudFrontOriginAccessIdentityRequest": {
             "type": "structure",
+            "documentation": "The request to delete a origin access identity.",
             "members": [
                 {
                     "name": "Id",
@@ -830,6 +861,7 @@
         },
         "DeleteDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to delete a distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -849,6 +881,7 @@
         },
         "DeleteStreamingDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to delete a streaming distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -868,6 +901,7 @@
         },
         "Distribution": {
             "type": "structure",
+            "documentation": "A distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -908,6 +942,7 @@
         },
         "DistributionAlreadyExists": {
             "type": "structure",
+            "documentation": "The caller reference you attempted to create the distribution with is associated with another distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -917,6 +952,7 @@
         },
         "DistributionConfig": {
             "type": "structure",
+            "documentation": "A distribution Configuration.",
             "members": [
                 {
                     "name": "CallerReference",
@@ -985,6 +1021,7 @@
         },
         "DistributionList": {
             "type": "structure",
+            "documentation": "A distribution list.",
             "members": [
                 {
                     "name": "Marker",
@@ -1029,6 +1066,7 @@
         },
         "DistributionSummary": {
             "type": "structure",
+            "documentation": "A summary of the information for an Amazon CloudFront distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -1105,6 +1143,7 @@
         },
         "ForwardedValues": {
             "type": "structure",
+            "documentation": "A complex type that specifies how CloudFront handles query strings, cookies and headers.",
             "members": [
                 {
                     "name": "QueryString",
@@ -1125,6 +1164,7 @@
         },
         "GeoRestriction": {
             "type": "structure",
+            "documentation": "A complex type that controls the countries in which your content is distributed. For more information about geo restriction, go to Customizing Error Responses in the Amazon CloudFront Developer Guide. CloudFront determines the location of your users using MaxMind GeoIP databases. For information about the accuracy of these databases, see How accurate are your GeoIP databases? on the MaxMind website.",
             "members": [
                 {
                     "name": "RestrictionType",
@@ -1148,6 +1188,7 @@
         },
         "GetCloudFrontOriginAccessIdentityConfigRequest": {
             "type": "structure",
+            "documentation": "The request to get an origin access identity's configuration.",
             "members": [
                 {
                     "name": "Id",
@@ -1160,6 +1201,7 @@
         },
         "GetCloudFrontOriginAccessIdentityConfigResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentityConfig",
@@ -1177,6 +1219,7 @@
         },
         "GetCloudFrontOriginAccessIdentityRequest": {
             "type": "structure",
+            "documentation": "The request to get an origin access identity's information.",
             "members": [
                 {
                     "name": "Id",
@@ -1189,6 +1232,7 @@
         },
         "GetCloudFrontOriginAccessIdentityResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentity",
@@ -1206,6 +1250,7 @@
         },
         "GetDistributionConfigRequest": {
             "type": "structure",
+            "documentation": "The request to get a distribution configuration.",
             "members": [
                 {
                     "name": "Id",
@@ -1218,6 +1263,7 @@
         },
         "GetDistributionConfigResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "DistributionConfig",
@@ -1235,6 +1281,7 @@
         },
         "GetDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to get a distribution's information.",
             "members": [
                 {
                     "name": "Id",
@@ -1247,6 +1294,7 @@
         },
         "GetDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "Distribution",
@@ -1264,6 +1312,7 @@
         },
         "GetInvalidationRequest": {
             "type": "structure",
+            "documentation": "The request to get an invalidation's information.",
             "members": [
                 {
                     "name": "DistributionId",
@@ -1283,6 +1332,7 @@
         },
         "GetInvalidationResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "Invalidation",
@@ -1293,6 +1343,7 @@
         },
         "GetStreamingDistributionConfigRequest": {
             "type": "structure",
+            "documentation": "To request to get a streaming distribution configuration.",
             "members": [
                 {
                     "name": "Id",
@@ -1305,6 +1356,7 @@
         },
         "GetStreamingDistributionConfigResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "StreamingDistributionConfig",
@@ -1322,6 +1374,7 @@
         },
         "GetStreamingDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to get a streaming distribution's information.",
             "members": [
                 {
                     "name": "Id",
@@ -1334,6 +1387,7 @@
         },
         "GetStreamingDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "StreamingDistribution",
@@ -1355,6 +1409,7 @@
         },
         "Headers": {
             "type": "structure",
+            "documentation": "A complex type that specifies the headers that you want CloudFront to forward to the origin for this cache behavior. For the headers that you specify, CloudFront also caches separate versions of a given object based on the header values in viewer requests; this is known as varying on headers. For example, suppose viewer requests for logo.jpg contain a custom Product header that has a value of either Acme or Apex, and you configure CloudFront to vary on the Product header. CloudFront forwards the Product header to the origin and caches the response from the origin once for each header value.",
             "members": [
                 {
                     "name": "Quantity",
@@ -1370,6 +1425,7 @@
         },
         "IllegalUpdate": {
             "type": "structure",
+            "documentation": "Origin and CallerReference cannot be updated.",
             "members": [
                 {
                     "name": "Message",
@@ -1379,6 +1435,7 @@
         },
         "InconsistentQuantities": {
             "type": "structure",
+            "documentation": "The value of Quantity and the size of Items do not match.",
             "members": [
                 {
                     "name": "Message",
@@ -1388,6 +1445,7 @@
         },
         "InvalidArgument": {
             "type": "structure",
+            "documentation": "The argument is invalid.",
             "members": [
                 {
                     "name": "Message",
@@ -1397,6 +1455,7 @@
         },
         "InvalidDefaultRootObject": {
             "type": "structure",
+            "documentation": "The default root object file name is too big or contains an invalid character.",
             "members": [
                 {
                     "name": "Message",
@@ -1415,6 +1474,7 @@
         },
         "InvalidForwardCookies": {
             "type": "structure",
+            "documentation": "Your request contains forward cookies option which doesn't match with the expectation for the whitelisted list of cookie names. Either list of cookie names has been specified when not allowed or list of cookie names is missing when expected.",
             "members": [
                 {
                     "name": "Message",
@@ -1442,6 +1502,7 @@
         },
         "InvalidIfMatchVersion": {
             "type": "structure",
+            "documentation": "The If-Match version is missing or not valid for the distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -1469,6 +1530,7 @@
         },
         "InvalidOrigin": {
             "type": "structure",
+            "documentation": "The Amazon S3 origin server specified does not refer to a valid Amazon S3 bucket.",
             "members": [
                 {
                     "name": "Message",
@@ -1478,6 +1540,7 @@
         },
         "InvalidOriginAccessIdentity": {
             "type": "structure",
+            "documentation": "The origin access identity is not valid or doesn't exist.",
             "members": [
                 {
                     "name": "Message",
@@ -1487,6 +1550,7 @@
         },
         "InvalidProtocolSettings": {
             "type": "structure",
+            "documentation": "You cannot specify SSLv3 as the minimum protocol version if you only want to support only clients that Support Server Name Indication (SNI).",
             "members": [
                 {
                     "name": "Message",
@@ -1496,6 +1560,7 @@
         },
         "InvalidRelativePath": {
             "type": "structure",
+            "documentation": "The relative path is too big, is not URL-encoded, or does not begin with a slash (/).",
             "members": [
                 {
                     "name": "Message",
@@ -1505,6 +1570,7 @@
         },
         "InvalidRequiredProtocol": {
             "type": "structure",
+            "documentation": "This operation requires the HTTPS protocol. Ensure that you specify the HTTPS protocol in your request, or omit the RequiredProtocols element from your distribution configuration.",
             "members": [
                 {
                     "name": "Message",
@@ -1541,6 +1607,7 @@
         },
         "Invalidation": {
             "type": "structure",
+            "documentation": "An invalidation.",
             "members": [
                 {
                     "name": "Id",
@@ -1566,6 +1633,7 @@
         },
         "InvalidationBatch": {
             "type": "structure",
+            "documentation": "An invalidation batch.",
             "members": [
                 {
                     "name": "Paths",
@@ -1581,6 +1649,7 @@
         },
         "InvalidationList": {
             "type": "structure",
+            "documentation": "An invalidation list.",
             "members": [
                 {
                     "name": "Marker",
@@ -1616,6 +1685,7 @@
         },
         "InvalidationSummary": {
             "type": "structure",
+            "documentation": "Summary of an invalidation request.",
             "members": [
                 {
                     "name": "Id",
@@ -1646,6 +1716,7 @@
         },
         "KeyPairIds": {
             "type": "structure",
+            "documentation": "A complex type that lists the active CloudFront key pairs, if any, that are associated with AwsAccountNumber.",
             "members": [
                 {
                     "name": "Quantity",
@@ -1661,6 +1732,7 @@
         },
         "ListCloudFrontOriginAccessIdentitiesRequest": {
             "type": "structure",
+            "documentation": "The request to list origin access identities.",
             "members": [
                 {
                     "name": "Marker",
@@ -1680,6 +1752,7 @@
         },
         "ListCloudFrontOriginAccessIdentitiesResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentityList",
@@ -1690,6 +1763,7 @@
         },
         "ListDistributionsRequest": {
             "type": "structure",
+            "documentation": "The request to list your distributions.",
             "members": [
                 {
                     "name": "Marker",
@@ -1709,6 +1783,7 @@
         },
         "ListDistributionsResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "DistributionList",
@@ -1719,6 +1794,7 @@
         },
         "ListInvalidationsRequest": {
             "type": "structure",
+            "documentation": "The request to list invalidations.",
             "members": [
                 {
                     "name": "DistributionId",
@@ -1745,6 +1821,7 @@
         },
         "ListInvalidationsResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "InvalidationList",
@@ -1755,6 +1832,7 @@
         },
         "ListStreamingDistributionsRequest": {
             "type": "structure",
+            "documentation": "The request to list your streaming distributions.",
             "members": [
                 {
                     "name": "Marker",
@@ -1774,6 +1852,7 @@
         },
         "ListStreamingDistributionsResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "StreamingDistributionList",
@@ -1788,6 +1867,7 @@
         },
         "LoggingConfig": {
             "type": "structure",
+            "documentation": "A complex type that controls whether access logs are written for the distribution.",
             "members": [
                 {
                     "name": "Enabled",
@@ -1823,6 +1903,7 @@
         },
         "MissingBody": {
             "type": "structure",
+            "documentation": "This operation requires a body. Ensure that the body is present and the Content-Type header is set.",
             "members": [
                 {
                     "name": "Message",
@@ -1832,6 +1913,7 @@
         },
         "NoSuchCloudFrontOriginAccessIdentity": {
             "type": "structure",
+            "documentation": "The specified origin access identity does not exist.",
             "members": [
                 {
                     "name": "Message",
@@ -1841,6 +1923,7 @@
         },
         "NoSuchDistribution": {
             "type": "structure",
+            "documentation": "The specified distribution does not exist.",
             "members": [
                 {
                     "name": "Message",
@@ -1850,6 +1933,7 @@
         },
         "NoSuchInvalidation": {
             "type": "structure",
+            "documentation": "The specified invalidation does not exist.",
             "members": [
                 {
                     "name": "Message",
@@ -1859,6 +1943,7 @@
         },
         "NoSuchOrigin": {
             "type": "structure",
+            "documentation": "No origin exists with the specified Origin Id.",
             "members": [
                 {
                     "name": "Message",
@@ -1868,6 +1953,7 @@
         },
         "NoSuchStreamingDistribution": {
             "type": "structure",
+            "documentation": "The specified streaming distribution does not exist.",
             "members": [
                 {
                     "name": "Message",
@@ -1877,6 +1963,7 @@
         },
         "Origin": {
             "type": "structure",
+            "documentation": "A complex type that describes the Amazon S3 bucket or the HTTP server (for example, a web server) from which CloudFront gets your files.You must create at least one origin.",
             "members": [
                 {
                     "name": "Id",
@@ -1914,6 +2001,7 @@
         },
         "Origins": {
             "type": "structure",
+            "documentation": "A complex type that contains information about origins for this distribution.",
             "members": [
                 {
                     "name": "Quantity",
@@ -1933,6 +2021,7 @@
         },
         "Paths": {
             "type": "structure",
+            "documentation": "A complex type that contains information about the objects that you want to invalidate.",
             "members": [
                 {
                     "name": "Quantity",
@@ -1948,6 +2037,7 @@
         },
         "PreconditionFailed": {
             "type": "structure",
+            "documentation": "The precondition given in one or more of the request-header fields evaluated to false.",
             "members": [
                 {
                     "name": "Message",
@@ -1960,6 +2050,7 @@
         },
         "Restrictions": {
             "type": "structure",
+            "documentation": "A complex type that identifies ways in which you want to restrict distribution of your content.",
             "members": [
                 {
                     "name": "GeoRestriction",
@@ -1969,6 +2060,7 @@
         },
         "S3Origin": {
             "type": "structure",
+            "documentation": "A complex type that contains information about the Amazon S3 bucket from which you want CloudFront to get your media files for distribution.",
             "members": [
                 {
                     "name": "DomainName",
@@ -1984,6 +2076,7 @@
         },
         "S3OriginConfig": {
             "type": "structure",
+            "documentation": "A complex type that contains information about the Amazon S3 origin. If the origin is a custom origin, use the CustomOriginConfig element instead.",
             "members": [
                 {
                     "name": "OriginAccessIdentity",
@@ -1997,6 +2090,7 @@
         },
         "Signer": {
             "type": "structure",
+            "documentation": "A complex type that lists the AWS accounts that were included in the TrustedSigners complex type, as well as their active CloudFront key pair IDs, if any.",
             "members": [
                 {
                     "name": "AwsAccountNumber",
@@ -2016,6 +2110,7 @@
         },
         "StreamingDistribution": {
             "type": "structure",
+            "documentation": "A streaming distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -2060,6 +2155,7 @@
         },
         "StreamingDistributionConfig": {
             "type": "structure",
+            "documentation": "The configuration for the streaming distribution.",
             "members": [
                 {
                     "name": "CallerReference",
@@ -2105,6 +2201,7 @@
         },
         "StreamingDistributionList": {
             "type": "structure",
+            "documentation": "A streaming distribution list.",
             "members": [
                 {
                     "name": "Marker",
@@ -2149,6 +2246,7 @@
         },
         "StreamingDistributionSummary": {
             "type": "structure",
+            "documentation": "A summary of the information for an Amazon CloudFront streaming distribution.",
             "members": [
                 {
                     "name": "Id",
@@ -2207,6 +2305,7 @@
         },
         "StreamingLoggingConfig": {
             "type": "structure",
+            "documentation": "A complex type that controls whether access logs are written for this streaming distribution.",
             "members": [
                 {
                     "name": "Enabled",
@@ -2227,6 +2326,7 @@
         },
         "TooManyCacheBehaviors": {
             "type": "structure",
+            "documentation": "You cannot create anymore cache behaviors for the distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -2236,6 +2336,7 @@
         },
         "TooManyCertificates": {
             "type": "structure",
+            "documentation": "You cannot create anymore custom ssl certificates.",
             "members": [
                 {
                     "name": "Message",
@@ -2245,6 +2346,7 @@
         },
         "TooManyCloudFrontOriginAccessIdentities": {
             "type": "structure",
+            "documentation": "Processing your request would cause you to exceed the maximum number of origin access identities allowed.",
             "members": [
                 {
                     "name": "Message",
@@ -2254,6 +2356,7 @@
         },
         "TooManyCookieNamesInWhiteList": {
             "type": "structure",
+            "documentation": "Your request contains more cookie names in the whitelist than are allowed per cache behavior.",
             "members": [
                 {
                     "name": "Message",
@@ -2263,6 +2366,7 @@
         },
         "TooManyDistributionCNAMEs": {
             "type": "structure",
+            "documentation": "Your request contains more CNAMEs than are allowed per distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -2272,6 +2376,7 @@
         },
         "TooManyDistributions": {
             "type": "structure",
+            "documentation": "Processing your request would cause you to exceed the maximum number of distributions allowed.",
             "members": [
                 {
                     "name": "Message",
@@ -2290,6 +2395,7 @@
         },
         "TooManyInvalidationsInProgress": {
             "type": "structure",
+            "documentation": "You have exceeded the maximum number of allowable InProgress invalidation batch requests, or invalidation objects.",
             "members": [
                 {
                     "name": "Message",
@@ -2299,6 +2405,7 @@
         },
         "TooManyOrigins": {
             "type": "structure",
+            "documentation": "You cannot create anymore origins for the distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -2317,6 +2424,7 @@
         },
         "TooManyStreamingDistributions": {
             "type": "structure",
+            "documentation": "Processing your request would cause you to exceed the maximum number of streaming distributions allowed.",
             "members": [
                 {
                     "name": "Message",
@@ -2326,6 +2434,7 @@
         },
         "TooManyTrustedSigners": {
             "type": "structure",
+            "documentation": "Your request contains more trusted signers than are allowed per distribution.",
             "members": [
                 {
                     "name": "Message",
@@ -2335,6 +2444,7 @@
         },
         "TrustedSignerDoesNotExist": {
             "type": "structure",
+            "documentation": "One or more of your trusted signers do not exist.",
             "members": [
                 {
                     "name": "Message",
@@ -2344,6 +2454,7 @@
         },
         "TrustedSigners": {
             "type": "structure",
+            "documentation": "A complex type that specifies the AWS accounts, if any, that you want to allow to create signed URLs for private content. If you want to require signed URLs in requests for objects in the target origin that match the PathPattern for this cache behavior, specify true for Enabled, and specify the applicable values for Quantity and Items. For more information, go to Using a Signed URL to Serve Private Content in the Amazon CloudFront Developer Guide. If you don't want to require signed URLs in requests for objects that match PathPattern, specify false for Enabled and 0 for Quantity. Omit Items. To add, change, or remove one or more trusted signers, change Enabled to true (if it's currently false), change Quantity as applicable, and specify all of the trusted signers that you want to include in the updated distribution.",
             "members": [
                 {
                     "name": "Enabled",
@@ -2364,6 +2475,7 @@
         },
         "UpdateCloudFrontOriginAccessIdentityRequest": {
             "type": "structure",
+            "documentation": "The request to update an origin access identity.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentityConfig",
@@ -2392,6 +2504,7 @@
         },
         "UpdateCloudFrontOriginAccessIdentityResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "CloudFrontOriginAccessIdentity",
@@ -2409,6 +2522,7 @@
         },
         "UpdateDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to update a distribution.",
             "members": [
                 {
                     "name": "DistributionConfig",
@@ -2437,6 +2551,7 @@
         },
         "UpdateDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "Distribution",
@@ -2454,6 +2569,7 @@
         },
         "UpdateStreamingDistributionRequest": {
             "type": "structure",
+            "documentation": "The request to update a streaming distribution.",
             "members": [
                 {
                     "name": "StreamingDistributionConfig",
@@ -2482,6 +2598,7 @@
         },
         "UpdateStreamingDistributionResult": {
             "type": "structure",
+            "documentation": "The returned result of the corresponding request.",
             "members": [
                 {
                     "name": "StreamingDistribution",
@@ -2499,6 +2616,7 @@
         },
         "ViewerCertificate": {
             "type": "structure",
+            "documentation": "A complex type that contains information about viewer certificates for this distribution.",
             "members": [
                 {
                     "name": "IAMCertificateId",

--- a/libcloudcore/data/aws/cloudhsm/service.json
+++ b/libcloudcore/data/aws/cloudhsm/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -216,6 +220,7 @@
         },
         "CloudHsmInternalException": {
             "type": "structure",
+            "documentation": "<p>Indicates that an internal error occurred.</p>",
             "members": []
         },
         "CloudHsmObjectState": {
@@ -223,6 +228,7 @@
         },
         "CloudHsmServiceException": {
             "type": "structure",
+            "documentation": "<p>Indicates that an exception occurred in the AWS CloudHSM service.</p>",
             "members": [
                 {
                     "name": "message",
@@ -238,6 +244,7 @@
         },
         "CreateHapgRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateHapgRequest</a> action.</p>",
             "members": [
                 {
                     "name": "Label",
@@ -248,6 +255,7 @@
         },
         "CreateHapgResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>CreateHAPartitionGroup</a> action.</p>",
             "members": [
                 {
                     "name": "HapgArn",
@@ -258,6 +266,7 @@
         },
         "CreateHsmRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateHsm</a> action. </p>",
             "members": [
                 {
                     "name": "SubnetId",
@@ -311,6 +320,7 @@
         },
         "CreateHsmResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>CreateHsm</a> action.</p>",
             "members": [
                 {
                     "name": "HsmArn",
@@ -321,6 +331,7 @@
         },
         "CreateLunaClientRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateLunaClient</a> action.</p>",
             "members": [
                 {
                     "name": "Label",
@@ -336,6 +347,7 @@
         },
         "CreateLunaClientResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>CreateLunaClient</a> action.</p>",
             "members": [
                 {
                     "name": "ClientArn",
@@ -346,6 +358,7 @@
         },
         "DeleteHapgRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DeleteHapg</a> action.</p>",
             "members": [
                 {
                     "name": "HapgArn",
@@ -356,6 +369,7 @@
         },
         "DeleteHapgResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>DeleteHapg</a> action.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -366,6 +380,7 @@
         },
         "DeleteHsmRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DeleteHsm</a> action. </p>",
             "members": [
                 {
                     "name": "HsmArn",
@@ -377,6 +392,7 @@
         },
         "DeleteHsmResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>DeleteHsm</a> action.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -407,6 +423,7 @@
         },
         "DescribeHapgRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeHapg</a> action.</p>",
             "members": [
                 {
                     "name": "HapgArn",
@@ -417,6 +434,7 @@
         },
         "DescribeHapgResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>DescribeHapg</a> action.</p>",
             "members": [
                 {
                     "name": "HapgArn",
@@ -464,6 +482,7 @@
         },
         "DescribeHsmRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeHsm</a> action. </p>",
             "members": [
                 {
                     "name": "HsmArn",
@@ -479,6 +498,7 @@
         },
         "DescribeHsmResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>DescribeHsm</a> action.</p>",
             "members": [
                 {
                     "name": "HsmArn",
@@ -686,10 +706,12 @@
             "of": "HapgArn"
         },
         "HsmArn": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>An ARN that identifies an HSM.</p>"
         },
         "HsmList": {
             "type": "list",
+            "documentation": "<p>Contains a list of ARNs that identify the HSMs.</p>",
             "of": "HsmArn"
         },
         "HsmSerialNumber": {
@@ -703,6 +725,7 @@
         },
         "InvalidRequestException": {
             "type": "structure",
+            "documentation": "<p>Indicates that one or more of the request parameters are not valid.</p>",
             "members": []
         },
         "IpAddress": {
@@ -713,6 +736,7 @@
         },
         "ListAvailableZonesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>ListAvailableZones</a> action. </p>",
             "members": []
         },
         "ListAvailableZonesResponse": {
@@ -762,6 +786,7 @@
         },
         "ListHsmsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>ListHsms</a> action.</p>",
             "members": [
                 {
                     "name": "HsmList",
@@ -832,6 +857,7 @@
         },
         "ModifyHsmRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>ModifyHsm</a> action. </p>",
             "members": [
                 {
                     "name": "HsmArn",
@@ -873,6 +899,7 @@
         },
         "ModifyHsmResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of the <a>ModifyHsm</a> action.</p>",
             "members": [
                 {
                     "name": "HsmArn",

--- a/libcloudcore/data/aws/cloudsearch/service.json
+++ b/libcloudcore/data/aws/cloudsearch/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://cloudsearch.amazonaws.com/doc/2013-01-01/"
         }
@@ -247,13 +250,16 @@
     },
     "shapes": {
         "APIVersion": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The Amazon CloudSearch API version for a domain: 2011-02-01 or 2013-01-01.</p>"
         },
         "ARN": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The Amazon Resource Name (ARN) of the search domain. See <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/index.html?Using_Identifiers.html\" target=\"_blank\">Identifiers for IAM Entities</a> in <i>Using AWS Identity and Access Management</i> for more information.</p>"
         },
         "AccessPoliciesStatus": {
             "type": "structure",
+            "documentation": "<p>The configured access rules for the domain's document and search endpoints, and the current status of those rules.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -270,6 +276,7 @@
         },
         "AnalysisOptions": {
             "type": "structure",
+            "documentation": "<p>Synonyms, stopwords, and stemming options for an analysis scheme. Includes tokenization dictionary for Japanese.</p>",
             "members": [
                 {
                     "name": "Synonyms",
@@ -300,6 +307,7 @@
         },
         "AnalysisScheme": {
             "type": "structure",
+            "documentation": "<p>Configuration information for an analysis scheme. Each analysis scheme has a unique name and specifies the language of the text to be processed. The following options can be configured for an analysis scheme: <code>Synonyms</code>, <code>Stopwords</code>, <code>StemmingDictionary</code>, <code>JapaneseTokenizationDictionary</code> and <code>AlgorithmicStemming</code>.</p>",
             "members": [
                 {
                     "name": "AnalysisSchemeName",
@@ -316,10 +324,12 @@
             ]
         },
         "AnalysisSchemeLanguage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>An <a href=\"http://tools.ietf.org/html/rfc4646\" target=\"_blank\">IETF RFC 4646</a> language code or <code>mul</code> for multiple languages.</p>"
         },
         "AnalysisSchemeStatus": {
             "type": "structure",
+            "documentation": "<p>The status and configuration of an <code>AnalysisScheme</code>.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -333,10 +343,12 @@
         },
         "AnalysisSchemeStatusList": {
             "type": "list",
+            "documentation": "<p>A list of the analysis schemes configured for a domain.</p>",
             "of": "AnalysisSchemeStatus"
         },
         "AvailabilityOptionsStatus": {
             "type": "structure",
+            "documentation": "<p>The status and configuration of the domain's availability options.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -351,6 +363,7 @@
         },
         "BaseException": {
             "type": "structure",
+            "documentation": "<p>An error occurred while processing the request.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -367,6 +380,7 @@
         },
         "BuildSuggestersRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>BuildSuggester</a></code> operation. Specifies the name of the domain you want to update.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -376,6 +390,7 @@
         },
         "BuildSuggestersResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>BuildSuggester</code> request. Contains a list of the fields used for suggestions.</p>",
             "members": [
                 {
                     "name": "FieldNames",
@@ -385,6 +400,7 @@
         },
         "CreateDomainRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>CreateDomain</a></code> operation. Specifies a name for the new search domain.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -395,6 +411,7 @@
         },
         "CreateDomainResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>CreateDomainRequest</code>. Contains the status of a newly created domain.</p>",
             "members": [
                 {
                     "name": "DomainStatus",
@@ -404,6 +421,7 @@
         },
         "DateArrayOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a field that contains an array of dates. Present if <code>IndexFieldType</code> specifies the field is of type <code>date-array</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -434,6 +452,7 @@
         },
         "DateOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a date field. Dates and times are specified in UTC (Coordinated Universal Time) according to IETF RFC3339: yyyy-mm-ddT00:00:00Z. Present if <code>IndexFieldType</code> specifies the field is of type <code>date</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -468,6 +487,7 @@
         },
         "DefineAnalysisSchemeRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DefineAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme configuration.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -481,6 +501,7 @@
         },
         "DefineAnalysisSchemeResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code><a>DefineAnalysisScheme</a></code> request. Contains the status of the newly-configured analysis scheme.</p>",
             "members": [
                 {
                     "name": "AnalysisScheme",
@@ -490,6 +511,7 @@
         },
         "DefineExpressionRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DefineExpression</a></code> operation. Specifies the name of the domain you want to update and the expression you want to configure.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -503,6 +525,7 @@
         },
         "DefineExpressionResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DefineExpression</code> request. Contains the status of the newly-configured expression.</p>",
             "members": [
                 {
                     "name": "Expression",
@@ -512,6 +535,7 @@
         },
         "DefineIndexFieldRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DefineIndexField</a></code> operation. Specifies the name of the domain you want to update and the index field configuration.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -526,6 +550,7 @@
         },
         "DefineIndexFieldResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code><a>DefineIndexField</a></code> request. Contains the status of the newly-configured index field.</p>",
             "members": [
                 {
                     "name": "IndexField",
@@ -535,6 +560,7 @@
         },
         "DefineSuggesterRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DefineSuggester</a></code> operation. Specifies the name of the domain you want to update and the suggester configuration.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -548,6 +574,7 @@
         },
         "DefineSuggesterResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DefineSuggester</code> request. Contains the status of the newly-configured suggester.</p>",
             "members": [
                 {
                     "name": "Suggester",
@@ -557,6 +584,7 @@
         },
         "DeleteAnalysisSchemeRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DeleteAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme you want to delete. </p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -571,6 +599,7 @@
         },
         "DeleteAnalysisSchemeResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DeleteAnalysisScheme</code> request. Contains the status of the deleted analysis scheme.</p>",
             "members": [
                 {
                     "name": "AnalysisScheme",
@@ -581,6 +610,7 @@
         },
         "DeleteDomainRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DeleteDomain</a></code> operation. Specifies the name of the domain you want to delete.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -591,6 +621,7 @@
         },
         "DeleteDomainResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DeleteDomain</code> request. Contains the status of a newly deleted domain, or no status if the domain has already been completely deleted.</p>",
             "members": [
                 {
                     "name": "DomainStatus",
@@ -600,6 +631,7 @@
         },
         "DeleteExpressionRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DeleteExpression</a></code> operation. Specifies the name of the domain you want to update and the name of the expression you want to delete.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -614,6 +646,7 @@
         },
         "DeleteExpressionResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code><a>DeleteExpression</a></code> request. Specifies the expression being deleted.</p>",
             "members": [
                 {
                     "name": "Expression",
@@ -624,6 +657,7 @@
         },
         "DeleteIndexFieldRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DeleteIndexField</a></code> operation. Specifies the name of the domain you want to update and the name of the index field you want to delete.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -638,6 +672,7 @@
         },
         "DeleteIndexFieldResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code><a>DeleteIndexField</a></code> request.</p>",
             "members": [
                 {
                     "name": "IndexField",
@@ -648,6 +683,7 @@
         },
         "DeleteSuggesterRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DeleteSuggester</a></code> operation. Specifies the name of the domain you want to update and name of the suggester you want to delete.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -662,6 +698,7 @@
         },
         "DeleteSuggesterResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DeleteSuggester</code> request. Contains the status of the deleted suggester.</p>",
             "members": [
                 {
                     "name": "Suggester",
@@ -672,6 +709,7 @@
         },
         "DescribeAnalysisSchemesRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeAnalysisSchemes</a></code> operation. Specifies the name of the domain you want to describe. To limit the response to particular analysis schemes, specify the names of the analysis schemes you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>. </p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -692,6 +730,7 @@
         },
         "DescribeAnalysisSchemesResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeAnalysisSchemes</code> request. Contains the analysis schemes configured for the domain specified in the request.</p>",
             "members": [
                 {
                     "name": "AnalysisSchemes",
@@ -702,6 +741,7 @@
         },
         "DescribeAvailabilityOptionsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the Deployed option to <code>true</code>.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -717,6 +757,7 @@
         },
         "DescribeAvailabilityOptionsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeAvailabilityOptions</code> request. Indicates whether or not the Multi-AZ option is enabled for the domain specified in the request. </p>",
             "members": [
                 {
                     "name": "AvailabilityOptions",
@@ -727,6 +768,7 @@
         },
         "DescribeDomainsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. By default shows the status of all domains. To restrict the response to particular domains, specify the names of the domains you want to describe.</p>",
             "members": [
                 {
                     "name": "DomainNames",
@@ -737,6 +779,7 @@
         },
         "DescribeDomainsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeDomains</code> request. Contains the status of the domains specified in the request or all domains owned by the account.</p>",
             "members": [
                 {
                     "name": "DomainStatusList",
@@ -746,6 +789,7 @@
         },
         "DescribeExpressionsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular expressions, specify the names of the expressions you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -766,6 +810,7 @@
         },
         "DescribeExpressionsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeExpressions</code> request. Contains the expressions configured for the domain specified in the request.</p>",
             "members": [
                 {
                     "name": "Expressions",
@@ -776,6 +821,7 @@
         },
         "DescribeIndexFieldsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeIndexFields</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular index fields, specify the names of the index fields you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -796,6 +842,7 @@
         },
         "DescribeIndexFieldsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeIndexFields</code> request. Contains the index fields configured for the domain specified in the request.</p>",
             "members": [
                 {
                     "name": "IndexFields",
@@ -806,6 +853,7 @@
         },
         "DescribeScalingParametersRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeScalingParameters</a></code> operation. Specifies the name of the domain you want to describe. </p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -815,6 +863,7 @@
         },
         "DescribeScalingParametersResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeScalingParameters</code> request. Contains the scaling parameters configured for the domain specified in the request.</p>",
             "members": [
                 {
                     "name": "ScalingParameters",
@@ -824,6 +873,7 @@
         },
         "DescribeServiceAccessPoliciesRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -839,6 +889,7 @@
         },
         "DescribeServiceAccessPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeServiceAccessPolicies</code> request.</p>",
             "members": [
                 {
                     "name": "AccessPolicies",
@@ -849,6 +900,7 @@
         },
         "DescribeSuggestersRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>DescribeSuggester</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular suggesters, specify the names of the suggesters you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -869,6 +921,7 @@
         },
         "DescribeSuggestersResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>DescribeSuggesters</code> request.</p>",
             "members": [
                 {
                     "name": "Suggesters",
@@ -879,10 +932,12 @@
         },
         "DisabledOperationException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted an operation which is not enabled.</p>",
             "members": []
         },
         "DocumentSuggesterOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a search suggester.</p>",
             "members": [
                 {
                     "name": "SourceField",
@@ -902,20 +957,27 @@
             ]
         },
         "DomainId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>An internally generated unique identifier for a domain.</p>"
         },
         "DomainName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A string that represents the name of a domain. Domain names are unique across the domains owned by an account within an AWS region. Domain names start with a letter or number and can contain the following characters: a-z (lowercase), 0-9, and - (hyphen).</p>"
         },
         "DomainNameList": {
             "type": "list",
+            "documentation": "<p>A list of domain names.</p>",
             "of": "DomainName"
         },
         "DomainNameMap": {
-            "type": "map"
+            "type": "map",
+            "documentation": "<p>A collection of domain names.</p>",
+            "key": "DomainName",
+            "value": "APIVersion"
         },
         "DomainStatus": {
             "type": "structure",
+            "documentation": "<p>The current status of the search domain.</p>",
             "members": [
                 {
                     "name": "DomainId",
@@ -982,6 +1044,7 @@
         },
         "DomainStatusList": {
             "type": "list",
+            "documentation": "<p>A list that contains the status of each requested domain.</p>",
             "of": "DomainStatus"
         },
         "Double": {
@@ -989,6 +1052,7 @@
         },
         "DoubleArrayOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a field that contains an array of double-precision 64-bit floating point values. Present if <code>IndexFieldType</code> specifies the field is of type <code>double-array</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1019,6 +1083,7 @@
         },
         "DoubleOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a double-precision 64-bit floating point field. Present if <code>IndexFieldType</code> specifies the field is of type <code>double</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1060,13 +1125,16 @@
             "of": "DynamicFieldName"
         },
         "ErrorCode": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A machine-parsable string error or warning code.</p>"
         },
         "ErrorMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A human-readable string error or warning message.</p>"
         },
         "Expression": {
             "type": "structure",
+            "documentation": "<p>A named expression that can be evaluated at search time. Can be used to sort the search results, define other expressions, or return computed information in the search results. </p>",
             "members": [
                 {
                     "name": "ExpressionName",
@@ -1080,6 +1148,7 @@
         },
         "ExpressionStatus": {
             "type": "structure",
+            "documentation": "<p>The value of an <code>Expression</code> and its current status.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -1094,26 +1163,32 @@
         },
         "ExpressionStatusList": {
             "type": "list",
+            "documentation": "<p>Contains the status of multiple expressions.</p>",
             "of": "ExpressionStatus"
         },
         "ExpressionValue": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The expression to evaluate for sorting while processing a search request. The <code>Expression</code> syntax is based on JavaScript expressions. For more information, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-expressions.html\" target=\"_blank\">Configuring Expressions</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"
         },
         "FieldName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A string that represents the name of an index field. CloudSearch supports regular index fields as well as dynamic fields. A dynamic field's name defines a pattern that begins or ends with a wildcard. Any document fields that don't map to a regular index field but do match a dynamic field's pattern are configured with the dynamic field's indexing options. </p> <p>Regular field names begin with a letter and can contain the following characters: a-z (lowercase), 0-9, and _ (underscore). Dynamic field names must begin or end with a wildcard (*). The wildcard can also be the only character in a dynamic field name. Multiple wildcards, and wildcards embedded within a string are not supported. </p> <p>The name <code>score</code> is reserved and cannot be used as a field name. To reference a document's ID, you can use the name <code>_id</code>. </p>"
         },
         "FieldNameCommaList": {
             "type": "string"
         },
         "FieldNameList": {
             "type": "list",
+            "documentation": "<p>A list of field names.</p>",
             "of": "FieldName"
         },
         "FieldValue": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The value of a field attribute.</p>"
         },
         "IndexDocumentsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>IndexDocuments</a></code> operation. Specifies the name of the domain you want to re-index.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1123,6 +1198,7 @@
         },
         "IndexDocumentsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of an <code>IndexDocuments</code> request. Contains the status of the indexing operation, including the fields being indexed.</p>",
             "members": [
                 {
                     "name": "FieldNames",
@@ -1133,6 +1209,7 @@
         },
         "IndexField": {
             "type": "structure",
+            "documentation": "<p>Configuration information for a field in the index, including its name, type, and options. The supported options depend on the <code><a>IndexFieldType</a></code>.</p>",
             "members": [
                 {
                     "name": "IndexFieldName",
@@ -1191,6 +1268,7 @@
         },
         "IndexFieldStatus": {
             "type": "structure",
+            "documentation": "<p>The value of an <code>IndexField</code> and its current status.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -1204,16 +1282,19 @@
         },
         "IndexFieldStatusList": {
             "type": "list",
+            "documentation": "<p>Contains the status of multiple index fields.</p>",
             "of": "IndexFieldStatus"
         },
         "IndexFieldType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The type of field. The valid options for a field depend on the field type. For more information about the supported field types, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-index-fields.html\" target=\"_blank\">Configuring Index Fields</a> in the <i>Amazon CloudSearch Developer Guide</i>.</p>"
         },
         "InstanceCount": {
             "type": "integer"
         },
         "IntArrayOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a field that contains an array of 64-bit signed integers. Present if <code>IndexFieldType</code> specifies the field is of type <code>int-array</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1244,6 +1325,7 @@
         },
         "IntOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a 64-bit signed integer field. Present if <code>IndexFieldType</code> specifies the field is of type <code>int</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1279,14 +1361,17 @@
         },
         "InternalException": {
             "type": "structure",
+            "documentation": "<p>An internal error occurred while processing the request. If this problem persists, report an issue from the <a href=\"http://status.aws.amazon.com/\" target=\"_blank\">Service Health Dashboard</a>.</p>",
             "members": []
         },
         "InvalidTypeException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it specified an invalid type definition.</p>",
             "members": []
         },
         "LatLonOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a latlon field. A latlon field contains a location stored as a latitude and longitude value pair. Present if <code>IndexFieldType</code> specifies the field is of type <code>latlon</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1321,6 +1406,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because a resource limit has already been met.</p>",
             "members": []
         },
         "Limits": {
@@ -1338,6 +1424,7 @@
         },
         "ListDomainNamesResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>ListDomainNames</code> request. Contains a list of the domains owned by an account.</p>",
             "members": [
                 {
                     "name": "DomainNames",
@@ -1348,6 +1435,7 @@
         },
         "LiteralArrayOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a field that contains an array of literal strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal-array</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1378,6 +1466,7 @@
         },
         "LiteralOptions": {
             "type": "structure",
+            "documentation": "<p>Options for literal field. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal</code>. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1423,10 +1512,12 @@
             "type": "boolean"
         },
         "OptionState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The state of processing a change to an option. One of:</p> <ul> <li>RequiresIndexDocuments: The option's latest value will not be deployed until <a>IndexDocuments</a> has been called and indexing is complete.</li> <li>Processing: The option's latest value is in the process of being activated.</li> <li>Active: The option's latest value is fully deployed. </li> <li>FailedToValidate: The option value is not compatible with the domain's data and cannot be used to index the data. You must either modify the option value or update or remove the incompatible documents.</li> </ul>"
         },
         "OptionStatus": {
             "type": "structure",
+            "documentation": "<p>The status of domain configuration option.</p>",
             "members": [
                 {
                     "name": "CreationDate",
@@ -1456,20 +1547,25 @@
             ]
         },
         "PartitionCount": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>The number of partitions used to hold the domain's index.</p>"
         },
         "PartitionInstanceType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The instance type (such as <code>search.m1.small</code>) on which an index partition is hosted.</p>"
         },
         "PolicyDocument": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Access rules for a domain's document or search service endpoints. For more information, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/configuring-access.html\" target=\"_blank\">Configuring Access for a Search Domain</a> in the <i>Amazon CloudSearch Developer Guide</i>. The maximum size of a policy document is 100 KB.</p>"
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted to reference a resource that does not exist.</p>",
             "members": []
         },
         "ScalingParameters": {
             "type": "structure",
+            "documentation": "<p>The desired instance type and desired number of replicas of each index partition.</p>",
             "members": [
                 {
                     "name": "DesiredInstanceType",
@@ -1490,6 +1586,7 @@
         },
         "ScalingParametersStatus": {
             "type": "structure",
+            "documentation": "<p>The status and configuration of a search domain's scaling parameters. </p>",
             "members": [
                 {
                     "name": "Options",
@@ -1502,10 +1599,12 @@
             ]
         },
         "SearchInstanceType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The instance type (such as <code>search.m1.small</code>) that is being used to process search requests.</p>"
         },
         "ServiceEndpoint": {
             "type": "structure",
+            "documentation": "<p>The endpoint to which service requests can be submitted.</p>",
             "members": [
                 {
                     "name": "Endpoint",
@@ -1514,10 +1613,12 @@
             ]
         },
         "ServiceUrl": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The endpoint to which service requests can be submitted. For example, <code>search-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com</code> or <code>doc-imdb-movies-oopcnjfn6ugofer3zx5iadxxca.eu-west-1.cloudsearch.amazonaws.com</code>.</p>"
         },
         "StandardName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Names must begin with a letter and can contain the following characters: a-z (lowercase), 0-9, and _ (underscore).</p>"
         },
         "StandardNameList": {
             "type": "list",
@@ -1528,6 +1629,7 @@
         },
         "Suggester": {
             "type": "structure",
+            "documentation": "<p>Configuration information for a search suggester. Each suggester has a unique name and specifies the text field you want to use for suggestions. The following options can be configured for a suggester: <code>FuzzyMatching</code>, <code>SortExpression</code>. </p>",
             "members": [
                 {
                     "name": "SuggesterName",
@@ -1544,6 +1646,7 @@
         },
         "SuggesterStatus": {
             "type": "structure",
+            "documentation": "<p>The value of a <code>Suggester</code> and its current status.</p>",
             "members": [
                 {
                     "name": "Options",
@@ -1557,10 +1660,12 @@
         },
         "SuggesterStatusList": {
             "type": "list",
+            "documentation": "<p>Contains the status of multiple suggesters.</p>",
             "of": "SuggesterStatus"
         },
         "TextArrayOptions": {
             "type": "structure",
+            "documentation": "<p>Options for a field that contains an array of text strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>text-array</code>. A <code>text-array</code> field is always searchable. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1591,6 +1696,7 @@
         },
         "TextOptions": {
             "type": "structure",
+            "documentation": "<p>Options for text field. Present if <code>IndexFieldType</code> specifies the field is of type <code>text</code>. A <code>text</code> field is always searchable. All options are enabled by default.</p>",
             "members": [
                 {
                     "name": "DefaultValue",
@@ -1628,6 +1734,7 @@
         },
         "UpdateAvailabilityOptionsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>UpdateAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to update and the Multi-AZ availability option.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1642,6 +1749,7 @@
         },
         "UpdateAvailabilityOptionsResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>UpdateAvailabilityOptions</code> request. Contains the status of the domain's availability options. </p>",
             "members": [
                 {
                     "name": "AvailabilityOptions",
@@ -1652,6 +1760,7 @@
         },
         "UpdateScalingParametersRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>UpdateScalingParameters</a></code> operation. Specifies the name of the domain you want to update and the scaling parameters you want to configure.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1665,6 +1774,7 @@
         },
         "UpdateScalingParametersResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>UpdateScalingParameters</code> request. Contains the status of the newly-configured scaling parameters.</p>",
             "members": [
                 {
                     "name": "ScalingParameters",
@@ -1674,6 +1784,7 @@
         },
         "UpdateServiceAccessPoliciesRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code><a>UpdateServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to update and the access rules you want to configure.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1688,6 +1799,7 @@
         },
         "UpdateServiceAccessPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>The result of an <code>UpdateServiceAccessPolicies</code> request. Contains the new access policies.</p>",
             "members": [
                 {
                     "name": "AccessPolicies",

--- a/libcloudcore/data/aws/cloudsearchdomain/service.json
+++ b/libcloudcore/data/aws/cloudsearchdomain/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -64,6 +68,7 @@
         },
         "Bucket": {
             "type": "structure",
+            "documentation": "<p>A container for facet information. </p>",
             "members": [
                 {
                     "name": "value",
@@ -79,6 +84,7 @@
         },
         "BucketInfo": {
             "type": "structure",
+            "documentation": "<p>A container for the calculated facet values and counts.</p>",
             "members": [
                 {
                     "name": "buckets",
@@ -102,6 +108,7 @@
         },
         "DocumentServiceException": {
             "type": "structure",
+            "documentation": "<p>Information about any problems encountered while processing an upload request.</p>",
             "members": [
                 {
                     "name": "status",
@@ -117,6 +124,7 @@
         },
         "DocumentServiceWarning": {
             "type": "structure",
+            "documentation": "<p>A warning returned by the document service when an issue is discovered while processing an upload request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -133,20 +141,26 @@
             "type": "string"
         },
         "Exprs": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "Facet": {
             "type": "string"
         },
         "Facets": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "BucketInfo"
         },
         "FieldValue": {
             "type": "list",
             "of": "String"
         },
         "Fields": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "FieldValue"
         },
         "FilterQuery": {
             "type": "string"
@@ -155,10 +169,13 @@
             "type": "string"
         },
         "Highlights": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "Hit": {
             "type": "structure",
+            "documentation": "<p>Information about a document that matches the search request.</p>",
             "members": [
                 {
                     "name": "id",
@@ -188,6 +205,7 @@
         },
         "Hits": {
             "type": "structure",
+            "documentation": "<p>The collection of documents that match the search request.</p>",
             "members": [
                 {
                     "name": "found",
@@ -231,6 +249,7 @@
         },
         "SearchException": {
             "type": "structure",
+            "documentation": "<p>Information about any problems encountered while processing a search request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -241,6 +260,7 @@
         },
         "SearchRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code>Search</code> request.</p>",
             "members": [
                 {
                     "name": "cursor",
@@ -337,6 +357,7 @@
         },
         "SearchResponse": {
             "type": "structure",
+            "documentation": "<p>The result of a <code>Search</code> request. Contains the documents that match the specified search criteria and any requested fields, highlights, and facet information.</p>",
             "members": [
                 {
                     "name": "status",
@@ -357,6 +378,7 @@
         },
         "SearchStatus": {
             "type": "structure",
+            "documentation": "<p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>",
             "members": [
                 {
                     "name": "timems",
@@ -384,6 +406,7 @@
         },
         "SuggestModel": {
             "type": "structure",
+            "documentation": "<p>Container for the suggestion information returned in a <code>SuggestResponse</code>.</p>",
             "members": [
                 {
                     "name": "query",
@@ -404,6 +427,7 @@
         },
         "SuggestRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code>Suggest</code> request.</p>",
             "members": [
                 {
                     "name": "query",
@@ -430,6 +454,7 @@
         },
         "SuggestResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>Suggest</code> request.</p>",
             "members": [
                 {
                     "name": "status",
@@ -445,6 +470,7 @@
         },
         "SuggestStatus": {
             "type": "structure",
+            "documentation": "<p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>",
             "members": [
                 {
                     "name": "timems",
@@ -463,6 +489,7 @@
         },
         "SuggestionMatch": {
             "type": "structure",
+            "documentation": "<p>An autocomplete suggestion that matches the query string specified in a <code>SuggestRequest</code>. </p>",
             "members": [
                 {
                     "name": "suggestion",
@@ -490,6 +517,7 @@
         },
         "UploadDocumentsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the <code>UploadDocuments</code> request.</p>",
             "members": [
                 {
                     "name": "documents",
@@ -507,6 +535,7 @@
         },
         "UploadDocumentsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to an <code>UploadDocuments</code> request.</p>",
             "members": [
                 {
                     "name": "status",

--- a/libcloudcore/data/aws/cloudtrail/service.json
+++ b/libcloudcore/data/aws/cloudtrail/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -106,10 +110,12 @@
         },
         "CloudWatchLogsDeliveryUnavailableException": {
             "type": "structure",
+            "documentation": "<p>Cannot set a CloudWatch Logs delivery for this region.</p>",
             "members": []
         },
         "CreateTrailRequest": {
             "type": "structure",
+            "documentation": "<p>Specifies the settings for each trail.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -150,6 +156,7 @@
         },
         "CreateTrailResponse": {
             "type": "structure",
+            "documentation": "Returns the objects or data listed below if successful. Otherwise, returns an error.",
             "members": [
                 {
                     "name": "Name",
@@ -193,6 +200,7 @@
         },
         "DeleteTrailRequest": {
             "type": "structure",
+            "documentation": "<a>The request that specifies the name of a trail to delete.</a>",
             "members": [
                 {
                     "name": "Name",
@@ -203,10 +211,12 @@
         },
         "DeleteTrailResponse": {
             "type": "structure",
+            "documentation": "<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>",
             "members": []
         },
         "DescribeTrailsRequest": {
             "type": "structure",
+            "documentation": "<p>Returns information about the trail.</p>",
             "members": [
                 {
                     "name": "trailNameList",
@@ -217,6 +227,7 @@
         },
         "DescribeTrailsResponse": {
             "type": "structure",
+            "documentation": "<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>",
             "members": [
                 {
                     "name": "trailList",
@@ -227,6 +238,7 @@
         },
         "Event": {
             "type": "structure",
+            "documentation": "<p>Contains information about an event that was returned by a lookup request. The result includes a representation of a CloudTrail event. </p>",
             "members": [
                 {
                     "name": "EventId",
@@ -266,6 +278,7 @@
         },
         "GetTrailStatusRequest": {
             "type": "structure",
+            "documentation": "<p>The name of a trail about which you want the current status.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -276,6 +289,7 @@
         },
         "GetTrailStatusResponse": {
             "type": "structure",
+            "documentation": "<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>",
             "members": [
                 {
                     "name": "IsLogging",
@@ -326,54 +340,67 @@
         },
         "InsufficientS3BucketPolicyException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the policy on the S3 bucket is not sufficient.</p>",
             "members": []
         },
         "InsufficientSnsTopicPolicyException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the policy on the SNS topic is not sufficient.</p>",
             "members": []
         },
         "InvalidCloudWatchLogsLogGroupArnException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided CloudWatch log group is not valid.</p>",
             "members": []
         },
         "InvalidCloudWatchLogsRoleArnException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided role is not valid.</p>",
             "members": []
         },
         "InvalidLookupAttributesException": {
             "type": "structure",
+            "documentation": "<p>Occurs when an invalid lookup attribute is specified.</p>",
             "members": []
         },
         "InvalidMaxResultsException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown if the limit specified is invalid. </p>",
             "members": []
         },
         "InvalidNextTokenException": {
             "type": "structure",
+            "documentation": "<p>Invalid token or token that was previously used in a request with different parameters. This exception is thrown if the token is invalid. </p>",
             "members": []
         },
         "InvalidS3BucketNameException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided S3 bucket name is not valid.</p>",
             "members": []
         },
         "InvalidS3PrefixException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided S3 prefix is not valid.</p>",
             "members": []
         },
         "InvalidSnsTopicNameException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided SNS topic name is not valid. </p>",
             "members": []
         },
         "InvalidTimeRangeException": {
             "type": "structure",
+            "documentation": "<p>Occurs if the timestamp values are invalid. Either the start time occurs after the end time or the time range is outside the range of possible values. </p>",
             "members": []
         },
         "InvalidTrailNameException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the provided trail name is not valid.</p>",
             "members": []
         },
         "LookupAttribute": {
             "type": "structure",
+            "documentation": "<p>Specifies an attribute and value that filter the events returned.</p>",
             "members": [
                 {
                     "name": "AttributeKey",
@@ -396,6 +423,7 @@
         },
         "LookupEventsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains a request for LookupEvents.</p>",
             "members": [
                 {
                     "name": "LookupAttributes",
@@ -426,6 +454,7 @@
         },
         "LookupEventsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains a response to a LookupEvents action.</p>",
             "members": [
                 {
                     "name": "Events",
@@ -444,6 +473,7 @@
         },
         "MaximumNumberOfTrailsExceededException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the maximum number of trails is reached.</p>",
             "members": []
         },
         "NextToken": {
@@ -451,6 +481,7 @@
         },
         "Resource": {
             "type": "structure",
+            "documentation": "<p>Specifies the type and name of a resource referenced by an event.</p>",
             "members": [
                 {
                     "name": "ResourceType",
@@ -466,14 +497,17 @@
         },
         "ResourceList": {
             "type": "list",
+            "documentation": "<p>A list of resources referenced by the event returned.</p>",
             "of": "Resource"
         },
         "S3BucketDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the specified S3 bucket does not exist.</p>",
             "members": []
         },
         "StartLoggingRequest": {
             "type": "structure",
+            "documentation": "<p>The request to CloudTrail to start logging AWS API calls for an account.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -484,10 +518,12 @@
         },
         "StartLoggingResponse": {
             "type": "structure",
+            "documentation": "<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>",
             "members": []
         },
         "StopLoggingRequest": {
             "type": "structure",
+            "documentation": "<p>Passes the request to CloudTrail to stop logging AWS API calls for the specified account.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -498,6 +534,7 @@
         },
         "StopLoggingResponse": {
             "type": "structure",
+            "documentation": "<p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>",
             "members": []
         },
         "String": {
@@ -505,6 +542,7 @@
         },
         "Trail": {
             "type": "structure",
+            "documentation": "<p>The settings for a trail.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -545,6 +583,7 @@
         },
         "TrailAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the specified trail already exists.</p>",
             "members": []
         },
         "TrailList": {
@@ -557,10 +596,12 @@
         },
         "TrailNotFoundException": {
             "type": "structure",
+            "documentation": "<p>This exception is thrown when the trail with the given name is not found.</p>",
             "members": []
         },
         "UpdateTrailRequest": {
             "type": "structure",
+            "documentation": "<p>Specifies settings to update for the trail.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -601,6 +642,7 @@
         },
         "UpdateTrailResponse": {
             "type": "structure",
+            "documentation": "Returns the objects or data listed below if successful. Otherwise, returns an error.",
             "members": [
                 {
                     "name": "Name",

--- a/libcloudcore/data/aws/cloudwatch/service.json
+++ b/libcloudcore/data/aws/cloudwatch/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://monitoring.amazonaws.com/doc/2010-08-01/"
         }
@@ -128,6 +131,7 @@
         },
         "AlarmHistoryItem": {
             "type": "structure",
+            "documentation": "<p> The <code>AlarmHistoryItem</code> data type contains descriptive information about the history of a specific alarm. If you call <a>DescribeAlarmHistory</a>, Amazon CloudWatch returns this data type as part of the <a>DescribeAlarmHistoryResult</a> data type. </p>",
             "members": [
                 {
                     "name": "AlarmName",
@@ -178,6 +182,7 @@
         },
         "Datapoint": {
             "type": "structure",
+            "documentation": "<p> The <code>Datapoint</code> data type encapsulates the statistical data that Amazon CloudWatch computes from metric data. </p>",
             "members": [
                 {
                     "name": "Timestamp",
@@ -270,6 +275,7 @@
         },
         "DescribeAlarmHistoryOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>DescribeAlarmHistory</a> action. </p>",
             "members": [
                 {
                     "name": "AlarmHistoryItems",
@@ -320,6 +326,7 @@
         },
         "DescribeAlarmsForMetricOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>DescribeAlarmsForMetric</a> action. </p>",
             "members": [
                 {
                     "name": "MetricAlarms",
@@ -365,6 +372,7 @@
         },
         "DescribeAlarmsOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>DescribeAlarms</a> action. </p>",
             "members": [
                 {
                     "name": "MetricAlarms",
@@ -380,6 +388,7 @@
         },
         "Dimension": {
             "type": "structure",
+            "documentation": "<p> The <code>Dimension</code> data type further expands on the identity of a metric using a Name, Value pair. </p> <p>For examples that use one or more dimensions, see <a>PutMetricData</a>.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -395,6 +404,7 @@
         },
         "DimensionFilter": {
             "type": "structure",
+            "documentation": "<p> The <code>DimensionFilter</code> data type is used to filter <a>ListMetrics</a> results. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -424,6 +434,7 @@
         },
         "DisableAlarmActionsInput": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "AlarmNames",
@@ -498,6 +509,7 @@
         },
         "GetMetricStatisticsOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>GetMetricStatistics</a> action. </p>",
             "members": [
                 {
                     "name": "Label",
@@ -522,6 +534,7 @@
         },
         "InternalServiceFault": {
             "type": "structure",
+            "documentation": "<p> Indicates that the request processing has failed due to some unknown error, exception, or failure. </p>",
             "members": [
                 {
                     "name": "Message",
@@ -532,6 +545,7 @@
         },
         "InvalidFormatFault": {
             "type": "structure",
+            "documentation": "<p> Data was not syntactically valid JSON. </p>",
             "members": [
                 {
                     "name": "message",
@@ -542,6 +556,7 @@
         },
         "InvalidNextToken": {
             "type": "structure",
+            "documentation": "<p> The next token specified is invalid. </p>",
             "members": [
                 {
                     "name": "message",
@@ -552,6 +567,7 @@
         },
         "InvalidParameterCombinationException": {
             "type": "structure",
+            "documentation": "<p> Parameters that must not be used together were used together. </p>",
             "members": [
                 {
                     "name": "message",
@@ -562,6 +578,7 @@
         },
         "InvalidParameterValueException": {
             "type": "structure",
+            "documentation": "<p> Bad or out-of-range value was supplied for the input parameter. </p>",
             "members": [
                 {
                     "name": "message",
@@ -572,6 +589,7 @@
         },
         "LimitExceededFault": {
             "type": "structure",
+            "documentation": "<p> The quota for alarms for this customer has already been reached. </p>",
             "members": [
                 {
                     "name": "message",
@@ -607,6 +625,7 @@
         },
         "ListMetricsOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>ListMetrics</a> action. </p>",
             "members": [
                 {
                     "name": "Metrics",
@@ -625,6 +644,7 @@
         },
         "Metric": {
             "type": "structure",
+            "documentation": "<p> The <code>Metric</code> data type contains information about a specific metric. If you call <a>ListMetrics</a>, Amazon CloudWatch returns information contained by this data type. </p> <p> The example in the Examples section publishes two metrics named buffers and latency. Both metrics are in the examples namespace. Both metrics have two dimensions, InstanceID and InstanceType. </p>",
             "members": [
                 {
                     "name": "Namespace",
@@ -645,6 +665,7 @@
         },
         "MetricAlarm": {
             "type": "structure",
+            "documentation": "<p> The <a>MetricAlarm</a> data type represents an alarm. You can use <a>PutMetricAlarm</a> to create or update an alarm. </p>",
             "members": [
                 {
                     "name": "AlarmName",
@@ -763,6 +784,7 @@
         },
         "MetricDatum": {
             "type": "structure",
+            "documentation": "<p> The <code>MetricDatum</code> data type encapsulates the information sent with <a>PutMetricData</a> to either create a new metric or add new values to be aggregated into an existing metric. </p>",
             "members": [
                 {
                     "name": "MetricName",
@@ -808,6 +830,7 @@
         },
         "MissingRequiredParameterException": {
             "type": "structure",
+            "documentation": "<p> An input parameter that is mandatory for processing the request is not supplied. </p>",
             "members": [
                 {
                     "name": "message",
@@ -929,6 +952,7 @@
         },
         "ResourceNotFound": {
             "type": "structure",
+            "documentation": "<p> The named resource does not exist. </p>",
             "members": [
                 {
                     "name": "message",
@@ -979,6 +1003,7 @@
         },
         "StatisticSet": {
             "type": "structure",
+            "documentation": "<p> The <code>StatisticSet</code> data type describes the <code>StatisticValues</code> component of <a>MetricDatum</a>, and represents a set of statistics that describes a specific metric. </p>",
             "members": [
                 {
                     "name": "SampleCount",

--- a/libcloudcore/data/aws/codecommit/service.json
+++ b/libcloudcore/data/aws/codecommit/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -124,6 +128,7 @@
         },
         "BatchGetRepositoriesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a batch get repositories operation.</p>",
             "members": [
                 {
                     "name": "repositoryNames",
@@ -134,6 +139,7 @@
         },
         "BatchGetRepositoriesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a batch get repositories operation.</p>",
             "members": [
                 {
                     "name": "repositories",
@@ -149,10 +155,12 @@
         },
         "BranchDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The specified branch does not exist.</p>",
             "members": []
         },
         "BranchInfo": {
             "type": "structure",
+            "documentation": "<p>Returns information about a branch.</p>",
             "members": [
                 {
                     "name": "branchName",
@@ -171,6 +179,7 @@
         },
         "BranchNameExistsException": {
             "type": "structure",
+            "documentation": "<p>The specified branch name already exists.</p>",
             "members": []
         },
         "BranchNameList": {
@@ -179,6 +188,7 @@
         },
         "BranchNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>A branch name is required but was not specified.</p>",
             "members": []
         },
         "CloneUrlHttp": {
@@ -189,6 +199,7 @@
         },
         "CommitDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The specified commit does not exist or no commit was specified, and the specified repository has no default branch.</p>",
             "members": []
         },
         "CommitId": {
@@ -196,10 +207,12 @@
         },
         "CommitIdRequiredException": {
             "type": "structure",
+            "documentation": "<p>A commit ID was not specified.</p>",
             "members": []
         },
         "CreateBranchInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create branch operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -220,6 +233,7 @@
         },
         "CreateRepositoryInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -235,6 +249,7 @@
         },
         "CreateRepositoryOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryMetadata",
@@ -248,6 +263,7 @@
         },
         "DeleteRepositoryInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -258,6 +274,7 @@
         },
         "DeleteRepositoryOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a delete repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryId",
@@ -268,26 +285,32 @@
         },
         "EncryptionIntegrityChecksFailedException": {
             "type": "structure",
+            "documentation": "<p>An encryption integrity check failed.</p>",
             "members": []
         },
         "EncryptionKeyAccessDeniedException": {
             "type": "structure",
+            "documentation": "<p>An encryption key could not be accessed.</p>",
             "members": []
         },
         "EncryptionKeyDisabledException": {
             "type": "structure",
+            "documentation": "<p>The encryption key is disabled.</p>",
             "members": []
         },
         "EncryptionKeyNotFoundException": {
             "type": "structure",
+            "documentation": "<p>No encryption key was found.</p>",
             "members": []
         },
         "EncryptionKeyUnavailableException": {
             "type": "structure",
+            "documentation": "<p>The encryption key is not available.</p>",
             "members": []
         },
         "GetBranchInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get branch operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -302,6 +325,7 @@
         },
         "GetBranchOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get branch operation.</p>",
             "members": [
                 {
                     "name": "branch",
@@ -312,6 +336,7 @@
         },
         "GetRepositoryInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -322,6 +347,7 @@
         },
         "GetRepositoryOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get repository operation.</p>",
             "members": [
                 {
                     "name": "repositoryMetadata",
@@ -332,30 +358,37 @@
         },
         "InvalidBranchNameException": {
             "type": "structure",
+            "documentation": "<p>The specified branch name is not valid.</p>",
             "members": []
         },
         "InvalidCommitIdException": {
             "type": "structure",
+            "documentation": "<p>The specified commit ID is not valid.</p>",
             "members": []
         },
         "InvalidContinuationTokenException": {
             "type": "structure",
+            "documentation": "<p>The specified continuation token is not valid.</p>",
             "members": []
         },
         "InvalidOrderException": {
             "type": "structure",
+            "documentation": "<p>The specified sort order is not valid.</p>",
             "members": []
         },
         "InvalidRepositoryDescriptionException": {
             "type": "structure",
+            "documentation": "<p>The specified repository description is not valid.</p>",
             "members": []
         },
         "InvalidRepositoryNameException": {
             "type": "structure",
+            "documentation": "<p>At least one specified repository name is not valid.</p> <note>This exception only occurs when a specified repository name is not valid. Other exceptions occur when a required repository parameter is missing, or when a specified repository does not exist.</note>",
             "members": []
         },
         "InvalidSortByException": {
             "type": "structure",
+            "documentation": "<p>The specified sort by value is not valid.</p>",
             "members": []
         },
         "LastModifiedDate": {
@@ -363,6 +396,7 @@
         },
         "ListBranchesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list branches operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -378,6 +412,7 @@
         },
         "ListBranchesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list branches operation.</p>",
             "members": [
                 {
                     "name": "branches",
@@ -393,6 +428,7 @@
         },
         "ListRepositoriesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list repositories operation.</p>",
             "members": [
                 {
                     "name": "nextToken",
@@ -413,6 +449,7 @@
         },
         "ListRepositoriesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list repositories operation.</p>",
             "members": [
                 {
                     "name": "repositories",
@@ -428,6 +465,7 @@
         },
         "MaximumRepositoryNamesExceededException": {
             "type": "structure",
+            "documentation": "<p>The maximum number of allowed repository names was exceeded. Currently, this number is 25.</p>",
             "members": []
         },
         "NextToken": {
@@ -441,6 +479,7 @@
         },
         "RepositoryDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The specified repository does not exist.</p>",
             "members": []
         },
         "RepositoryId": {
@@ -448,10 +487,12 @@
         },
         "RepositoryLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>A repository resource limit was exceeded.</p>",
             "members": []
         },
         "RepositoryMetadata": {
             "type": "structure",
+            "documentation": "<p>Information about a repository.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -510,14 +551,17 @@
             "of": "RepositoryMetadata"
         },
         "RepositoryName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Repository name is restricted to alphanumeric characters (a-z, A-Z, 0-9), \".\", \"_\", and \"-\". Additionally, the suffix \".git\" is prohibited in a repository name."
         },
         "RepositoryNameExistsException": {
             "type": "structure",
+            "documentation": "<p>The specified repository name already exists.</p>",
             "members": []
         },
         "RepositoryNameIdPair": {
             "type": "structure",
+            "documentation": "<p>Information about a repository name and ID.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -540,10 +584,12 @@
         },
         "RepositoryNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>A repository name is required but was not specified.</p>",
             "members": []
         },
         "RepositoryNamesRequiredException": {
             "type": "structure",
+            "documentation": "<p>A repository names object is required but was not specified.</p>",
             "members": []
         },
         "RepositoryNotFoundList": {
@@ -555,6 +601,7 @@
         },
         "UpdateDefaultBranchInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update default branch operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -570,6 +617,7 @@
         },
         "UpdateRepositoryDescriptionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update repository description operation.</p>",
             "members": [
                 {
                     "name": "repositoryName",
@@ -585,6 +633,7 @@
         },
         "UpdateRepositoryNameInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update repository description operation.</p>",
             "members": [
                 {
                     "name": "oldName",

--- a/libcloudcore/data/aws/codedeploy/service.json
+++ b/libcloudcore/data/aws/codedeploy/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -295,6 +299,7 @@
     "shapes": {
         "AddTagsToOnPremisesInstancesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an adds tags to on-premises instance operation.</p>",
             "members": [
                 {
                     "name": "tags",
@@ -310,10 +315,12 @@
         },
         "ApplicationAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>An application with the specified name already exists with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "ApplicationDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The application does not exist with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "ApplicationId": {
@@ -321,6 +328,7 @@
         },
         "ApplicationInfo": {
             "type": "structure",
+            "documentation": "<p>Information about an application.</p>",
             "members": [
                 {
                     "name": "applicationId",
@@ -346,6 +354,7 @@
         },
         "ApplicationLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>More applications were attempted to be created than were allowed.</p>",
             "members": []
         },
         "ApplicationName": {
@@ -353,6 +362,7 @@
         },
         "ApplicationNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>The minimum number of required application names was not specified.</p>",
             "members": []
         },
         "ApplicationRevisionSortBy": {
@@ -368,6 +378,7 @@
         },
         "AutoScalingGroup": {
             "type": "structure",
+            "documentation": "<p>Information about an Auto Scaling group.</p>",
             "members": [
                 {
                     "name": "name",
@@ -397,6 +408,7 @@
         },
         "BatchGetApplicationsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a batch get applications operation.</p>",
             "members": [
                 {
                     "name": "applicationNames",
@@ -407,6 +419,7 @@
         },
         "BatchGetApplicationsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a batch get applications operation.</p>",
             "members": [
                 {
                     "name": "applicationsInfo",
@@ -417,6 +430,7 @@
         },
         "BatchGetDeploymentsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a batch get deployments operation.</p>",
             "members": [
                 {
                     "name": "deploymentIds",
@@ -427,6 +441,7 @@
         },
         "BatchGetDeploymentsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a batch get deployments operation.</p>",
             "members": [
                 {
                     "name": "deploymentsInfo",
@@ -437,6 +452,7 @@
         },
         "BatchGetOnPremisesInstancesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a batch get on-premises instances operation.</p>",
             "members": [
                 {
                     "name": "instanceNames",
@@ -447,6 +463,7 @@
         },
         "BatchGetOnPremisesInstancesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a batch get on-premises instances operation.</p>",
             "members": [
                 {
                     "name": "instanceInfos",
@@ -460,6 +477,7 @@
         },
         "BucketNameFilterRequiredException": {
             "type": "structure",
+            "documentation": "<p>A bucket name is required but was not provided.</p>",
             "members": []
         },
         "BundleType": {
@@ -470,6 +488,7 @@
         },
         "CreateApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create application operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -480,6 +499,7 @@
         },
         "CreateApplicationOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create application operation.</p>",
             "members": [
                 {
                     "name": "applicationId",
@@ -490,6 +510,7 @@
         },
         "CreateDeploymentConfigInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create deployment configuration operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigName",
@@ -505,6 +526,7 @@
         },
         "CreateDeploymentConfigOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create deployment configuration operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigId",
@@ -515,6 +537,7 @@
         },
         "CreateDeploymentGroupInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create deployment group operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -555,6 +578,7 @@
         },
         "CreateDeploymentGroupOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create deployment group operation.</p>",
             "members": [
                 {
                     "name": "deploymentGroupId",
@@ -565,6 +589,7 @@
         },
         "CreateDeploymentInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create deployment operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -600,6 +625,7 @@
         },
         "CreateDeploymentOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create deployment operation.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -610,6 +636,7 @@
         },
         "DeleteApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete application operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -620,6 +647,7 @@
         },
         "DeleteDeploymentConfigInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete deployment configuration operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigName",
@@ -630,6 +658,7 @@
         },
         "DeleteDeploymentGroupInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete deployment group operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -645,6 +674,7 @@
         },
         "DeleteDeploymentGroupOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a delete deployment group operation.</p>",
             "members": [
                 {
                     "name": "hooksNotCleanedUp",
@@ -655,14 +685,17 @@
         },
         "DeploymentAlreadyCompletedException": {
             "type": "structure",
+            "documentation": "<p>The deployment is already completed.</p>",
             "members": []
         },
         "DeploymentConfigAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>A deployment configuration with the specified name already exists with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "DeploymentConfigDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The deployment configuration does not exist with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "DeploymentConfigId": {
@@ -670,10 +703,12 @@
         },
         "DeploymentConfigInUseException": {
             "type": "structure",
+            "documentation": "<p>The deployment configuration is still in use.</p>",
             "members": []
         },
         "DeploymentConfigInfo": {
             "type": "structure",
+            "documentation": "<p>Information about a deployment configuration.</p>",
             "members": [
                 {
                     "name": "deploymentConfigId",
@@ -699,6 +734,7 @@
         },
         "DeploymentConfigLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The deployment configurations limit was exceeded.</p>",
             "members": []
         },
         "DeploymentConfigName": {
@@ -706,6 +742,7 @@
         },
         "DeploymentConfigNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>The deployment configuration name was not specified.</p>",
             "members": []
         },
         "DeploymentConfigsList": {
@@ -717,14 +754,17 @@
         },
         "DeploymentDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The deployment does not exist with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "DeploymentGroupAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>A deployment group with the specified name already exists with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "DeploymentGroupDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The named deployment group does not exist with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "DeploymentGroupId": {
@@ -732,6 +772,7 @@
         },
         "DeploymentGroupInfo": {
             "type": "structure",
+            "documentation": "<p>Information about a deployment group.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -782,6 +823,7 @@
         },
         "DeploymentGroupLimitExceededException": {
             "type": "structure",
+            "documentation": "<p> The deployment groups limit was exceeded.</p>",
             "members": []
         },
         "DeploymentGroupName": {
@@ -789,6 +831,7 @@
         },
         "DeploymentGroupNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>The deployment group name was not specified.</p>",
             "members": []
         },
         "DeploymentGroupsList": {
@@ -800,10 +843,12 @@
         },
         "DeploymentIdRequiredException": {
             "type": "structure",
+            "documentation": "<p>At least one deployment ID must be specified.</p>",
             "members": []
         },
         "DeploymentInfo": {
             "type": "structure",
+            "documentation": "<p>Information about a deployment.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -879,14 +924,17 @@
         },
         "DeploymentLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The number of allowed deployments was exceeded.</p>",
             "members": []
         },
         "DeploymentNotStartedException": {
             "type": "structure",
+            "documentation": "<p>The specified deployment has not started.</p>",
             "members": []
         },
         "DeploymentOverview": {
             "type": "structure",
+            "documentation": "<p>Information about the deployment status of the instances in the deployment.</p>",
             "members": [
                 {
                     "name": "Pending",
@@ -932,6 +980,7 @@
         },
         "DeregisterOnPremisesInstanceInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a deregister on-premises instance operation.</p>",
             "members": [
                 {
                     "name": "instanceName",
@@ -945,10 +994,12 @@
         },
         "DescriptionTooLongException": {
             "type": "structure",
+            "documentation": "<p>The description that was provided is too long.</p>",
             "members": []
         },
         "Diagnostics": {
             "type": "structure",
+            "documentation": "<p>Diagnostic information about executable scripts that are part of a deployment.</p>",
             "members": [
                 {
                     "name": "errorCode",
@@ -974,6 +1025,7 @@
         },
         "EC2TagFilter": {
             "type": "structure",
+            "documentation": "<p>Information about a tag filter.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1007,6 +1059,7 @@
         },
         "ErrorInformation": {
             "type": "structure",
+            "documentation": "<p>Information about a deployment error.</p>",
             "members": [
                 {
                     "name": "code",
@@ -1025,6 +1078,7 @@
         },
         "GenericRevisionInfo": {
             "type": "structure",
+            "documentation": "<p>Information about an application revision.</p>",
             "members": [
                 {
                     "name": "description",
@@ -1055,6 +1109,7 @@
         },
         "GetApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get application operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1065,6 +1120,7 @@
         },
         "GetApplicationOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get application operation.</p>",
             "members": [
                 {
                     "name": "application",
@@ -1075,6 +1131,7 @@
         },
         "GetApplicationRevisionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get application revision operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1090,6 +1147,7 @@
         },
         "GetApplicationRevisionOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get application revision operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1110,6 +1168,7 @@
         },
         "GetDeploymentConfigInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get deployment configuration operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigName",
@@ -1120,6 +1179,7 @@
         },
         "GetDeploymentConfigOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get deployment configuration operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigInfo",
@@ -1130,6 +1190,7 @@
         },
         "GetDeploymentGroupInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get deployment group operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1145,6 +1206,7 @@
         },
         "GetDeploymentGroupOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get deployment group operation.</p>",
             "members": [
                 {
                     "name": "deploymentGroupInfo",
@@ -1155,6 +1217,7 @@
         },
         "GetDeploymentInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get deployment operation.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -1165,6 +1228,7 @@
         },
         "GetDeploymentInstanceInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get deployment instance operation.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -1180,6 +1244,7 @@
         },
         "GetDeploymentInstanceOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get deployment instance operation.</p>",
             "members": [
                 {
                     "name": "instanceSummary",
@@ -1190,6 +1255,7 @@
         },
         "GetDeploymentOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get deployment operation.</p>",
             "members": [
                 {
                     "name": "deploymentInfo",
@@ -1200,6 +1266,7 @@
         },
         "GetOnPremisesInstanceInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get on-premises instance operation.</p>",
             "members": [
                 {
                     "name": "instanceName",
@@ -1210,6 +1277,7 @@
         },
         "GetOnPremisesInstanceOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get on-premises instance operation.</p>",
             "members": [
                 {
                     "name": "instanceInfo",
@@ -1220,6 +1288,7 @@
         },
         "GitHubLocation": {
             "type": "structure",
+            "documentation": "<p>Information about the location of application artifacts that are stored in GitHub.</p>",
             "members": [
                 {
                     "name": "repository",
@@ -1238,10 +1307,12 @@
         },
         "IamUserArnAlreadyRegisteredException": {
             "type": "structure",
+            "documentation": "<p>The specified IAM user ARN is already registered with an on-premises instance.</p>",
             "members": []
         },
         "IamUserArnRequiredException": {
             "type": "structure",
+            "documentation": "<p>An IAM user ARN was not specified.</p>",
             "members": []
         },
         "InstanceArn": {
@@ -1252,6 +1323,7 @@
         },
         "InstanceDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The specified instance does not exist in the deployment group.</p>",
             "members": []
         },
         "InstanceId": {
@@ -1259,10 +1331,12 @@
         },
         "InstanceIdRequiredException": {
             "type": "structure",
+            "documentation": "<p>The instance ID was not specified.</p>",
             "members": []
         },
         "InstanceInfo": {
             "type": "structure",
+            "documentation": "<p>Information about an on-premises instance.</p>",
             "members": [
                 {
                     "name": "instanceName",
@@ -1302,6 +1376,7 @@
         },
         "InstanceLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The maximum number of allowed on-premises instances in a single call was exceeded.</p>",
             "members": []
         },
         "InstanceName": {
@@ -1309,6 +1384,7 @@
         },
         "InstanceNameAlreadyRegisteredException": {
             "type": "structure",
+            "documentation": "<p>The specified on-premises instance name is already registered.</p>",
             "members": []
         },
         "InstanceNameList": {
@@ -1317,10 +1393,12 @@
         },
         "InstanceNameRequiredException": {
             "type": "structure",
+            "documentation": "<p>An on-premises instance name was not specified.</p>",
             "members": []
         },
         "InstanceNotRegisteredException": {
             "type": "structure",
+            "documentation": "<p>The specified on-premises instance is not registered.</p>",
             "members": []
         },
         "InstanceStatus": {
@@ -1332,6 +1410,7 @@
         },
         "InstanceSummary": {
             "type": "structure",
+            "documentation": "<p>Information about an instance in a deployment.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -1366,98 +1445,122 @@
         },
         "InvalidApplicationNameException": {
             "type": "structure",
+            "documentation": "<p>The application name was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidAutoScalingGroupException": {
             "type": "structure",
+            "documentation": "<p>The Auto Scaling group was specified in an invalid format or does not exist.</p>",
             "members": []
         },
         "InvalidBucketNameFilterException": {
             "type": "structure",
+            "documentation": "<p>The bucket name either doesn't exist or was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidDeployedStateFilterException": {
             "type": "structure",
+            "documentation": "<p>The deployed state filter was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidDeploymentConfigNameException": {
             "type": "structure",
+            "documentation": "<p>The deployment configuration name was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidDeploymentGroupNameException": {
             "type": "structure",
+            "documentation": "<p>The deployment group name was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidDeploymentIdException": {
             "type": "structure",
+            "documentation": "<p>At least one of the deployment IDs was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidDeploymentStatusException": {
             "type": "structure",
+            "documentation": "<p>The specified deployment status doesn't exist or cannot be determined.</p>",
             "members": []
         },
         "InvalidEC2TagException": {
             "type": "structure",
+            "documentation": "<p>The tag was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidIamUserArnException": {
             "type": "structure",
+            "documentation": "<p>The IAM user ARN was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidInstanceNameException": {
             "type": "structure",
+            "documentation": "<p>The specified on-premises instance name was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidInstanceStatusException": {
             "type": "structure",
+            "documentation": "<p>The specified instance status does not exist.</p>",
             "members": []
         },
         "InvalidKeyPrefixFilterException": {
             "type": "structure",
+            "documentation": "<p>The specified key prefix filter was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidMinimumHealthyHostValueException": {
             "type": "structure",
+            "documentation": "<p>The minimum healthy instances value was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidNextTokenException": {
             "type": "structure",
+            "documentation": "<p>The next token was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidOperationException": {
             "type": "structure",
+            "documentation": "<p>An invalid operation was detected.</p>",
             "members": []
         },
         "InvalidRegistrationStatusException": {
             "type": "structure",
+            "documentation": "<p>The registration status was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidRevisionException": {
             "type": "structure",
+            "documentation": "<p>The revision was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidRoleException": {
             "type": "structure",
+            "documentation": "<p>The service role ARN was specified in an invalid format. Or, if an Auto Scaling group was specified, the specified service role does not grant the appropriate permissions to Auto Scaling.</p>",
             "members": []
         },
         "InvalidSortByException": {
             "type": "structure",
+            "documentation": "<p>The column name to sort by is either not present or was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidSortOrderException": {
             "type": "structure",
+            "documentation": "<p>The sort order was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidTagException": {
             "type": "structure",
+            "documentation": "<p>The specified tag was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidTagFilterException": {
             "type": "structure",
+            "documentation": "<p>The specified tag filter was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidTimeRangeException": {
             "type": "structure",
+            "documentation": "<p>The specified time range was specified in an invalid format.</p>",
             "members": []
         },
         "Key": {
@@ -1468,6 +1571,7 @@
         },
         "LifecycleEvent": {
             "type": "structure",
+            "documentation": "<p>Information about a deployment lifecycle event.</p>",
             "members": [
                 {
                     "name": "lifecycleEventName",
@@ -1511,6 +1615,7 @@
         },
         "ListApplicationRevisionsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list application revisions operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1551,6 +1656,7 @@
         },
         "ListApplicationRevisionsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list application revisions operation.</p>",
             "members": [
                 {
                     "name": "revisions",
@@ -1566,6 +1672,7 @@
         },
         "ListApplicationsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list applications operation.</p>",
             "members": [
                 {
                     "name": "nextToken",
@@ -1576,6 +1683,7 @@
         },
         "ListApplicationsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list applications operation.</p>",
             "members": [
                 {
                     "name": "applications",
@@ -1591,6 +1699,7 @@
         },
         "ListDeploymentConfigsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list deployment configurations operation.</p>",
             "members": [
                 {
                     "name": "nextToken",
@@ -1601,6 +1710,7 @@
         },
         "ListDeploymentConfigsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list deployment configurations operation.</p>",
             "members": [
                 {
                     "name": "deploymentConfigsList",
@@ -1616,6 +1726,7 @@
         },
         "ListDeploymentGroupsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list deployment groups operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1631,6 +1742,7 @@
         },
         "ListDeploymentGroupsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list deployment groups operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1651,6 +1763,7 @@
         },
         "ListDeploymentInstancesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list deployment instances operation.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -1671,6 +1784,7 @@
         },
         "ListDeploymentInstancesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list deployment instances operation.</p>",
             "members": [
                 {
                     "name": "instancesList",
@@ -1686,6 +1800,7 @@
         },
         "ListDeploymentsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list deployments operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1716,6 +1831,7 @@
         },
         "ListDeploymentsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list deployments operation.</p>",
             "members": [
                 {
                     "name": "deployments",
@@ -1731,6 +1847,7 @@
         },
         "ListOnPremisesInstancesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list on-premises instances operation.</p>.",
             "members": [
                 {
                     "name": "registrationStatus",
@@ -1751,6 +1868,7 @@
         },
         "ListOnPremisesInstancesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of list on-premises instances operation.</p>",
             "members": [
                 {
                     "name": "instanceNames",
@@ -1775,6 +1893,7 @@
         },
         "MinimumHealthyHosts": {
             "type": "structure",
+            "documentation": "<p>Information about minimum healthy instances.</p>",
             "members": [
                 {
                     "name": "value",
@@ -1799,6 +1918,7 @@
         },
         "RegisterApplicationRevisionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a register application revision operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -1819,6 +1939,7 @@
         },
         "RegisterOnPremisesInstanceInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of register on-premises instance operation.</p>",
             "members": [
                 {
                     "name": "instanceName",
@@ -1837,6 +1958,7 @@
         },
         "RemoveTagsFromOnPremisesInstancesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a remove tags from on-premises instances operation.</p>",
             "members": [
                 {
                     "name": "tags",
@@ -1855,10 +1977,12 @@
         },
         "RevisionDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The named revision does not exist with the applicable IAM user or AWS account.</p>",
             "members": []
         },
         "RevisionLocation": {
             "type": "structure",
+            "documentation": "<p>Information about an application revision's location.</p>",
             "members": [
                 {
                     "name": "revisionType",
@@ -1884,6 +2008,7 @@
         },
         "RevisionRequiredException": {
             "type": "structure",
+            "documentation": "<p>The revision ID was not specified.</p>",
             "members": []
         },
         "Role": {
@@ -1891,6 +2016,7 @@
         },
         "RoleRequiredException": {
             "type": "structure",
+            "documentation": "<p>The role ID was not specified.</p>",
             "members": []
         },
         "S3Bucket": {
@@ -1901,6 +2027,7 @@
         },
         "S3Location": {
             "type": "structure",
+            "documentation": "<p>Information about the location of application artifacts that are stored in Amazon S3.</p>",
             "members": [
                 {
                     "name": "bucket",
@@ -1937,6 +2064,7 @@
         },
         "StopDeploymentInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a stop deployment operation.</p>",
             "members": [
                 {
                     "name": "deploymentId",
@@ -1947,6 +2075,7 @@
         },
         "StopDeploymentOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a stop deployment operation.</p>",
             "members": [
                 {
                     "name": "status",
@@ -1965,6 +2094,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Information about a tag.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1980,6 +2110,7 @@
         },
         "TagFilter": {
             "type": "structure",
+            "documentation": "<p>Information about an on-premises instance tag filter.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -2007,6 +2138,7 @@
         },
         "TagLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The maximum allowed number of tags was exceeded.</p>",
             "members": []
         },
         "TagList": {
@@ -2015,10 +2147,12 @@
         },
         "TagRequiredException": {
             "type": "structure",
+            "documentation": "<p>A tag was not specified.</p>",
             "members": []
         },
         "TimeRange": {
             "type": "structure",
+            "documentation": "<p>Information about a time range.</p>",
             "members": [
                 {
                     "name": "start",
@@ -2037,6 +2171,7 @@
         },
         "UpdateApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update application operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -2052,6 +2187,7 @@
         },
         "UpdateDeploymentGroupInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update deployment group operation.</p>",
             "members": [
                 {
                     "name": "applicationName",
@@ -2097,6 +2233,7 @@
         },
         "UpdateDeploymentGroupOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an update deployment group operation.</p>",
             "members": [
                 {
                     "name": "hooksNotCleanedUp",

--- a/libcloudcore/data/aws/codepipeline/service.json
+++ b/libcloudcore/data/aws/codepipeline/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -214,6 +218,7 @@
     "shapes": {
         "AWSSessionCredentials": {
             "type": "structure",
+            "documentation": "<p>Represents an AWS session credentials object. These credentials are temporary credentials that are issued by AWS Secure Token Service (STS). They can be used to access input and output artifacts in the Amazon S3 bucket used to store artifact for the pipeline in AWS CodePipeline.</p>",
             "members": [
                 {
                     "name": "accessKeyId",
@@ -240,6 +245,7 @@
         },
         "AcknowledgeJobInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an acknowledge job action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -255,6 +261,7 @@
         },
         "AcknowledgeJobOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an acknowledge job action.</p>",
             "members": [
                 {
                     "name": "status",
@@ -265,6 +272,7 @@
         },
         "AcknowledgeThirdPartyJobInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an acknowledge third party job action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -285,6 +293,7 @@
         },
         "AcknowledgeThirdPartyJobOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an acknowledge third party job action.</p>",
             "members": [
                 {
                     "name": "status",
@@ -298,6 +307,7 @@
         },
         "ActionConfiguration": {
             "type": "structure",
+            "documentation": "<p>Represents information about an action configuration.</p>",
             "members": [
                 {
                     "name": "configuration",
@@ -310,10 +320,13 @@
             "type": "string"
         },
         "ActionConfigurationMap": {
-            "type": "map"
+            "type": "map",
+            "key": "ActionConfigurationKey",
+            "value": "ActionConfigurationValue"
         },
         "ActionConfigurationProperty": {
             "type": "structure",
+            "documentation": "<p>Represents information about an action configuration property.</p>",
             "members": [
                 {
                     "name": "name",
@@ -364,6 +377,7 @@
         },
         "ActionContext": {
             "type": "structure",
+            "documentation": "<p>Represents the context of an action within the stage of a pipeline to a job worker.</p>",
             "members": [
                 {
                     "name": "name",
@@ -374,6 +388,7 @@
         },
         "ActionDeclaration": {
             "type": "structure",
+            "documentation": "<p>Represents information about an action declaration.</p>",
             "members": [
                 {
                     "name": "name",
@@ -414,6 +429,7 @@
         },
         "ActionExecution": {
             "type": "structure",
+            "documentation": "<p>Represents information about how an action runs.</p>",
             "members": [
                 {
                     "name": "status",
@@ -460,6 +476,7 @@
         },
         "ActionNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified action cannot be found.</p>",
             "members": []
         },
         "ActionOwner": {
@@ -470,6 +487,7 @@
         },
         "ActionRevision": {
             "type": "structure",
+            "documentation": "<p>Represents information about the version (or revision) of an action.</p>",
             "members": [
                 {
                     "name": "revisionId",
@@ -493,6 +511,7 @@
         },
         "ActionState": {
             "type": "structure",
+            "documentation": "<p>Represents information about the state of an action.</p>",
             "members": [
                 {
                     "name": "actionName",
@@ -525,6 +544,7 @@
         },
         "ActionType": {
             "type": "structure",
+            "documentation": "<p>Returns information about the details of an action type. </p>",
             "members": [
                 {
                     "name": "id",
@@ -554,6 +574,7 @@
         },
         "ActionTypeId": {
             "type": "structure",
+            "documentation": "<p>Represents information about an action type.</p>",
             "members": [
                 {
                     "name": "category",
@@ -583,10 +604,12 @@
         },
         "ActionTypeNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified action type cannot be found.</p>",
             "members": []
         },
         "ActionTypeSettings": {
             "type": "structure",
+            "documentation": "<p>Returns information about the settings for an action type. </p>",
             "members": [
                 {
                     "name": "thirdPartyConfigurationUrl",
@@ -612,6 +635,7 @@
         },
         "Artifact": {
             "type": "structure",
+            "documentation": "<p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>",
             "members": [
                 {
                     "name": "name",
@@ -632,6 +656,7 @@
         },
         "ArtifactDetails": {
             "type": "structure",
+            "documentation": "<p>Returns information about the details of an artifact.</p>",
             "members": [
                 {
                     "name": "minimumCount",
@@ -651,6 +676,7 @@
         },
         "ArtifactLocation": {
             "type": "structure",
+            "documentation": "<p>Represents information about the location of an artifact.</p>",
             "members": [
                 {
                     "name": "type",
@@ -672,6 +698,7 @@
         },
         "ArtifactStore": {
             "type": "structure",
+            "documentation": "<p>The Amazon S3 location where artifacts are stored for the pipeline. If this Amazon S3 bucket is created manually, it must meet the requirements for AWS CodePipeline. For more information, see the <ulink url=\"http://docs.aws.amazon.com/codepipeline/latest/UserGuide/concepts.html\">Concepts</ulink>.</p>",
             "members": [
                 {
                     "name": "type",
@@ -693,6 +720,7 @@
         },
         "BlockerDeclaration": {
             "type": "structure",
+            "documentation": "<p>Represents information about a gate declaration.</p>",
             "members": [
                 {
                     "name": "name",
@@ -729,6 +757,7 @@
         },
         "CreateCustomActionTypeInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create custom action operation. </p>",
             "members": [
                 {
                     "name": "category",
@@ -766,6 +795,7 @@
         },
         "CreateCustomActionTypeOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create custom action operation.</p>",
             "members": [
                 {
                     "name": "actionType",
@@ -775,6 +805,7 @@
         },
         "CreatePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a create pipeline action.</p>",
             "members": [
                 {
                     "name": "pipeline",
@@ -784,6 +815,7 @@
         },
         "CreatePipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a create pipeline action.</p>",
             "members": [
                 {
                     "name": "pipeline",
@@ -793,6 +825,7 @@
         },
         "CurrentRevision": {
             "type": "structure",
+            "documentation": "<p>Represents information about a current revision.</p>",
             "members": [
                 {
                     "name": "revision",
@@ -808,6 +841,7 @@
         },
         "DeleteCustomActionTypeInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete custom action operation. The custom action will be marked as deleted.</p>",
             "members": [
                 {
                     "name": "category",
@@ -828,6 +862,7 @@
         },
         "DeletePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a delete pipeline action.</p>",
             "members": [
                 {
                     "name": "name",
@@ -841,6 +876,7 @@
         },
         "DisableStageTransitionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a disable stage transition input action.</p>",
             "members": [
                 {
                     "name": "pipelineName",
@@ -869,6 +905,7 @@
         },
         "EnableStageTransitionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an enable stage transition action.</p>",
             "members": [
                 {
                     "name": "pipelineName",
@@ -892,6 +929,7 @@
         },
         "ErrorDetails": {
             "type": "structure",
+            "documentation": "<p>Represents information about an error in AWS CodePipeline.</p>",
             "members": [
                 {
                     "name": "code",
@@ -907,6 +945,7 @@
         },
         "ExecutionDetails": {
             "type": "structure",
+            "documentation": "<p>The details of the actions taken and results produced on an artifact as it passes through stages in the pipeline.</p>",
             "members": [
                 {
                     "name": "summary",
@@ -933,6 +972,7 @@
         },
         "FailureDetails": {
             "type": "structure",
+            "documentation": "<p>Represents information about failure details.</p>",
             "members": [
                 {
                     "name": "type",
@@ -956,6 +996,7 @@
         },
         "GetJobDetailsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get job details action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -966,6 +1007,7 @@
         },
         "GetJobDetailsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get job details action.</p>",
             "members": [
                 {
                     "name": "jobDetails",
@@ -976,6 +1018,7 @@
         },
         "GetPipelineInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get pipeline action.</p>",
             "members": [
                 {
                     "name": "name",
@@ -991,6 +1034,7 @@
         },
         "GetPipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get pipeline action.</p>",
             "members": [
                 {
                     "name": "pipeline",
@@ -1000,6 +1044,7 @@
         },
         "GetPipelineStateInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get pipeline state action.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1010,6 +1055,7 @@
         },
         "GetPipelineStateOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get pipeline state action.</p>",
             "members": [
                 {
                     "name": "pipelineName",
@@ -1040,6 +1086,7 @@
         },
         "GetThirdPartyJobDetailsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a get third party job details action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -1055,6 +1102,7 @@
         },
         "GetThirdPartyJobDetailsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a get third party job details action. </p>",
             "members": [
                 {
                     "name": "jobDetails",
@@ -1065,6 +1113,7 @@
         },
         "InputArtifact": {
             "type": "structure",
+            "documentation": "<p>Represents information about an artifact to be worked on, such as a test or build artifact.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1079,42 +1128,52 @@
         },
         "InvalidActionDeclarationException": {
             "type": "structure",
+            "documentation": "<p>The specified action declaration was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidBlockerDeclarationException": {
             "type": "structure",
+            "documentation": "<p>The specified gate declaration was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidClientTokenException": {
             "type": "structure",
+            "documentation": "<p>The client token was specified in an invalid format</p>",
             "members": []
         },
         "InvalidJobException": {
             "type": "structure",
+            "documentation": "<p>The specified job was specified in an invalid format or cannot be found.</p>",
             "members": []
         },
         "InvalidJobStateException": {
             "type": "structure",
+            "documentation": "<p>The specified job state was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidNextTokenException": {
             "type": "structure",
+            "documentation": "<p>The next token was specified in an invalid format. Make sure that the next token you provided is the token returned by a previous call.</p>",
             "members": []
         },
         "InvalidNonceException": {
             "type": "structure",
+            "documentation": "<p>The specified nonce was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidStageDeclarationException": {
             "type": "structure",
+            "documentation": "<p>The specified stage declaration was specified in an invalid format.</p>",
             "members": []
         },
         "InvalidStructureException": {
             "type": "structure",
+            "documentation": "<p>The specified structure was specified in an invalid format.</p>",
             "members": []
         },
         "Job": {
             "type": "structure",
+            "documentation": "<p>Represents information about a job.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1140,6 +1199,7 @@
         },
         "JobData": {
             "type": "structure",
+            "documentation": "<p>Represents additional information about a job required for a job worker to complete the job. </p>",
             "members": [
                 {
                     "name": "actionTypeId",
@@ -1176,6 +1236,7 @@
         },
         "JobDetails": {
             "type": "structure",
+            "documentation": "<p>Represents information about the details of a job.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1202,6 +1263,7 @@
         },
         "JobNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified job was specified in an invalid format or cannot be found.</p>",
             "members": []
         },
         "JobStatus": {
@@ -1215,10 +1277,12 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The number of pipelines associated with the AWS account has exceeded the limit allowed for the account.</p>",
             "members": []
         },
         "ListActionTypesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list action types action.</p>",
             "members": [
                 {
                     "name": "actionOwnerFilter",
@@ -1234,6 +1298,7 @@
         },
         "ListActionTypesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list action types action.</p>",
             "members": [
                 {
                     "name": "actionTypes",
@@ -1249,6 +1314,7 @@
         },
         "ListPipelinesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a list pipelines action. </p>",
             "members": [
                 {
                     "name": "nextToken",
@@ -1259,6 +1325,7 @@
         },
         "ListPipelinesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a list pipelines action.</p>",
             "members": [
                 {
                     "name": "pipelines",
@@ -1292,6 +1359,7 @@
         },
         "OutputArtifact": {
             "type": "structure",
+            "documentation": "<p>Represents information about the output of an action.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1309,6 +1377,7 @@
         },
         "PipelineContext": {
             "type": "structure",
+            "documentation": "<p>Represents information about a pipeline to a job worker.</p>",
             "members": [
                 {
                     "name": "pipelineName",
@@ -1328,6 +1397,7 @@
         },
         "PipelineDeclaration": {
             "type": "structure",
+            "documentation": "<p>Represents the structure of actions and stages to be performed in the pipeline. </p>",
             "members": [
                 {
                     "name": "name",
@@ -1367,10 +1437,12 @@
         },
         "PipelineNameInUseException": {
             "type": "structure",
+            "documentation": "<p>The specified pipeline name is already in use.</p>",
             "members": []
         },
         "PipelineNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified pipeline was specified in an invalid format or cannot be found.</p>",
             "members": []
         },
         "PipelineStageDeclarationList": {
@@ -1379,6 +1451,7 @@
         },
         "PipelineSummary": {
             "type": "structure",
+            "documentation": "<p>Returns a summary of a pipeline.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1407,10 +1480,12 @@
         },
         "PipelineVersionNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified pipeline version was specified in an invalid format or cannot be found.</p>",
             "members": []
         },
         "PollForJobsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a poll for jobs action.</p>",
             "members": [
                 {
                     "name": "actionTypeId",
@@ -1430,6 +1505,7 @@
         },
         "PollForJobsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a poll for jobs action.</p>",
             "members": [
                 {
                     "name": "jobs",
@@ -1440,6 +1516,7 @@
         },
         "PollForThirdPartyJobsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a poll for third party jobs action.</p>",
             "members": [
                 {
                     "name": "actionTypeId",
@@ -1454,6 +1531,7 @@
         },
         "PollForThirdPartyJobsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a poll for third party jobs action.</p>",
             "members": [
                 {
                     "name": "jobs",
@@ -1464,6 +1542,7 @@
         },
         "PutActionRevisionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a put action revision action.</p>",
             "members": [
                 {
                     "name": "pipelineName",
@@ -1488,6 +1567,7 @@
         },
         "PutActionRevisionOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a put action revision action.</p>",
             "members": [
                 {
                     "name": "newRevision",
@@ -1503,6 +1583,7 @@
         },
         "PutJobFailureResultInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a put job failure result action. </p>",
             "members": [
                 {
                     "name": "jobId",
@@ -1518,6 +1599,7 @@
         },
         "PutJobSuccessResultInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a put job success result action. </p>",
             "members": [
                 {
                     "name": "jobId",
@@ -1543,6 +1625,7 @@
         },
         "PutThirdPartyJobFailureResultInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a third party job failure result action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -1562,6 +1645,7 @@
         },
         "PutThirdPartyJobSuccessResultInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a put third party job success result action.</p>",
             "members": [
                 {
                     "name": "jobId",
@@ -1589,7 +1673,9 @@
             ]
         },
         "QueryParamMap": {
-            "type": "map"
+            "type": "map",
+            "key": "ActionConfigurationKey",
+            "value": "ActionConfigurationValue"
         },
         "Revision": {
             "type": "string"
@@ -1608,6 +1694,7 @@
         },
         "S3ArtifactLocation": {
             "type": "structure",
+            "documentation": "<p>The location of the Amazon S3 bucket that contains a revision.</p>",
             "members": [
                 {
                     "name": "bucketName",
@@ -1643,6 +1730,7 @@
         },
         "StageContext": {
             "type": "structure",
+            "documentation": "<p>Represents information about a stage to a job worker.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1653,6 +1741,7 @@
         },
         "StageDeclaration": {
             "type": "structure",
+            "documentation": "<p>Represents information about a stage and its definition.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1676,10 +1765,12 @@
         },
         "StageNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified stage was specified in an invalid format or cannot be found.</p>",
             "members": []
         },
         "StageState": {
             "type": "structure",
+            "documentation": "<p>Represents information about the state of the stage.</p>",
             "members": [
                 {
                     "name": "stageName",
@@ -1707,6 +1798,7 @@
         },
         "StartPipelineExecutionInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a start pipeline execution action.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1717,6 +1809,7 @@
         },
         "StartPipelineExecutionOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a start pipeline execution action.</p>",
             "members": [
                 {
                     "name": "pipelineExecutionId",
@@ -1727,6 +1820,7 @@
         },
         "ThirdPartyJob": {
             "type": "structure",
+            "documentation": "<p>A response to a PollForThirdPartyJobs request returned by AWS CodePipeline when there is a job to be worked upon by a partner action.</p>",
             "members": [
                 {
                     "name": "clientId",
@@ -1742,6 +1836,7 @@
         },
         "ThirdPartyJobData": {
             "type": "structure",
+            "documentation": "<p>Represents information about the job data for a partner action.</p>",
             "members": [
                 {
                     "name": "actionTypeId",
@@ -1778,6 +1873,7 @@
         },
         "ThirdPartyJobDetails": {
             "type": "structure",
+            "documentation": "<p>The details of a job sent in response to a GetThirdPartyJobDetails request.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1808,6 +1904,7 @@
         },
         "TransitionState": {
             "type": "structure",
+            "documentation": "<p>Represents information about the state of transitions between one stage and another stage.</p>",
             "members": [
                 {
                     "name": "enabled",
@@ -1833,6 +1930,7 @@
         },
         "UpdatePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an update pipeline action.</p>",
             "members": [
                 {
                     "name": "pipeline",
@@ -1843,6 +1941,7 @@
         },
         "UpdatePipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an update pipeline action.</p>",
             "members": [
                 {
                     "name": "pipeline",
@@ -1859,6 +1958,7 @@
         },
         "ValidationException": {
             "type": "structure",
+            "documentation": "<p>The validation was specified in an invalid format.</p>",
             "members": []
         },
         "Version": {

--- a/libcloudcore/data/aws/cognito-identity/service.json
+++ b/libcloudcore/data/aws/cognito-identity/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -190,6 +194,7 @@
         },
         "ConcurrentModificationException": {
             "type": "structure",
+            "documentation": "<p>Thrown if there are parallel requests to modify a resource.</p>",
             "members": [
                 {
                     "name": "message",
@@ -200,6 +205,7 @@
         },
         "CreateIdentityPoolInput": {
             "type": "structure",
+            "documentation": "<p>Input to the CreateIdentityPool action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolName",
@@ -230,6 +236,7 @@
         },
         "Credentials": {
             "type": "structure",
+            "documentation": "<p>Credentials for the the provided identity ID.</p>",
             "members": [
                 {
                     "name": "AccessKeyId",
@@ -258,6 +265,7 @@
         },
         "DeleteIdentitiesInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>DeleteIdentities</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityIdsToDelete",
@@ -268,6 +276,7 @@
         },
         "DeleteIdentitiesResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>DeleteIdentities</code> operation.</p>",
             "members": [
                 {
                     "name": "UnprocessedIdentityIds",
@@ -278,6 +287,7 @@
         },
         "DeleteIdentityPoolInput": {
             "type": "structure",
+            "documentation": "<p>Input to the DeleteIdentityPool action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -288,6 +298,7 @@
         },
         "DescribeIdentityInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>DescribeIdentity</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -298,6 +309,7 @@
         },
         "DescribeIdentityPoolInput": {
             "type": "structure",
+            "documentation": "Input to the DescribeIdentityPool action.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -311,6 +323,7 @@
         },
         "DeveloperUserAlreadyRegisteredException": {
             "type": "structure",
+            "documentation": "<p>The provided developer user identifier is already registered with Cognito under a different identity ID.</p>",
             "members": [
                 {
                     "name": "message",
@@ -331,6 +344,7 @@
         },
         "ExternalServiceException": {
             "type": "structure",
+            "documentation": "<p>An exception thrown when a dependent service such as Facebook or Twitter is not responding</p>",
             "members": [
                 {
                     "name": "message",
@@ -341,6 +355,7 @@
         },
         "GetCredentialsForIdentityInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>GetCredentialsForIdentity</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -356,6 +371,7 @@
         },
         "GetCredentialsForIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>GetCredentialsForIdentity</code> operation.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -371,6 +387,7 @@
         },
         "GetIdInput": {
             "type": "structure",
+            "documentation": "Input to the GetId action.",
             "members": [
                 {
                     "name": "AccountId",
@@ -391,6 +408,7 @@
         },
         "GetIdResponse": {
             "type": "structure",
+            "documentation": "Returned in response to a GetId request.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -401,6 +419,7 @@
         },
         "GetIdentityPoolRolesInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>GetIdentityPoolRoles</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -411,6 +430,7 @@
         },
         "GetIdentityPoolRolesResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>GetIdentityPoolRoles</code> operation.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -426,6 +446,7 @@
         },
         "GetOpenIdTokenForDeveloperIdentityInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>GetOpenIdTokenForDeveloperIdentity</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -451,6 +472,7 @@
         },
         "GetOpenIdTokenForDeveloperIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>GetOpenIdTokenForDeveloperIdentity</code> request.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -466,6 +488,7 @@
         },
         "GetOpenIdTokenInput": {
             "type": "structure",
+            "documentation": "Input to the GetOpenIdToken action.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -481,6 +504,7 @@
         },
         "GetOpenIdTokenResponse": {
             "type": "structure",
+            "documentation": "Returned in response to a successful GetOpenIdToken request.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -503,6 +527,7 @@
         },
         "IdentityDescription": {
             "type": "structure",
+            "documentation": "A description of the identity.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -535,6 +560,7 @@
         },
         "IdentityPool": {
             "type": "structure",
+            "documentation": "An object representing a Cognito identity pool.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -576,6 +602,7 @@
         },
         "IdentityPoolShortDescription": {
             "type": "structure",
+            "documentation": "A description of the identity pool.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -606,10 +633,13 @@
             "type": "string"
         },
         "IdentityProviders": {
-            "type": "map"
+            "type": "map",
+            "key": "IdentityProviderName",
+            "value": "IdentityProviderId"
         },
         "InternalErrorException": {
             "type": "structure",
+            "documentation": "Thrown when the service encounters an error during processing the request.",
             "members": [
                 {
                     "name": "message",
@@ -620,6 +650,7 @@
         },
         "InvalidIdentityPoolConfigurationException": {
             "type": "structure",
+            "documentation": "<p>Thrown if the identity pool has no role associated for the given auth type (auth/unauth) or if the AssumeRole fails.</p>",
             "members": [
                 {
                     "name": "message",
@@ -630,6 +661,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "Thrown for missing or bad input parameter(s).",
             "members": [
                 {
                     "name": "message",
@@ -640,6 +672,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "Thrown when the total number of user pools has exceeded a preset limit.",
             "members": [
                 {
                     "name": "message",
@@ -650,6 +683,7 @@
         },
         "ListIdentitiesInput": {
             "type": "structure",
+            "documentation": "Input to the ListIdentities action.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -675,6 +709,7 @@
         },
         "ListIdentitiesResponse": {
             "type": "structure",
+            "documentation": "The response to a ListIdentities request.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -695,6 +730,7 @@
         },
         "ListIdentityPoolsInput": {
             "type": "structure",
+            "documentation": "Input to the ListIdentityPools action.",
             "members": [
                 {
                     "name": "MaxResults",
@@ -710,6 +746,7 @@
         },
         "ListIdentityPoolsResponse": {
             "type": "structure",
+            "documentation": "The result of a successful ListIdentityPools action.",
             "members": [
                 {
                     "name": "IdentityPools",
@@ -728,10 +765,13 @@
             "of": "IdentityProviderName"
         },
         "LoginsMap": {
-            "type": "map"
+            "type": "map",
+            "key": "IdentityProviderName",
+            "value": "IdentityProviderToken"
         },
         "LookupDeveloperIdentityInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>LookupDeveloperIdentityInput</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -762,6 +802,7 @@
         },
         "LookupDeveloperIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>LookupDeveloperIdentity</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -782,6 +823,7 @@
         },
         "MergeDeveloperIdentitiesInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>MergeDeveloperIdentities</code> action.</p>",
             "members": [
                 {
                     "name": "SourceUserIdentifier",
@@ -807,6 +849,7 @@
         },
         "MergeDeveloperIdentitiesResponse": {
             "type": "structure",
+            "documentation": "<p>Returned in response to a successful <code>MergeDeveloperIdentities</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -817,6 +860,7 @@
         },
         "NotAuthorizedException": {
             "type": "structure",
+            "documentation": "Thrown when a user is not authorized to access the requested resource.",
             "members": [
                 {
                     "name": "message",
@@ -840,6 +884,7 @@
         },
         "ResourceConflictException": {
             "type": "structure",
+            "documentation": "Thrown when a user tries to use a login which is already linked to another account.",
             "members": [
                 {
                     "name": "message",
@@ -850,6 +895,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "Thrown when the requested resource (for example, a dataset or record) does not exist.",
             "members": [
                 {
                     "name": "message",
@@ -862,7 +908,9 @@
             "type": "string"
         },
         "RolesMap": {
-            "type": "map"
+            "type": "map",
+            "key": "RoleType",
+            "value": "ARNString"
         },
         "SecretKeyString": {
             "type": "string"
@@ -872,6 +920,7 @@
         },
         "SetIdentityPoolRolesInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>SetIdentityPoolRoles</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -893,6 +942,7 @@
         },
         "TooManyRequestsException": {
             "type": "structure",
+            "documentation": "Thrown when a request is throttled.",
             "members": [
                 {
                     "name": "message",
@@ -903,6 +953,7 @@
         },
         "UnlinkDeveloperIdentityInput": {
             "type": "structure",
+            "documentation": "<p>Input to the <code>UnlinkDeveloperIdentity</code> action.</p>",
             "members": [
                 {
                     "name": "IdentityId",
@@ -928,6 +979,7 @@
         },
         "UnlinkIdentityInput": {
             "type": "structure",
+            "documentation": "Input to the UnlinkIdentity action.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -948,6 +1000,7 @@
         },
         "UnprocessedIdentityId": {
             "type": "structure",
+            "documentation": "<p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>",
             "members": [
                 {
                     "name": "IdentityId",

--- a/libcloudcore/data/aws/cognito-sync/service.json
+++ b/libcloudcore/data/aws/cognito-sync/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -181,6 +185,7 @@
     "shapes": {
         "AlreadyStreamedException": {
             "type": "structure",
+            "documentation": "An exception thrown when a bulk publish operation is requested less than 24 hours after a previous bulk publish operation completed successfully.",
             "members": [
                 {
                     "name": "message",
@@ -204,6 +209,7 @@
         },
         "BulkPublishRequest": {
             "type": "structure",
+            "documentation": "The input for the BulkPublish operation.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -216,6 +222,7 @@
         },
         "BulkPublishResponse": {
             "type": "structure",
+            "documentation": "The output for the BulkPublish operation.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -235,6 +242,7 @@
         },
         "CognitoStreams": {
             "type": "structure",
+            "documentation": "Configuration options for configure Cognito streams.",
             "members": [
                 {
                     "name": "StreamName",
@@ -255,6 +263,7 @@
         },
         "ConcurrentModificationException": {
             "type": "structure",
+            "documentation": "<p>Thrown if there are parallel requests to modify a resource.</p>",
             "members": [
                 {
                     "name": "message",
@@ -265,6 +274,7 @@
         },
         "Dataset": {
             "type": "structure",
+            "documentation": "A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don't exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -315,6 +325,7 @@
         },
         "DeleteDatasetRequest": {
             "type": "structure",
+            "documentation": "A request to delete the specific dataset.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -341,6 +352,7 @@
         },
         "DeleteDatasetResponse": {
             "type": "structure",
+            "documentation": "Response to a successful DeleteDataset request.",
             "members": [
                 {
                     "name": "Dataset",
@@ -351,6 +363,7 @@
         },
         "DescribeDatasetRequest": {
             "type": "structure",
+            "documentation": "A request for meta data about a dataset (creation date, number of records, size) by owner and dataset name.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -377,6 +390,7 @@
         },
         "DescribeDatasetResponse": {
             "type": "structure",
+            "documentation": "Response to a successful DescribeDataset request.",
             "members": [
                 {
                     "name": "Dataset",
@@ -387,6 +401,7 @@
         },
         "DescribeIdentityPoolUsageRequest": {
             "type": "structure",
+            "documentation": "A request for usage information about the identity pool.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -399,6 +414,7 @@
         },
         "DescribeIdentityPoolUsageResponse": {
             "type": "structure",
+            "documentation": "Response to a successful DescribeIdentityPoolUsage request.",
             "members": [
                 {
                     "name": "IdentityPoolUsage",
@@ -409,6 +425,7 @@
         },
         "DescribeIdentityUsageRequest": {
             "type": "structure",
+            "documentation": "A request for information about the usage of an identity pool.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -428,6 +445,7 @@
         },
         "DescribeIdentityUsageResponse": {
             "type": "structure",
+            "documentation": "The response to a successful DescribeIdentityUsage request.",
             "members": [
                 {
                     "name": "IdentityUsage",
@@ -441,6 +459,7 @@
         },
         "DuplicateRequestException": {
             "type": "structure",
+            "documentation": "An exception thrown when there is an IN_PROGRESS bulk publish operation for the given identity pool.",
             "members": [
                 {
                     "name": "message",
@@ -450,13 +469,16 @@
             ]
         },
         "Events": {
-            "type": "map"
+            "type": "map",
+            "key": "CognitoEventType",
+            "value": "LambdaFunctionArn"
         },
         "ExceptionMessage": {
             "type": "string"
         },
         "GetBulkPublishDetailsRequest": {
             "type": "structure",
+            "documentation": "The input for the GetBulkPublishDetails operation.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -469,6 +491,7 @@
         },
         "GetBulkPublishDetailsResponse": {
             "type": "structure",
+            "documentation": "The output for the GetBulkPublishDetails operation.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -499,6 +522,7 @@
         },
         "GetCognitoEventsRequest": {
             "type": "structure",
+            "documentation": "<p>A request for a list of the configured Cognito Events</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -511,6 +535,7 @@
         },
         "GetCognitoEventsResponse": {
             "type": "structure",
+            "documentation": "<p>The response from the GetCognitoEvents request</p>",
             "members": [
                 {
                     "name": "Events",
@@ -521,6 +546,7 @@
         },
         "GetIdentityPoolConfigurationRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the GetIdentityPoolConfiguration operation.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -533,6 +559,7 @@
         },
         "GetIdentityPoolConfigurationResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the GetIdentityPoolConfiguration operation.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -559,6 +586,7 @@
         },
         "IdentityPoolUsage": {
             "type": "structure",
+            "documentation": "Usage information for the identity pool.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -588,6 +616,7 @@
         },
         "IdentityUsage": {
             "type": "structure",
+            "documentation": "Usage information for the identity.",
             "members": [
                 {
                     "name": "IdentityId",
@@ -624,6 +653,7 @@
         },
         "InternalErrorException": {
             "type": "structure",
+            "documentation": "Indicates an internal service error.",
             "members": [
                 {
                     "name": "message",
@@ -644,6 +674,7 @@
         },
         "InvalidLambdaFunctionOutputException": {
             "type": "structure",
+            "documentation": "<p>The AWS Lambda function returned invalid output or an exception.</p>",
             "members": [
                 {
                     "name": "message",
@@ -654,6 +685,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "Thrown when a request parameter does not comply with the associated constraints.",
             "members": [
                 {
                     "name": "message",
@@ -667,6 +699,7 @@
         },
         "LambdaThrottledException": {
             "type": "structure",
+            "documentation": "<p>AWS Lambda throttled your account, please contact AWS Support</p>",
             "members": [
                 {
                     "name": "message",
@@ -677,6 +710,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "Thrown when the limit on the number of objects or operations has been exceeded.",
             "members": [
                 {
                     "name": "message",
@@ -687,6 +721,7 @@
         },
         "ListDatasetsRequest": {
             "type": "structure",
+            "documentation": "Request for a list of datasets for an identity.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -720,6 +755,7 @@
         },
         "ListDatasetsResponse": {
             "type": "structure",
+            "documentation": "Returned for a successful ListDatasets request.",
             "members": [
                 {
                     "name": "Datasets",
@@ -740,6 +776,7 @@
         },
         "ListIdentityPoolUsageRequest": {
             "type": "structure",
+            "documentation": "A request for usage information on an identity pool.",
             "members": [
                 {
                     "name": "NextToken",
@@ -759,6 +796,7 @@
         },
         "ListIdentityPoolUsageResponse": {
             "type": "structure",
+            "documentation": "Returned for a successful ListIdentityPoolUsage request.",
             "members": [
                 {
                     "name": "IdentityPoolUsages",
@@ -784,6 +822,7 @@
         },
         "ListRecordsRequest": {
             "type": "structure",
+            "documentation": "A request for a list of records.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -838,6 +877,7 @@
         },
         "ListRecordsResponse": {
             "type": "structure",
+            "documentation": "Returned for a successful ListRecordsRequest.",
             "members": [
                 {
                     "name": "Records",
@@ -895,6 +935,7 @@
         },
         "NotAuthorizedException": {
             "type": "structure",
+            "documentation": "Thrown when a user is not authorized to access the requested resource.",
             "members": [
                 {
                     "name": "message",
@@ -911,6 +952,7 @@
         },
         "PushSync": {
             "type": "structure",
+            "documentation": "<p>Configuration options to be applied to the identity pool.</p>",
             "members": [
                 {
                     "name": "ApplicationArns",
@@ -929,6 +971,7 @@
         },
         "Record": {
             "type": "structure",
+            "documentation": "The basic data structure of a dataset.",
             "members": [
                 {
                     "name": "Key",
@@ -971,6 +1014,7 @@
         },
         "RecordPatch": {
             "type": "structure",
+            "documentation": "An update operation for a record.",
             "members": [
                 {
                     "name": "Op",
@@ -1008,6 +1052,7 @@
         },
         "RegisterDeviceRequest": {
             "type": "structure",
+            "documentation": "<p>A request to RegisterDevice.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1037,6 +1082,7 @@
         },
         "RegisterDeviceResponse": {
             "type": "structure",
+            "documentation": "<p>Response to a RegisterDevice request.</p>",
             "members": [
                 {
                     "name": "DeviceId",
@@ -1047,6 +1093,7 @@
         },
         "ResourceConflictException": {
             "type": "structure",
+            "documentation": "Thrown if an update can't be applied because the resource was changed by another call and this would result in a conflict.",
             "members": [
                 {
                     "name": "message",
@@ -1057,6 +1104,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "Thrown if the resource doesn't exist.",
             "members": [
                 {
                     "name": "message",
@@ -1067,6 +1115,7 @@
         },
         "SetCognitoEventsRequest": {
             "type": "structure",
+            "documentation": "<p>A request to configure Cognito Events\"</p>\"",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1084,6 +1133,7 @@
         },
         "SetIdentityPoolConfigurationRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the SetIdentityPoolConfiguration operation.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1106,6 +1156,7 @@
         },
         "SetIdentityPoolConfigurationResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the SetIdentityPoolConfiguration operation</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1135,6 +1186,7 @@
         },
         "SubscribeToDatasetRequest": {
             "type": "structure",
+            "documentation": "<p>A request to SubscribeToDatasetRequest.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1168,6 +1220,7 @@
         },
         "SubscribeToDatasetResponse": {
             "type": "structure",
+            "documentation": "<p>Response to a SubscribeToDataset request.</p>",
             "members": []
         },
         "SyncSessionToken": {
@@ -1175,6 +1228,7 @@
         },
         "TooManyRequestsException": {
             "type": "structure",
+            "documentation": "Thrown if the request is throttled.",
             "members": [
                 {
                     "name": "message",
@@ -1185,6 +1239,7 @@
         },
         "UnsubscribeFromDatasetRequest": {
             "type": "structure",
+            "documentation": "<p>A request to UnsubscribeFromDataset.</p>",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1218,10 +1273,12 @@
         },
         "UnsubscribeFromDatasetResponse": {
             "type": "structure",
+            "documentation": "<p>Response to an UnsubscribeFromDataset request.</p>",
             "members": []
         },
         "UpdateRecordsRequest": {
             "type": "structure",
+            "documentation": "A request to post updates to records or add and delete records for a dataset and user.",
             "members": [
                 {
                     "name": "IdentityPoolId",
@@ -1270,6 +1327,7 @@
         },
         "UpdateRecordsResponse": {
             "type": "structure",
+            "documentation": "Returned for a successful UpdateRecordsRequest.",
             "members": [
                 {
                     "name": "Records",

--- a/libcloudcore/data/aws/config/service.json
+++ b/libcloudcore/data/aws/config/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -136,6 +140,7 @@
         },
         "ConfigExportDeliveryInfo": {
             "type": "structure",
+            "documentation": "<p>A list that contains the status of the delivery of either the snapshot or the configuration history to the specified Amazon S3 bucket.</p>",
             "members": [
                 {
                     "name": "lastStatus",
@@ -166,6 +171,7 @@
         },
         "ConfigStreamDeliveryInfo": {
             "type": "structure",
+            "documentation": "<p>A list that contains the status of the delivery of the configuration stream notification to the Amazon SNS topic. </p>",
             "members": [
                 {
                     "name": "lastStatus",
@@ -194,6 +200,7 @@
         },
         "ConfigurationItem": {
             "type": "structure",
+            "documentation": "<p>A list that contains detailed configurations of a specified resource.</p> <note> <p>Currently, the list does not contain information about non-AWS components (for example, applications on your Amazon EC2 instances). </p> </note>",
             "members": [
                 {
                     "name": "version",
@@ -287,6 +294,7 @@
         },
         "ConfigurationRecorder": {
             "type": "structure",
+            "documentation": "<p>An object that represents the recording of configuration changes of an AWS resource.</p>",
             "members": [
                 {
                     "name": "name",
@@ -315,6 +323,7 @@
         },
         "ConfigurationRecorderStatus": {
             "type": "structure",
+            "documentation": "<p>The current status of the configuration recorder.</p>",
             "members": [
                 {
                     "name": "name",
@@ -370,6 +379,7 @@
         },
         "DeleteDeliveryChannelRequest": {
             "type": "structure",
+            "documentation": "<p> The input for the <a>DeleteDeliveryChannel</a> action. The action accepts the following data in JSON format. </p>",
             "members": [
                 {
                     "name": "DeliveryChannelName",
@@ -380,6 +390,7 @@
         },
         "DeliverConfigSnapshotRequest": {
             "type": "structure",
+            "documentation": "<p> The input for the <a>DeliverConfigSnapshot</a> action. </p>",
             "members": [
                 {
                     "name": "deliveryChannelName",
@@ -390,6 +401,7 @@
         },
         "DeliverConfigSnapshotResponse": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>DeliverConfigSnapshot</a> action in JSON format. </p>",
             "members": [
                 {
                     "name": "configSnapshotId",
@@ -400,6 +412,7 @@
         },
         "DeliveryChannel": {
             "type": "structure",
+            "documentation": "<p>A logical container used for storing the configuration changes of an AWS resource.</p>",
             "members": [
                 {
                     "name": "name",
@@ -433,6 +446,7 @@
         },
         "DeliveryChannelStatus": {
             "type": "structure",
+            "documentation": "<p>The status of a specified delivery channel.</p> <p>Valid values: <code>Success</code> | <code>Failure</code></p>",
             "members": [
                 {
                     "name": "name",
@@ -465,6 +479,7 @@
         },
         "DescribeConfigurationRecorderStatusRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>DescribeConfigurationRecorderStatus</a> action.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecorderNames",
@@ -475,6 +490,7 @@
         },
         "DescribeConfigurationRecorderStatusResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>DescribeConfigurationRecorderStatus</a> action in JSON format.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecordersStatus",
@@ -485,6 +501,7 @@
         },
         "DescribeConfigurationRecordersRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>DescribeConfigurationRecorders</a> action.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecorderNames",
@@ -495,6 +512,7 @@
         },
         "DescribeConfigurationRecordersResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>DescribeConfigurationRecorders</a> action.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecorders",
@@ -505,6 +523,7 @@
         },
         "DescribeDeliveryChannelStatusRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>DeliveryChannelStatus</a> action.</p>",
             "members": [
                 {
                     "name": "DeliveryChannelNames",
@@ -515,6 +534,7 @@
         },
         "DescribeDeliveryChannelStatusResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>DescribeDeliveryChannelStatus</a> action.</p>",
             "members": [
                 {
                     "name": "DeliveryChannelsStatus",
@@ -525,6 +545,7 @@
         },
         "DescribeDeliveryChannelsRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>DescribeDeliveryChannels</a> action.</p>",
             "members": [
                 {
                     "name": "DeliveryChannelNames",
@@ -535,6 +556,7 @@
         },
         "DescribeDeliveryChannelsResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>DescribeDeliveryChannels</a> action.</p>",
             "members": [
                 {
                     "name": "DeliveryChannels",
@@ -548,6 +570,7 @@
         },
         "GetResourceConfigHistoryRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>GetResourceConfigHistory</a> action.</p>",
             "members": [
                 {
                     "name": "resourceType",
@@ -588,6 +611,7 @@
         },
         "GetResourceConfigHistoryResponse": {
             "type": "structure",
+            "documentation": "<p>The output for the <a>GetResourceConfigHistory</a> action.</p>",
             "members": [
                 {
                     "name": "configurationItems",
@@ -603,46 +627,57 @@
         },
         "InsufficientDeliveryPolicyException": {
             "type": "structure",
+            "documentation": "<p>Your Amazon S3 bucket policy does not permit AWS Config to write to it.</p>",
             "members": []
         },
         "InvalidConfigurationRecorderNameException": {
             "type": "structure",
+            "documentation": "<p>You have provided a configuration recorder name that is not valid.</p>",
             "members": []
         },
         "InvalidDeliveryChannelNameException": {
             "type": "structure",
+            "documentation": "<p>The specified delivery channel name is not valid.</p>",
             "members": []
         },
         "InvalidLimitException": {
             "type": "structure",
+            "documentation": "<p>You have reached the limit on the pagination.</p>",
             "members": []
         },
         "InvalidNextTokenException": {
             "type": "structure",
+            "documentation": "<p>The specified nextToken for pagination is not valid.</p>",
             "members": []
         },
         "InvalidRecordingGroupException": {
             "type": "structure",
+            "documentation": "<p>AWS Config throws an exception if the recording group does not contain a valid list of resource types. Invalid values could also be incorrectly formatted.</p>",
             "members": []
         },
         "InvalidRoleException": {
             "type": "structure",
+            "documentation": "<p>You have provided a null or empty role ARN.</p>",
             "members": []
         },
         "InvalidS3KeyPrefixException": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon S3 key prefix is not valid.</p>",
             "members": []
         },
         "InvalidSNSTopicARNException": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon SNS topic does not exist.</p>",
             "members": []
         },
         "InvalidTimeRangeException": {
             "type": "structure",
+            "documentation": "<p>The specified time range is not valid. The earlier time is not chronologically before the later time.</p>",
             "members": []
         },
         "LastDeliveryChannelDeleteFailedException": {
             "type": "structure",
+            "documentation": "<p>You cannot delete the delivery channel you specified because the configuration recorder is running.</p>",
             "members": []
         },
         "LaterTime": {
@@ -653,10 +688,12 @@
         },
         "MaxNumberOfConfigurationRecordersExceededException": {
             "type": "structure",
+            "documentation": "<p>You have reached the limit on the number of recorders you can create.</p>",
             "members": []
         },
         "MaxNumberOfDeliveryChannelsExceededException": {
             "type": "structure",
+            "documentation": "<p>You have reached the limit on the number of delivery channels you can create.</p>",
             "members": []
         },
         "Name": {
@@ -667,30 +704,37 @@
         },
         "NoAvailableConfigurationRecorderException": {
             "type": "structure",
+            "documentation": "<p>There are no configuration recorders available to provide the role needed to describe your resources.</p>",
             "members": []
         },
         "NoAvailableDeliveryChannelException": {
             "type": "structure",
+            "documentation": "<p>There is no delivery channel available to record configurations.</p>",
             "members": []
         },
         "NoRunningConfigurationRecorderException": {
             "type": "structure",
+            "documentation": "<p>There is no configuration recorder running.</p>",
             "members": []
         },
         "NoSuchBucketException": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon S3 bucket does not exist.</p>",
             "members": []
         },
         "NoSuchConfigurationRecorderException": {
             "type": "structure",
+            "documentation": "<p>You have specified a configuration recorder that does not exist.</p>",
             "members": []
         },
         "NoSuchDeliveryChannelException": {
             "type": "structure",
+            "documentation": "<p>You have specified a delivery channel that does not exist.</p>",
             "members": []
         },
         "PutConfigurationRecorderRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>PutConfigurationRecorder</a> action.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecorder",
@@ -701,6 +745,7 @@
         },
         "PutDeliveryChannelRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>PutDeliveryChannel</a> action.</p>",
             "members": [
                 {
                     "name": "DeliveryChannel",
@@ -717,6 +762,7 @@
         },
         "RecordingGroup": {
             "type": "structure",
+            "documentation": "<p>The group of AWS resource types that AWS Config records when starting the configuration recorder.</p> <p><b>recordingGroup</b> can have one and only one parameter. Choose either <b>allSupported</b> or <b>resourceTypes</b>.</p>",
             "members": [
                 {
                     "name": "allSupported",
@@ -739,6 +785,7 @@
         },
         "Relationship": {
             "type": "structure",
+            "documentation": "<p>The relationship of the related resource to the main resource.</p>",
             "members": [
                 {
                     "name": "resourceType",
@@ -772,6 +819,7 @@
         },
         "ResourceNotDiscoveredException": {
             "type": "structure",
+            "documentation": "<p>You have specified a resource that is either unknown or has not been discovered.</p>",
             "members": []
         },
         "ResourceType": {
@@ -783,6 +831,7 @@
         },
         "StartConfigurationRecorderRequest": {
             "type": "structure",
+            "documentation": "<p>The input for the <a>StartConfigurationRecorder</a> action.</p>",
             "members": [
                 {
                     "name": "ConfigurationRecorderName",
@@ -793,6 +842,7 @@
         },
         "StopConfigurationRecorderRequest": {
             "type": "structure",
+            "documentation": "<p><p>The input for the <a>StopConfigurationRecorder</a> action.</p></p>",
             "members": [
                 {
                     "name": "ConfigurationRecorderName",
@@ -805,10 +855,13 @@
             "type": "string"
         },
         "Tags": {
-            "type": "map"
+            "type": "map",
+            "key": "Name",
+            "value": "Value"
         },
         "ValidationException": {
             "type": "structure",
+            "documentation": "<p>The requested action is not valid.</p>",
             "members": []
         },
         "Value": {

--- a/libcloudcore/data/aws/datapipeline/service.json
+++ b/libcloudcore/data/aws/datapipeline/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -196,6 +200,7 @@
     "shapes": {
         "ActivatePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for ActivatePipeline.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -216,10 +221,12 @@
         },
         "ActivatePipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of ActivatePipeline.</p>",
             "members": []
         },
         "AddTagsInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for AddTags.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -235,10 +242,12 @@
         },
         "AddTagsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of AddTags.</p>",
             "members": []
         },
         "CreatePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for CreatePipeline.</p>",
             "members": [
                 {
                     "name": "name",
@@ -264,6 +273,7 @@
         },
         "CreatePipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of CreatePipeline.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -274,6 +284,7 @@
         },
         "DeactivatePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DeactivatePipeline.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -289,10 +300,12 @@
         },
         "DeactivatePipelineOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DeactivatePipeline.</p>",
             "members": []
         },
         "DeletePipelineInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DeletePipeline.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -303,6 +316,7 @@
         },
         "DescribeObjectsInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeObjects.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -328,6 +342,7 @@
         },
         "DescribeObjectsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeObjects.</p>",
             "members": [
                 {
                     "name": "pipelineObjects",
@@ -348,6 +363,7 @@
         },
         "DescribePipelinesInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribePipelines.</p>",
             "members": [
                 {
                     "name": "pipelineIds",
@@ -358,6 +374,7 @@
         },
         "DescribePipelinesOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribePipelines.</p>",
             "members": [
                 {
                     "name": "pipelineDescriptionList",
@@ -368,6 +385,7 @@
         },
         "EvaluateExpressionInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for EvaluateExpression.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -388,6 +406,7 @@
         },
         "EvaluateExpressionOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of EvaluateExpression.</p>",
             "members": [
                 {
                     "name": "evaluatedExpression",
@@ -398,6 +417,7 @@
         },
         "Field": {
             "type": "structure",
+            "documentation": "<p>A key-value pair that describes a property of a pipeline object. The value is specified as either a string value (<code>StringValue</code>) or a reference to another object (<code>RefValue</code>) but not as both.</p>",
             "members": [
                 {
                     "name": "key",
@@ -418,6 +438,7 @@
         },
         "GetPipelineDefinitionInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for GetPipelineDefinition.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -433,6 +454,7 @@
         },
         "GetPipelineDefinitionOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of GetPipelineDefinition.</p>",
             "members": [
                 {
                     "name": "pipelineObjects",
@@ -453,6 +475,7 @@
         },
         "InstanceIdentity": {
             "type": "structure",
+            "documentation": "<p><p>Identity information for the EC2 instance that is hosting the task runner. You can get this value by calling a metadata URI from the EC2 instance. For more information, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html\">Instance Metadata</a> in the <i>Amazon Elastic Compute Cloud User Guide.</i> Passing in this value proves that your task runner is running on an EC2 instance, and ensures the proper AWS Data Pipeline service charges are applied to your pipeline.</p></p>",
             "members": [
                 {
                     "name": "document",
@@ -468,6 +491,7 @@
         },
         "InternalServiceError": {
             "type": "structure",
+            "documentation": "<p>An internal service error occurred.</p>",
             "members": [
                 {
                     "name": "message",
@@ -478,6 +502,7 @@
         },
         "InvalidRequestException": {
             "type": "structure",
+            "documentation": "<p>The request was not valid. Verify that your request was properly formatted, that the signature was generated with the correct credentials, and that you haven't exceeded any of the service limits for your account.</p>",
             "members": [
                 {
                     "name": "message",
@@ -488,6 +513,7 @@
         },
         "ListPipelinesInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for ListPipelines.</p>",
             "members": [
                 {
                     "name": "marker",
@@ -498,6 +524,7 @@
         },
         "ListPipelinesOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of ListPipelines.</p>",
             "members": [
                 {
                     "name": "pipelineIdList",
@@ -518,6 +545,7 @@
         },
         "Operator": {
             "type": "structure",
+            "documentation": "<p>Contains a logical operation for comparing the value of a field with a specified value.</p>",
             "members": [
                 {
                     "name": "type",
@@ -536,6 +564,7 @@
         },
         "ParameterAttribute": {
             "type": "structure",
+            "documentation": "<p>The attributes allowed or specified with a parameter object.</p>",
             "members": [
                 {
                     "name": "key",
@@ -555,6 +584,7 @@
         },
         "ParameterObject": {
             "type": "structure",
+            "documentation": "<p>Contains information about a parameter object.</p>",
             "members": [
                 {
                     "name": "id",
@@ -574,6 +604,7 @@
         },
         "ParameterValue": {
             "type": "structure",
+            "documentation": "<p>A value or list of parameter values. </p>",
             "members": [
                 {
                     "name": "id",
@@ -593,6 +624,7 @@
         },
         "PipelineDeletedException": {
             "type": "structure",
+            "documentation": "<p>The specified pipeline has been deleted.</p>",
             "members": [
                 {
                     "name": "message",
@@ -603,6 +635,7 @@
         },
         "PipelineDescription": {
             "type": "structure",
+            "documentation": "<p>Contains pipeline metadata.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -637,6 +670,7 @@
         },
         "PipelineIdName": {
             "type": "structure",
+            "documentation": "<p>Contains the name and identifier of a pipeline.</p>",
             "members": [
                 {
                     "name": "id",
@@ -652,6 +686,7 @@
         },
         "PipelineNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified pipeline was not found. Verify that you used the correct user and account identifiers.</p>",
             "members": [
                 {
                     "name": "message",
@@ -662,6 +697,7 @@
         },
         "PipelineObject": {
             "type": "structure",
+            "documentation": "<p>Contains information about a pipeline object. This can be a logical, physical, or physical attempt pipeline object. The complete set of components of a pipeline defines the pipeline.</p>",
             "members": [
                 {
                     "name": "id",
@@ -685,10 +721,13 @@
             "of": "PipelineObject"
         },
         "PipelineObjectMap": {
-            "type": "map"
+            "type": "map",
+            "key": "id",
+            "value": "PipelineObject"
         },
         "PollForTaskInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for PollForTask.</p>",
             "members": [
                 {
                     "name": "workerGroup",
@@ -709,6 +748,7 @@
         },
         "PollForTaskOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of PollForTask.</p>",
             "members": [
                 {
                     "name": "taskObject",
@@ -719,6 +759,7 @@
         },
         "PutPipelineDefinitionInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for PutPipelineDefinition.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -744,6 +785,7 @@
         },
         "PutPipelineDefinitionOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of PutPipelineDefinition.</p>",
             "members": [
                 {
                     "name": "validationErrors",
@@ -764,6 +806,7 @@
         },
         "Query": {
             "type": "structure",
+            "documentation": "<p>Defines the query to run against an object.</p>",
             "members": [
                 {
                     "name": "selectors",
@@ -774,6 +817,7 @@
         },
         "QueryObjectsInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for QueryObjects.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -804,6 +848,7 @@
         },
         "QueryObjectsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of QueryObjects.</p>",
             "members": [
                 {
                     "name": "ids",
@@ -824,6 +869,7 @@
         },
         "RemoveTagsInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for RemoveTags.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -839,10 +885,12 @@
         },
         "RemoveTagsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of RemoveTags.</p>",
             "members": []
         },
         "ReportTaskProgressInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for ReportTaskProgress.</p>",
             "members": [
                 {
                     "name": "taskId",
@@ -858,6 +906,7 @@
         },
         "ReportTaskProgressOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of ReportTaskProgress.</p>",
             "members": [
                 {
                     "name": "canceled",
@@ -868,6 +917,7 @@
         },
         "ReportTaskRunnerHeartbeatInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for ReportTaskRunnerHeartbeat.</p>",
             "members": [
                 {
                     "name": "taskrunnerId",
@@ -888,6 +938,7 @@
         },
         "ReportTaskRunnerHeartbeatOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of ReportTaskRunnerHeartbeat.</p>",
             "members": [
                 {
                     "name": "terminate",
@@ -898,6 +949,7 @@
         },
         "Selector": {
             "type": "structure",
+            "documentation": "<p>A comparision that is used to determine whether a query should return this object.</p>",
             "members": [
                 {
                     "name": "fieldName",
@@ -912,10 +964,12 @@
         },
         "SelectorList": {
             "type": "list",
+            "documentation": "<p>The list of Selectors that define queries on individual fields.</p>",
             "of": "Selector"
         },
         "SetStatusInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for SetStatus.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -936,6 +990,7 @@
         },
         "SetTaskStatusInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for SetTaskStatus.</p>",
             "members": [
                 {
                     "name": "taskId",
@@ -966,10 +1021,12 @@
         },
         "SetTaskStatusOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of SetTaskStatus.</p>",
             "members": []
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Tags are key/value pairs defined by a user and associated with a pipeline to control access. AWS Data Pipeline allows you to associate ten tags per pipeline. For more information, see <a href=\"http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html\">Controlling User Access to Pipelines</a> in the <i>AWS Data Pipeline Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "key",
@@ -985,6 +1042,7 @@
         },
         "TaskNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified task was not found. </p>",
             "members": [
                 {
                     "name": "message",
@@ -995,6 +1053,7 @@
         },
         "TaskObject": {
             "type": "structure",
+            "documentation": "<p>Contains information about a pipeline task that is assigned to a task runner.</p>",
             "members": [
                 {
                     "name": "taskId",
@@ -1023,6 +1082,7 @@
         },
         "ValidatePipelineDefinitionInput": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for ValidatePipelineDefinition.</p>",
             "members": [
                 {
                     "name": "pipelineId",
@@ -1048,6 +1108,7 @@
         },
         "ValidatePipelineDefinitionOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the output of ValidatePipelineDefinition.</p>",
             "members": [
                 {
                     "name": "validationErrors",
@@ -1068,6 +1129,7 @@
         },
         "ValidationError": {
             "type": "structure",
+            "documentation": "<p>Defines a validation error. Validation errors prevent pipeline activation. The set of validation errors that can be returned are defined by AWS Data Pipeline.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1087,6 +1149,7 @@
         },
         "ValidationWarning": {
             "type": "structure",
+            "documentation": "<p>Defines a validation warning. Validation warnings do not prevent pipeline activation. The set of validation warnings that can be returned are defined by AWS Data Pipeline.</p>",
             "members": [
                 {
                     "name": "id",

--- a/libcloudcore/data/aws/devicefarm/service.json
+++ b/libcloudcore/data/aws/devicefarm/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -254,6 +258,7 @@
         },
         "ArgumentException": {
             "type": "structure",
+            "documentation": "<p>An invalid argument was specified.</p>",
             "members": [
                 {
                     "name": "message",
@@ -264,6 +269,7 @@
         },
         "Artifact": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a test. Examples of artifacts include logs and screenshots.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -307,6 +313,7 @@
         },
         "CPU": {
             "type": "structure",
+            "documentation": "<p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>",
             "members": [
                 {
                     "name": "frequency",
@@ -330,6 +337,7 @@
         },
         "Counters": {
             "type": "structure",
+            "documentation": "<p>Represents entity counters.</p>",
             "members": [
                 {
                     "name": "total",
@@ -370,6 +378,7 @@
         },
         "CreateDevicePoolRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the create device pool operation.</p>",
             "members": [
                 {
                     "name": "projectArn",
@@ -395,6 +404,7 @@
         },
         "CreateDevicePoolResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a create device pool request.</p>",
             "members": [
                 {
                     "name": "devicePool",
@@ -405,6 +415,7 @@
         },
         "CreateProjectRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the create project operation.</p>",
             "members": [
                 {
                     "name": "name",
@@ -415,6 +426,7 @@
         },
         "CreateProjectResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a create project request.</p>",
             "members": [
                 {
                     "name": "project",
@@ -425,6 +437,7 @@
         },
         "CreateUploadRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the create upload operation.</p>",
             "members": [
                 {
                     "name": "projectArn",
@@ -450,6 +463,7 @@
         },
         "CreateUploadResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a create upload request.</p>",
             "members": [
                 {
                     "name": "upload",
@@ -463,6 +477,7 @@
         },
         "Device": {
             "type": "structure",
+            "documentation": "<p>Represents a device type that an app is tested against.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -546,6 +561,7 @@
         },
         "DevicePool": {
             "type": "structure",
+            "documentation": "<p>Represents a collection of device types.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -576,6 +592,7 @@
         },
         "DevicePoolCompatibilityResult": {
             "type": "structure",
+            "documentation": "<p>Represents a device pool compatibility result.</p>",
             "members": [
                 {
                     "name": "device",
@@ -622,6 +639,7 @@
         },
         "GetDevicePoolCompatibilityRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get device pool compatibility operation.</p>",
             "members": [
                 {
                     "name": "devicePoolArn",
@@ -642,6 +660,7 @@
         },
         "GetDevicePoolCompatibilityResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of describe device pool compatibility request.</p>",
             "members": [
                 {
                     "name": "compatibleDevices",
@@ -657,6 +676,7 @@
         },
         "GetDevicePoolRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get device pool operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -667,6 +687,7 @@
         },
         "GetDevicePoolResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get device pool request.</p>",
             "members": [
                 {
                     "name": "devicePool",
@@ -676,6 +697,7 @@
         },
         "GetDeviceRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get device request.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -686,6 +708,7 @@
         },
         "GetDeviceResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get device request.</p>",
             "members": [
                 {
                     "name": "device",
@@ -695,6 +718,7 @@
         },
         "GetJobRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get job operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -705,6 +729,7 @@
         },
         "GetJobResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get job request.</p>",
             "members": [
                 {
                     "name": "job",
@@ -714,6 +739,7 @@
         },
         "GetProjectRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get project operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -724,6 +750,7 @@
         },
         "GetProjectResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get project request.</p>",
             "members": [
                 {
                     "name": "project",
@@ -733,6 +760,7 @@
         },
         "GetRunRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get run operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -743,6 +771,7 @@
         },
         "GetRunResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get run request.</p>",
             "members": [
                 {
                     "name": "run",
@@ -752,6 +781,7 @@
         },
         "GetSuiteRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get suite operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -762,6 +792,7 @@
         },
         "GetSuiteResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get suite request.</p>",
             "members": [
                 {
                     "name": "suite",
@@ -771,6 +802,7 @@
         },
         "GetTestRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get test operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -781,6 +813,7 @@
         },
         "GetTestResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get test request.</p>",
             "members": [
                 {
                     "name": "test",
@@ -790,6 +823,7 @@
         },
         "GetUploadRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the get upload operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -800,6 +834,7 @@
         },
         "GetUploadResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a get upload request.</p>",
             "members": [
                 {
                     "name": "upload",
@@ -809,6 +844,7 @@
         },
         "IdempotencyException": {
             "type": "structure",
+            "documentation": "<p>An entity with the same name already exists.</p>",
             "members": [
                 {
                     "name": "message",
@@ -819,6 +855,7 @@
         },
         "IncompatibilityMessage": {
             "type": "structure",
+            "documentation": "<p>Represents information about incompatibility.</p>",
             "members": [
                 {
                     "name": "message",
@@ -841,6 +878,7 @@
         },
         "Job": {
             "type": "structure",
+            "documentation": "<p>Represents a device.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -904,6 +942,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>A limit was exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -914,6 +953,7 @@
         },
         "ListArtifactsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list artifacts operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -934,6 +974,7 @@
         },
         "ListArtifactsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list artifacts operation.</p>",
             "members": [
                 {
                     "name": "artifacts",
@@ -949,6 +990,7 @@
         },
         "ListDevicePoolsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list device pools request.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -969,6 +1011,7 @@
         },
         "ListDevicePoolsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list device pools request.</p>",
             "members": [
                 {
                     "name": "devicePools",
@@ -984,6 +1027,7 @@
         },
         "ListDevicesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list devices request.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -999,6 +1043,7 @@
         },
         "ListDevicesResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list devices operation.</p>",
             "members": [
                 {
                     "name": "devices",
@@ -1014,6 +1059,7 @@
         },
         "ListJobsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list jobs operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1029,6 +1075,7 @@
         },
         "ListJobsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list jobs request.</p>",
             "members": [
                 {
                     "name": "jobs",
@@ -1044,6 +1091,7 @@
         },
         "ListProjectsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list projects operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1059,6 +1107,7 @@
         },
         "ListProjectsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list projects request.</p>",
             "members": [
                 {
                     "name": "projects",
@@ -1074,6 +1123,7 @@
         },
         "ListRunsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list runs operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1089,6 +1139,7 @@
         },
         "ListRunsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list runs request.</p>",
             "members": [
                 {
                     "name": "runs",
@@ -1104,6 +1155,7 @@
         },
         "ListSamplesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list samples operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1119,6 +1171,7 @@
         },
         "ListSamplesResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list samples request.</p>",
             "members": [
                 {
                     "name": "samples",
@@ -1134,6 +1187,7 @@
         },
         "ListSuitesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list suites operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1149,6 +1203,7 @@
         },
         "ListSuitesResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list suites request.</p>",
             "members": [
                 {
                     "name": "suites",
@@ -1164,6 +1219,7 @@
         },
         "ListTestsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list tests operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1179,6 +1235,7 @@
         },
         "ListTestsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list tests request.</p>",
             "members": [
                 {
                     "name": "tests",
@@ -1194,6 +1251,7 @@
         },
         "ListUniqueProblemsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list unique problems operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1209,6 +1267,7 @@
         },
         "ListUniqueProblemsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list unique problems request.</p>",
             "members": [
                 {
                     "name": "uniqueProblems",
@@ -1224,6 +1283,7 @@
         },
         "ListUploadsRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the list uploads operation.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1239,6 +1299,7 @@
         },
         "ListUploadsResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a list uploads request.</p>",
             "members": [
                 {
                     "name": "uploads",
@@ -1254,6 +1315,7 @@
         },
         "Location": {
             "type": "structure",
+            "documentation": "<p>Represents a latitude and longitude pair, expressed in geographic coordinate system degrees (for example 47.6204, -122.3491).</p> <p>Elevation is currently not supported.</p>",
             "members": [
                 {
                     "name": "latitude",
@@ -1281,6 +1343,7 @@
         },
         "NotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified entity was not found.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1294,6 +1357,7 @@
         },
         "Problem": {
             "type": "structure",
+            "documentation": "<p>Represents a specific warning or failure.</p>",
             "members": [
                 {
                     "name": "run",
@@ -1334,6 +1398,7 @@
         },
         "ProblemDetail": {
             "type": "structure",
+            "documentation": "<p>Information about a problem detail.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1353,6 +1418,7 @@
         },
         "Project": {
             "type": "structure",
+            "documentation": "<p>Represents an operating-system neutral workspace for running and managing tests.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1377,6 +1443,7 @@
         },
         "Radios": {
             "type": "structure",
+            "documentation": "<p>Represents the set of radios and their states on a device. Examples of radios include Wi-Fi, GPS, Bluetooth, and NFC.</p>",
             "members": [
                 {
                     "name": "wifi",
@@ -1402,6 +1469,7 @@
         },
         "Resolution": {
             "type": "structure",
+            "documentation": "<p>Represents the screen resolution of a device in height and width, expressed in pixels.</p>",
             "members": [
                 {
                     "name": "width",
@@ -1417,6 +1485,7 @@
         },
         "Rule": {
             "type": "structure",
+            "documentation": "<p>Represents a condition for a device pool.</p>",
             "members": [
                 {
                     "name": "attribute",
@@ -1444,6 +1513,7 @@
         },
         "Run": {
             "type": "structure",
+            "documentation": "<p>Represents an app on a set of devices with a specific test and configuration.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1518,6 +1588,7 @@
         },
         "Sample": {
             "type": "structure",
+            "documentation": "<p>Represents a sample of performance data.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1545,6 +1616,7 @@
         },
         "ScheduleRunConfiguration": {
             "type": "structure",
+            "documentation": "<p>Represents the settings for a run. Includes things like location, radio states, auxiliary apps, and network profiles.</p>",
             "members": [
                 {
                     "name": "extraDataPackageArn",
@@ -1580,6 +1652,7 @@
         },
         "ScheduleRunRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to the schedule run operation.</p>",
             "members": [
                 {
                     "name": "projectArn",
@@ -1615,6 +1688,7 @@
         },
         "ScheduleRunResult": {
             "type": "structure",
+            "documentation": "<p>Represents the result of a schedule run request.</p>",
             "members": [
                 {
                     "name": "run",
@@ -1625,6 +1699,7 @@
         },
         "ScheduleRunTest": {
             "type": "structure",
+            "documentation": "<p>Represents additional test settings.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1650,6 +1725,7 @@
         },
         "ServiceAccountException": {
             "type": "structure",
+            "documentation": "<p>There was a problem with the service account.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1663,6 +1739,7 @@
         },
         "Suite": {
             "type": "structure",
+            "documentation": "<p>Represents a collection of one or more tests.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1722,6 +1799,7 @@
         },
         "Test": {
             "type": "structure",
+            "documentation": "<p>Represents a condition that is evaluated.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -1776,7 +1854,9 @@
             ]
         },
         "TestParameters": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "TestType": {
             "type": "string"
@@ -1790,6 +1870,7 @@
         },
         "UniqueProblem": {
             "type": "structure",
+            "documentation": "<p>A collection of one or more problems, grouped by their result.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1808,10 +1889,13 @@
             "of": "UniqueProblem"
         },
         "UniqueProblemsByExecutionResultMap": {
-            "type": "map"
+            "type": "map",
+            "key": "ExecutionResult",
+            "value": "UniqueProblems"
         },
         "Upload": {
             "type": "structure",
+            "documentation": "<p>An app or a set of one or more tests to upload or that have been uploaded.</p>",
             "members": [
                 {
                     "name": "arn",

--- a/libcloudcore/data/aws/directconnect/service.json
+++ b/libcloudcore/data/aws/directconnect/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -195,10 +199,12 @@
     },
     "shapes": {
         "ASN": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>Autonomous system (AS) number for Border Gateway Protocol (BGP) configuration.</p> <p>Example: 65000</p>"
         },
         "AllocateConnectionOnInterconnectRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the AllocateConnectionOnInterconnect operation.</p>",
             "members": [
                 {
                     "name": "bandwidth",
@@ -229,6 +235,7 @@
         },
         "AllocatePrivateVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the AllocatePrivateVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -249,6 +256,7 @@
         },
         "AllocatePublicVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the AllocatePublicVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -268,19 +276,23 @@
             ]
         },
         "AmazonAddress": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>IP address assigned to the Amazon interface.</p> <p>Example: 192.168.1.1/30</p>"
         },
         "BGPAuthKey": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Authentication key for BGP configuration.</p> <p>Example: asdf34example</p>"
         },
         "Bandwidth": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Bandwidth of the connection.</p> <p>Example: 1Gbps</p> <p>Default: None</p>"
         },
         "CIDR": {
             "type": "string"
         },
         "ConfirmConnectionRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the ConfirmConnection operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -290,6 +302,7 @@
         },
         "ConfirmConnectionResponse": {
             "type": "structure",
+            "documentation": "<p>The response received when ConfirmConnection is called.</p>",
             "members": [
                 {
                     "name": "connectionState",
@@ -299,6 +312,7 @@
         },
         "ConfirmPrivateVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the ConfirmPrivateVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceId",
@@ -313,6 +327,7 @@
         },
         "ConfirmPrivateVirtualInterfaceResponse": {
             "type": "structure",
+            "documentation": "<p>The response received when ConfirmPrivateVirtualInterface is called.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceState",
@@ -322,6 +337,7 @@
         },
         "ConfirmPublicVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the ConfirmPublicVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceId",
@@ -331,6 +347,7 @@
         },
         "ConfirmPublicVirtualInterfaceResponse": {
             "type": "structure",
+            "documentation": "<p>The response received when ConfirmPublicVirtualInterface is called.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceState",
@@ -340,6 +357,7 @@
         },
         "Connection": {
             "type": "structure",
+            "documentation": "<p>A connection represents the physical network connection between the AWS Direct Connect location and the customer.</p>",
             "members": [
                 {
                     "name": "ownerAccount",
@@ -381,20 +399,25 @@
             ]
         },
         "ConnectionId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>ID of the connection.</p> <p>Example: dxcon-fg5678gh</p> <p>Default: None</p>"
         },
         "ConnectionList": {
             "type": "list",
+            "documentation": "<p>A list of connections.</p>",
             "of": "Connection"
         },
         "ConnectionName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of the connection.</p> <p>Example: \"<i>My Connection to AWS</i>\"</p> <p>Default: None</p>"
         },
         "ConnectionState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "State of the connection. <ul> <li> <b>Ordering</b>: The initial state of a hosted connection provisioned on an interconnect. The connection stays in the ordering state until the owner of the hosted connection confirms or declines the connection order.</li> <li> <b>Requested</b>: The initial state of a standard connection. The connection stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</li> <li> <b>Pending</b>: The connection has been approved, and is being initialized.</li> <li> <b>Available</b>: The network link is up, and the connection is ready for use.</li> <li> <b>Down</b>: The network link is down.</li> <li> <b>Deleted</b>: The connection has been deleted.</li> <li> <b>Rejected</b>: A hosted connection in the 'Ordering' state will enter the 'Rejected' state if it is deleted by the end customer.</li> </ul>"
         },
         "Connections": {
             "type": "structure",
+            "documentation": "<p>A structure containing a list of connections.</p>",
             "members": [
                 {
                     "name": "connections",
@@ -405,6 +428,7 @@
         },
         "CreateConnectionRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the CreateConnection operation.</p>",
             "members": [
                 {
                     "name": "location",
@@ -422,6 +446,7 @@
         },
         "CreateInterconnectRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the CreateInterconnect operation.</p>",
             "members": [
                 {
                     "name": "interconnectName",
@@ -442,6 +467,7 @@
         },
         "CreatePrivateVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the CreatePrivateVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -456,6 +482,7 @@
         },
         "CreatePublicVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the CreatePublicVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -469,10 +496,12 @@
             ]
         },
         "CustomerAddress": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>IP address assigned to the customer interface.</p> <p>Example: 192.168.1.2/30</p>"
         },
         "DeleteConnectionRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DeleteConnection operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -482,6 +511,7 @@
         },
         "DeleteInterconnectRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DeleteInterconnect operation.</p>",
             "members": [
                 {
                     "name": "interconnectId",
@@ -491,6 +521,7 @@
         },
         "DeleteInterconnectResponse": {
             "type": "structure",
+            "documentation": "<p>The response received when DeleteInterconnect is called.</p>",
             "members": [
                 {
                     "name": "interconnectState",
@@ -500,6 +531,7 @@
         },
         "DeleteVirtualInterfaceRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DeleteVirtualInterface operation.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceId",
@@ -509,6 +541,7 @@
         },
         "DeleteVirtualInterfaceResponse": {
             "type": "structure",
+            "documentation": "<p>The response received when DeleteVirtualInterface is called.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceState",
@@ -518,6 +551,7 @@
         },
         "DescribeConnectionsOnInterconnectRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DescribeConnectionsOnInterconnect operation.</p>",
             "members": [
                 {
                     "name": "interconnectId",
@@ -528,6 +562,7 @@
         },
         "DescribeConnectionsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DescribeConnections operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -537,6 +572,7 @@
         },
         "DescribeInterconnectsRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DescribeInterconnects operation.</p>",
             "members": [
                 {
                     "name": "interconnectId",
@@ -546,6 +582,7 @@
         },
         "DescribeVirtualInterfacesRequest": {
             "type": "structure",
+            "documentation": "<p>Container for the parameters to the DescribeVirtualInterfaces operation.</p>",
             "members": [
                 {
                     "name": "connectionId",
@@ -559,6 +596,7 @@
         },
         "DirectConnectClientException": {
             "type": "structure",
+            "documentation": "<p>The API was called with invalid parameters. The error message will contain additional details about the cause.</p>",
             "members": [
                 {
                     "name": "message",
@@ -568,6 +606,7 @@
         },
         "DirectConnectServerException": {
             "type": "structure",
+            "documentation": "<p>A server-side error occurred during the API call. The error message will contain additional details about the cause.</p>",
             "members": [
                 {
                     "name": "message",
@@ -580,6 +619,7 @@
         },
         "Interconnect": {
             "type": "structure",
+            "documentation": "<p>An interconnect is a connection that can host other connections.</p> <p>Like a standard AWS Direct Connect connection, an interconnect represents the physical connection between an AWS Direct Connect partner's network and a specific Direct Connect location. An AWS Direct Connect partner who owns an interconnect can provision hosted connections on the interconnect for their end customers, thereby providing the end customers with connectivity to AWS services.</p> <p>The resources of the interconnect, including bandwidth and VLAN numbers, are shared by all of the hosted connections on the interconnect, and the owner of the interconnect determines how these resources are assigned.</p>",
             "members": [
                 {
                     "name": "interconnectId",
@@ -608,20 +648,25 @@
             ]
         },
         "InterconnectId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The ID of the interconnect.</p> <p>Example: dxcon-abc123</p>"
         },
         "InterconnectList": {
             "type": "list",
+            "documentation": "<p>A list of interconnects.</p>",
             "of": "Interconnect"
         },
         "InterconnectName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of the interconnect.</p> <p>Example: \"<i>1G Interconnect to AWS</i>\"</p>"
         },
         "InterconnectState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "State of the interconnect. <ul> <li> <b>Requested</b>: The initial state of an interconnect. The interconnect stays in the requested state until the Letter of Authorization (LOA) is sent to the customer.</li> <li> <b>Pending</b>: The interconnect has been approved, and is being initialized.</li> <li> <b>Available</b>: The network link is up, and the interconnect is ready for use.</li> <li> <b>Down</b>: The network link is down.</li> <li> <b>Deleted</b>: The interconnect has been deleted.</li> </ul>"
         },
         "Interconnects": {
             "type": "structure",
+            "documentation": "<p>A structure containing a list of interconnects.</p>",
             "members": [
                 {
                     "name": "interconnects",
@@ -632,6 +677,7 @@
         },
         "Location": {
             "type": "structure",
+            "documentation": "<p>An AWS Direct Connect location where connections and interconnects can be requested.</p>",
             "members": [
                 {
                     "name": "locationCode",
@@ -646,7 +692,8 @@
             ]
         },
         "LocationCode": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Where the connection is located.</p> <p>Example: EqSV5</p> <p>Default: None</p>"
         },
         "LocationList": {
             "type": "list",
@@ -666,6 +713,7 @@
         },
         "NewPrivateVirtualInterface": {
             "type": "structure",
+            "documentation": "<p>A structure containing information about a new private virtual interface.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceName",
@@ -699,6 +747,7 @@
         },
         "NewPrivateVirtualInterfaceAllocation": {
             "type": "structure",
+            "documentation": "<p>A structure containing information about a private virtual interface that will be provisioned on a connection.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceName",
@@ -728,6 +777,7 @@
         },
         "NewPublicVirtualInterface": {
             "type": "structure",
+            "documentation": "<p>A structure containing information about a new public virtual interface.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceName",
@@ -761,6 +811,7 @@
         },
         "NewPublicVirtualInterfaceAllocation": {
             "type": "structure",
+            "documentation": "<p>A structure containing information about a public virtual interface that will be provisioned on a connection.</p>",
             "members": [
                 {
                     "name": "virtualInterfaceName",
@@ -799,10 +850,12 @@
             "type": "string"
         },
         "Region": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The AWS region where the connection is located.</p> <p>Example: us-east-1</p> <p>Default: None</p>"
         },
         "RouteFilterPrefix": {
             "type": "structure",
+            "documentation": "<p>A route filter prefix that the customer can advertise through Border Gateway Protocol (BGP) over a public virtual interface.</p>",
             "members": [
                 {
                     "name": "cidr",
@@ -813,16 +866,19 @@
         },
         "RouteFilterPrefixList": {
             "type": "list",
+            "documentation": "<p>A list of routes to be advertised to the AWS network in this region (public virtual interface) or your VPC (private virtual interface).</p>",
             "of": "RouteFilterPrefix"
         },
         "RouterConfig": {
             "type": "string"
         },
         "VLAN": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>The VLAN ID.</p> <p>Example: 101</p>"
         },
         "VirtualGateway": {
             "type": "structure",
+            "documentation": "<p>You can create one or more AWS Direct Connect private virtual interfaces linking to your virtual private gateway.</p> <p>Virtual private gateways can be managed using the Amazon Virtual Private Cloud (Amazon VPC) console or the <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html\">Amazon EC2 CreateVpnGateway action</a>.</p>",
             "members": [
                 {
                     "name": "virtualGatewayId",
@@ -835,17 +891,21 @@
             ]
         },
         "VirtualGatewayId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The ID of the virtual private gateway to a VPC. This only applies to private virtual interfaces.</p> <p>Example: vgw-123er56</p>"
         },
         "VirtualGatewayList": {
             "type": "list",
+            "documentation": "<p>A list of virtual private gateways.</p>",
             "of": "VirtualGateway"
         },
         "VirtualGatewayState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "State of the virtual private gateway. <ul> <li> <b>Pending</b>: This is the initial state after calling <i>CreateVpnGateway</i>.</li> <li> <b>Available</b>: Ready for use by a private virtual interface.</li> <li> <b>Deleting</b>: This is the initial state after calling <i>DeleteVpnGateway</i>.</li> <li> <b>Deleted</b>: In this state, a private virtual interface is unable to send traffic over this gateway.</li> </ul>"
         },
         "VirtualGateways": {
             "type": "structure",
+            "documentation": "<p>A structure containing a list of virtual private gateways.</p>",
             "members": [
                 {
                     "name": "virtualGateways",
@@ -856,6 +916,7 @@
         },
         "VirtualInterface": {
             "type": "structure",
+            "documentation": "<p>A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect location and the customer.</p>",
             "members": [
                 {
                     "name": "ownerAccount",
@@ -921,23 +982,29 @@
             ]
         },
         "VirtualInterfaceId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>ID of the virtual interface.</p> <p>Example: dxvif-123dfg56</p> <p>Default: None</p>"
         },
         "VirtualInterfaceList": {
             "type": "list",
+            "documentation": "<p>A list of virtual interfaces.</p>",
             "of": "VirtualInterface"
         },
         "VirtualInterfaceName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of the virtual interface assigned by the customer.</p> <p>Example: \"My VPC\"</p>"
         },
         "VirtualInterfaceState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "State of the virtual interface. <ul> <li> <b>Confirming</b>: The creation of the virtual interface is pending confirmation from the virtual interface owner. If the owner of the virtual interface is different from the owner of the connection on which it is provisioned, then the virtual interface will remain in this state until it is confirmed by the virtual interface owner.</li> <li> <b>Verifying</b>: This state only applies to public virtual interfaces. Each public virtual interface needs validation before the virtual interface can be created.</li> <li> <b>Pending</b>: A virtual interface is in this state from the time that it is created until the virtual interface is ready to forward traffic.</li> <li> <b>Available</b>: A virtual interface that is able to forward traffic.</li> <li> <b>Deleting</b>: A virtual interface is in this state immediately after calling <i>DeleteVirtualInterface</i> until it can no longer forward traffic.</li> <li> <b>Deleted</b>: A virtual interface that cannot forward traffic.</li> <li> <b>Rejected</b>: The virtual interface owner has declined creation of the virtual interface. If a virtual interface in the 'Confirming' state is deleted by the virtual interface owner, the virtual interface will enter the 'Rejected' state.</li> </ul>"
         },
         "VirtualInterfaceType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The type of virtual interface.</p> <p>Example: private (Amazon VPC) or public (Amazon S3, Amazon DynamoDB, and so on.)</p>"
         },
         "VirtualInterfaces": {
             "type": "structure",
+            "documentation": "<p>A structure containing a list of virtual interfaces.</p>",
             "members": [
                 {
                     "name": "virtualInterfaces",

--- a/libcloudcore/data/aws/ds/service.json
+++ b/libcloudcore/data/aws/ds/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -190,6 +194,7 @@
         },
         "Attribute": {
             "type": "structure",
+            "documentation": "<p>Represents a named directory attribute.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -215,6 +220,7 @@
         },
         "AuthenticationFailedException": {
             "type": "structure",
+            "documentation": "<p>An authentication error occurred.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -237,6 +243,7 @@
         },
         "ClientException": {
             "type": "structure",
+            "documentation": "<p>A client exception has occurred.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -253,6 +260,7 @@
         },
         "Computer": {
             "type": "structure",
+            "documentation": "<p>Contains information about a computer account in a directory.</p>",
             "members": [
                 {
                     "name": "ComputerId",
@@ -279,6 +287,7 @@
         },
         "ConnectDirectoryRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>ConnectDirectory</a> operation.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -314,6 +323,7 @@
         },
         "ConnectDirectoryResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>ConnectDirectory</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -330,6 +340,7 @@
         },
         "CreateAliasRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateAlias</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -345,6 +356,7 @@
         },
         "CreateAliasResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>CreateAlias</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -360,6 +372,7 @@
         },
         "CreateComputerRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateComputer</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -390,6 +403,7 @@
         },
         "CreateComputerResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results for the <a>CreateComputer</a> operation.</p>",
             "members": [
                 {
                     "name": "Computer",
@@ -400,6 +414,7 @@
         },
         "CreateDirectoryRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateDirectory</a> operation. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -435,6 +450,7 @@
         },
         "CreateDirectoryResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>CreateDirectory</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -445,6 +461,7 @@
         },
         "CreateSnapshotRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateSnapshot</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -460,6 +477,7 @@
         },
         "CreateSnapshotResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>CreateSnapshot</a> operation.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -470,6 +488,7 @@
         },
         "DeleteDirectoryRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DeleteDirectory</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -480,6 +499,7 @@
         },
         "DeleteDirectoryResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DeleteDirectory</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -490,6 +510,7 @@
         },
         "DeleteSnapshotRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DeleteSnapshot</a> operation.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -500,6 +521,7 @@
         },
         "DeleteSnapshotResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DeleteSnapshot</a> operation.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -510,6 +532,7 @@
         },
         "DescribeDirectoriesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeDirectories</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryIds",
@@ -530,6 +553,7 @@
         },
         "DescribeDirectoriesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DescribeDirectories</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryDescriptions",
@@ -545,6 +569,7 @@
         },
         "DescribeSnapshotsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeSnapshots</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -570,6 +595,7 @@
         },
         "DescribeSnapshotsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DescribeSnapshots</a> operation.</p>",
             "members": [
                 {
                     "name": "Snapshots",
@@ -588,6 +614,7 @@
         },
         "DirectoryConnectSettings": {
             "type": "structure",
+            "documentation": "<p>Contains information for the <a>ConnectDirectory</a> operation when an AD Connector directory is being created.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -613,6 +640,7 @@
         },
         "DirectoryConnectSettingsDescription": {
             "type": "structure",
+            "documentation": "<p>Contains information about an AD Connector directory.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -648,6 +676,7 @@
         },
         "DirectoryDescription": {
             "type": "structure",
+            "documentation": "<p>Contains information about an AWS Directory Service directory.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -743,6 +772,7 @@
         },
         "DirectoryDescriptions": {
             "type": "list",
+            "documentation": "<p>A list of directory descriptions.</p>",
             "of": "DirectoryDescription"
         },
         "DirectoryId": {
@@ -750,10 +780,12 @@
         },
         "DirectoryIds": {
             "type": "list",
+            "documentation": "<p>A list of directory identifiers.</p>",
             "of": "DirectoryId"
         },
         "DirectoryLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The maximum number of directories in the region has been reached. You can use the <a>GetDirectoryLimits</a> operation to determine your directory limits in the region.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -767,6 +799,7 @@
         },
         "DirectoryLimits": {
             "type": "structure",
+            "documentation": "<p>Contains directory limit information for a region.</p>",
             "members": [
                 {
                     "name": "CloudOnlyDirectoriesLimit",
@@ -817,6 +850,7 @@
         },
         "DirectoryUnavailableException": {
             "type": "structure",
+            "documentation": "<p>The specified directory is unavailable or could not be found.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -830,6 +864,7 @@
         },
         "DirectoryVpcSettings": {
             "type": "structure",
+            "documentation": "<p>Contains information for the <a>CreateDirectory</a> operation when a Simple AD directory is being created.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -845,6 +880,7 @@
         },
         "DirectoryVpcSettingsDescription": {
             "type": "structure",
+            "documentation": "<p>Contains information about a Simple AD directory.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -870,6 +906,7 @@
         },
         "DisableRadiusRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DisableRadius</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -880,10 +917,12 @@
         },
         "DisableRadiusResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DisableRadius</a> operation.</p>",
             "members": []
         },
         "DisableSsoRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DisableSso</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -904,6 +943,7 @@
         },
         "DisableSsoResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DisableSso</a> operation.</p>",
             "members": []
         },
         "DnsIpAddrs": {
@@ -912,6 +952,7 @@
         },
         "EnableRadiusRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>EnableRadius</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -927,10 +968,12 @@
         },
         "EnableRadiusResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>EnableRadius</a> operation.</p>",
             "members": []
         },
         "EnableSsoRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>EnableSso</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -951,10 +994,12 @@
         },
         "EnableSsoResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>EnableSso</a> operation.</p>",
             "members": []
         },
         "EntityAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>The specified entity already exists.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -968,6 +1013,7 @@
         },
         "EntityDoesNotExistException": {
             "type": "structure",
+            "documentation": "<p>The specified entity could not be found.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -980,14 +1026,17 @@
             ]
         },
         "ExceptionMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The descriptive message for the exception.</p>"
         },
         "GetDirectoryLimitsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>GetDirectoryLimits</a> operation.</p>",
             "members": []
         },
         "GetDirectoryLimitsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>GetDirectoryLimits</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryLimits",
@@ -998,6 +1047,7 @@
         },
         "GetSnapshotLimitsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>GetSnapshotLimits</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -1008,6 +1058,7 @@
         },
         "GetSnapshotLimitsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>GetSnapshotLimits</a> operation.</p>",
             "members": [
                 {
                     "name": "SnapshotLimits",
@@ -1018,6 +1069,7 @@
         },
         "InsufficientPermissionsException": {
             "type": "structure",
+            "documentation": "<p>The account does not have sufficient permission to perform the operation.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1031,6 +1083,7 @@
         },
         "InvalidNextTokenException": {
             "type": "structure",
+            "documentation": "<p>The <i>NextToken</i> value is not valid.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1044,6 +1097,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "<p>One or more parameters are not valid.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1097,6 +1151,7 @@
         },
         "RadiusSettings": {
             "type": "structure",
+            "documentation": "<p>Contains information about a Remote Authentication Dial In User Service (RADIUS) server.</p>",
             "members": [
                 {
                     "name": "RadiusServers",
@@ -1150,10 +1205,12 @@
             "type": "integer"
         },
         "RequestId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The AWS request identifier.</p>"
         },
         "RestoreFromSnapshotRequest": {
             "type": "structure",
+            "documentation": "<p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -1164,6 +1221,7 @@
         },
         "RestoreFromSnapshotResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>RestoreFromSnapshot</a> operation.</p>",
             "members": []
         },
         "SID": {
@@ -1181,6 +1239,7 @@
         },
         "ServiceException": {
             "type": "structure",
+            "documentation": "<p>An exception has occurred in AWS Directory Service.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1194,6 +1253,7 @@
         },
         "Snapshot": {
             "type": "structure",
+            "documentation": "<p>Describes a directory snapshot.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -1232,10 +1292,12 @@
         },
         "SnapshotIds": {
             "type": "list",
+            "documentation": "<p>A list of directory snapshot identifiers.</p>",
             "of": "SnapshotId"
         },
         "SnapshotLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The maximum number of manual snapshots for the directory has been reached. You can use the <a>GetSnapshotLimits</a> operation to determine the snapshot limits for a directory.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1249,6 +1311,7 @@
         },
         "SnapshotLimits": {
             "type": "structure",
+            "documentation": "<p>Contains manual snapshot limit information for a directory.</p>",
             "members": [
                 {
                     "name": "ManualSnapshotsLimit",
@@ -1278,6 +1341,7 @@
         },
         "Snapshots": {
             "type": "list",
+            "documentation": "<p>A list of descriptions of directory snapshots.</p>",
             "of": "Snapshot"
         },
         "SsoEnabled": {
@@ -1298,6 +1362,7 @@
         },
         "UnsupportedOperationException": {
             "type": "structure",
+            "documentation": "<p>The operation is not supported.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1311,6 +1376,7 @@
         },
         "UpdateRadiusRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>UpdateRadius</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -1326,6 +1392,7 @@
         },
         "UpdateRadiusResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>UpdateRadius</a> operation.</p>",
             "members": []
         },
         "UseSameUsername": {

--- a/libcloudcore/data/aws/dynamodb/service.json
+++ b/libcloudcore/data/aws/dynamodb/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -163,6 +167,7 @@
         },
         "AttributeDefinition": {
             "type": "structure",
+            "documentation": "<p>Represents an attribute for describing the key schema for the table and indexes.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -181,7 +186,9 @@
             "of": "AttributeDefinition"
         },
         "AttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "AttributeName": {
             "type": "string"
@@ -191,10 +198,13 @@
             "of": "AttributeName"
         },
         "AttributeUpdates": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValueUpdate"
         },
         "AttributeValue": {
             "type": "structure",
+            "documentation": "<p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed. </p>",
             "members": [
                 {
                     "name": "S",
@@ -254,6 +264,7 @@
         },
         "AttributeValueUpdate": {
             "type": "structure",
+            "documentation": "<p>For the <i>UpdateItem</i> operation, represents the attributes to be modified, the action to perform on each, and the new value for each.</p> <note> <p>You cannot use <i>UpdateItem</i> to update any primary key attributes. Instead, you will need to delete the item, and then use <i>PutItem</i> to create a new item with new attributes.</p> </note> <p>Attribute values cannot be null; string and binary type attributes must have lengths greater than zero; and set type attributes must not be empty. Requests with empty values will be rejected with a <i>ValidationException</i> exception.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -271,6 +282,7 @@
         },
         "BatchGetItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>BatchGetItem</i> operation.</p>",
             "members": [
                 {
                     "name": "RequestItems",
@@ -285,6 +297,7 @@
         },
         "BatchGetItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>BatchGetItem</i> operation.</p>",
             "members": [
                 {
                     "name": "Responses",
@@ -304,13 +317,18 @@
             ]
         },
         "BatchGetRequestMap": {
-            "type": "map"
+            "type": "map",
+            "key": "TableName",
+            "value": "KeysAndAttributes"
         },
         "BatchGetResponseMap": {
-            "type": "map"
+            "type": "map",
+            "key": "TableName",
+            "value": "ItemList"
         },
         "BatchWriteItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>BatchWriteItem</i> operation.</p>",
             "members": [
                 {
                     "name": "RequestItems",
@@ -330,6 +348,7 @@
         },
         "BatchWriteItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>BatchWriteItem</i> operation.</p>",
             "members": [
                 {
                     "name": "UnprocessedItems",
@@ -349,7 +368,9 @@
             ]
         },
         "BatchWriteItemRequestMap": {
-            "type": "map"
+            "type": "map",
+            "key": "TableName",
+            "value": "WriteRequests"
         },
         "BinaryAttributeValue": {
             "type": "blob"
@@ -366,6 +387,7 @@
         },
         "Capacity": {
             "type": "structure",
+            "documentation": "<p>Represents the amount of provisioned throughput capacity consumed on a table or an index. </p>",
             "members": [
                 {
                     "name": "CapacityUnits",
@@ -379,6 +401,7 @@
         },
         "Condition": {
             "type": "structure",
+            "documentation": "<p>Represents the selection criteria for a <i>Query</i> or <i>Scan</i> operation:</p> <ul> <li> <p>For a <i>Query</i> operation, <i>Condition</i> is used for specifying the <i>KeyConditions</i> to use when querying a table or an index. For <i>KeyConditions</i>, only the following comparison operators are supported:</p> <p> <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code> </p> <p><i>Condition</i> is also used in a <i>QueryFilter</i>, which evaluates the query results and returns only the desired values.</p> </li> <li> <p>For a <i>Scan</i> operation, <i>Condition</i> is used in a <i>ScanFilter</i>, which evaluates the scan results and returns only the desired values.</p> </li> </ul>",
             "members": [
                 {
                     "name": "AttributeValueList",
@@ -397,6 +420,7 @@
         },
         "ConditionalCheckFailedException": {
             "type": "structure",
+            "documentation": "<p>A condition specified in the operation could not be evaluated.</p>",
             "members": [
                 {
                     "name": "message",
@@ -413,6 +437,7 @@
         },
         "ConsumedCapacity": {
             "type": "structure",
+            "documentation": "<p>The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <i>ConsumedCapacity</i> is only returned if the request asked for it. For more information, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -450,6 +475,7 @@
         },
         "CreateGlobalSecondaryIndexAction": {
             "type": "structure",
+            "documentation": "<p>Represents a new global secondary index to be added to an existing table.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -473,6 +499,7 @@
         },
         "CreateTableInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateTable</i> operation.</p>",
             "members": [
                 {
                     "name": "AttributeDefinitions",
@@ -512,6 +539,7 @@
         },
         "CreateTableOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>CreateTable</i> operation.</p>",
             "members": [
                 {
                     "name": "TableDescription",
@@ -524,6 +552,7 @@
         },
         "DeleteGlobalSecondaryIndexAction": {
             "type": "structure",
+            "documentation": "<p>Represents a global secondary index to be deleted from an existing table.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -534,6 +563,7 @@
         },
         "DeleteItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteItem</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -588,6 +618,7 @@
         },
         "DeleteItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DeleteItem</i> operation.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -607,6 +638,7 @@
         },
         "DeleteRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to perform a <i>DeleteItem</i> operation on an item.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -617,6 +649,7 @@
         },
         "DeleteTableInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteTable</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -627,6 +660,7 @@
         },
         "DeleteTableOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DeleteTable</i> operation.</p>",
             "members": [
                 {
                     "name": "TableDescription",
@@ -636,6 +670,7 @@
         },
         "DescribeTableInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeTable</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -646,6 +681,7 @@
         },
         "DescribeTableOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeTable</i> operation.</p>",
             "members": [
                 {
                     "name": "Table",
@@ -657,10 +693,13 @@
             "type": "string"
         },
         "ExpectedAttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "ExpectedAttributeValue"
         },
         "ExpectedAttributeValue": {
             "type": "structure",
+            "documentation": "<p>Represents a condition to be compared with an attribute value. This condition can be used with <i>DeleteItem</i>, <i>PutItem</i> or <i>UpdateItem</i> operations; if the comparison evaluates to true, the operation succeeds; if not, the operation fails. You can use <i>ExpectedAttributeValue</i> in one of two different ways:</p> <ul> <li> <p>Use <i>AttributeValueList</i> to specify one or more values to compare against an attribute. Use <i>ComparisonOperator</i> to specify how you want to perform the comparison. If the comparison evaluates to true, then the conditional operation succeeds.</p> </li> <li> <p>Use <i>Value</i> to specify a value that DynamoDB will compare against an attribute. If the values match, then <i>ExpectedAttributeValue</i> evaluates to true and the conditional operation succeeds. Optionally, you can also set <i>Exists</i> to false, indicating that you <i>do not</i> expect to find the attribute value in the table. In this case, the conditional operation succeeds only if the comparison evaluates to false.</p> </li> </ul> <p><i>Value</i> and <i>Exists</i> are incompatible with <i>AttributeValueList</i> and <i>ComparisonOperator</i>. Note that if you use both sets of parameters at once, DynamoDB will return a <i>ValidationException</i> exception.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -684,22 +723,29 @@
             ]
         },
         "ExpressionAttributeNameMap": {
-            "type": "map"
+            "type": "map",
+            "key": "ExpressionAttributeNameVariable",
+            "value": "AttributeName"
         },
         "ExpressionAttributeNameVariable": {
             "type": "string"
         },
         "ExpressionAttributeValueMap": {
-            "type": "map"
+            "type": "map",
+            "key": "ExpressionAttributeValueVariable",
+            "value": "AttributeValue"
         },
         "ExpressionAttributeValueVariable": {
             "type": "string"
         },
         "FilterConditionMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "Condition"
         },
         "GetItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>GetItem</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -739,6 +785,7 @@
         },
         "GetItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>GetItem</i> operation.</p>",
             "members": [
                 {
                     "name": "Item",
@@ -753,6 +800,7 @@
         },
         "GlobalSecondaryIndex": {
             "type": "structure",
+            "documentation": "<p>Represents the properties of a global secondary index.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -776,6 +824,7 @@
         },
         "GlobalSecondaryIndexDescription": {
             "type": "structure",
+            "documentation": "<p>Represents the properties of a global secondary index.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -832,6 +881,7 @@
         },
         "GlobalSecondaryIndexUpdate": {
             "type": "structure",
+            "documentation": "<p>Represents one of the following:</p> <ul> <li><p>A new global secondary index to be added to an existing table.</p></li> <li><p>New provisioned throughput parameters for an existing global secondary index.</p></li> <li><p>An existing global secondary index to be removed from an existing table.</p></li> </ul>",
             "members": [
                 {
                     "name": "Update",
@@ -865,6 +915,7 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>An error occurred on the server side.</p>",
             "members": [
                 {
                     "name": "message",
@@ -874,10 +925,13 @@
             ]
         },
         "ItemCollectionKeyAttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "ItemCollectionMetrics": {
             "type": "structure",
+            "documentation": "<p>Information about item collections, if any, that were affected by the operation. <i>ItemCollectionMetrics</i> is only returned if the request asked for it. If the table does not have any local secondary indexes, this information is not returned in the response.</p>",
             "members": [
                 {
                     "name": "ItemCollectionKey",
@@ -896,7 +950,9 @@
             "of": "ItemCollectionMetrics"
         },
         "ItemCollectionMetricsPerTable": {
-            "type": "map"
+            "type": "map",
+            "key": "TableName",
+            "value": "ItemCollectionMetricsMultiple"
         },
         "ItemCollectionSizeEstimateBound": {
             "type": "double"
@@ -907,6 +963,7 @@
         },
         "ItemCollectionSizeLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>An item collection is too large. This exception is only returned for tables that have one or more local secondary indexes.</p>",
             "members": [
                 {
                     "name": "message",
@@ -920,10 +977,14 @@
             "of": "AttributeMap"
         },
         "Key": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "KeyConditions": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "Condition"
         },
         "KeyExpression": {
             "type": "string"
@@ -941,6 +1002,7 @@
         },
         "KeySchemaElement": {
             "type": "structure",
+            "documentation": "<p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <i>KeySchemaElement</i> represents exactly one attribute of the primary key. For example, a hash type primary key would be represented by one <i>KeySchemaElement</i>. A hash-and-range type primary key would require one <i>KeySchemaElement</i> for the hash attribute, and another <i>KeySchemaElement</i> for the range attribute.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -959,6 +1021,7 @@
         },
         "KeysAndAttributes": {
             "type": "structure",
+            "documentation": "<p>Represents a set of primary keys and, for each key, the attributes to retrieve from the table.</p> <p>For each primary key, you must provide <i>all</i> of the key attributes. For example, with a hash type primary key, you only need to provide the hash attribute. For a hash-and-range type primary key, you must provide <i>both</i> the hash attribute and the range attribute.</p>",
             "members": [
                 {
                     "name": "Keys",
@@ -989,6 +1052,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The number of concurrent table requests (cumulative number of tables in the <code>CREATING</code>, <code>DELETING</code> or <code>UPDATING</code> state) exceeds the maximum allowed of 10.</p> <p>Also, for tables with secondary indexes, only one of those tables can be in the <code>CREATING</code> state at any point in time. Do not attempt to create more than one such table simultaneously.</p> <p>The total limit of tables in the <code>ACTIVE</code> state is 250.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1003,6 +1067,7 @@
         },
         "ListTablesInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ListTables</i> operation.</p>",
             "members": [
                 {
                     "name": "ExclusiveStartTableName",
@@ -1021,6 +1086,7 @@
         },
         "ListTablesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>ListTables</i> operation.</p>",
             "members": [
                 {
                     "name": "TableNames",
@@ -1036,6 +1102,7 @@
         },
         "LocalSecondaryIndex": {
             "type": "structure",
+            "documentation": "<p>Represents the properties of a local secondary index.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -1055,6 +1122,7 @@
         },
         "LocalSecondaryIndexDescription": {
             "type": "structure",
+            "documentation": "<p>Represents the properties of a local secondary index.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -1099,7 +1167,9 @@
             "type": "long"
         },
         "MapAttributeValue": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "NonKeyAttributeName": {
             "type": "string"
@@ -1126,6 +1196,7 @@
         },
         "Projection": {
             "type": "structure",
+            "documentation": "<p>Represents attributes that are copied (projected) from the table into an index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.</p>",
             "members": [
                 {
                     "name": "ProjectionType",
@@ -1147,6 +1218,7 @@
         },
         "ProvisionedThroughput": {
             "type": "structure",
+            "documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The settings can be modified using the <i>UpdateTable</i> operation.</p> <p>For current minimum and maximum provisioned throughput values, see <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Limits</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "ReadCapacityUnits",
@@ -1162,6 +1234,7 @@
         },
         "ProvisionedThroughputDescription": {
             "type": "structure",
+            "documentation": "<p>Represents the provisioned throughput settings for the table, consisting of read and write capacity units, along with data about increases and decreases.</p>",
             "members": [
                 {
                     "name": "LastIncreaseDateTime",
@@ -1192,6 +1265,7 @@
         },
         "ProvisionedThroughputExceededException": {
             "type": "structure",
+            "documentation": "<p>Your request rate is too high. The AWS SDKs for DynamoDB automatically retry requests that receive this exception. Your request is eventually successful, unless your retry queue is too large to finish. Reduce the frequency of requests and use exponential backoff. For more information, go to <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#APIRetries\">Error Retries and Exponential Backoff</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1202,6 +1276,7 @@
         },
         "PutItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>PutItem</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -1255,10 +1330,13 @@
             ]
         },
         "PutItemInputAttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "PutItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>PutItem</i> operation.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -1278,6 +1356,7 @@
         },
         "PutRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to perform a <i>PutItem</i> operation on an item.</p>",
             "members": [
                 {
                     "name": "Item",
@@ -1288,6 +1367,7 @@
         },
         "QueryInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>Query</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -1377,6 +1457,7 @@
         },
         "QueryOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>Query</i> operation.</p>",
             "members": [
                 {
                     "name": "Items",
@@ -1406,6 +1487,7 @@
         },
         "ResourceInUseException": {
             "type": "structure",
+            "documentation": "<p>The operation conflicts with the resource's availability. For example, you attempted to recreate an existing table, or tried to delete a table currently in the <code>CREATING</code> state.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1416,6 +1498,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The operation tried to access a nonexistent table or index. The resource might not be specified correctly, or its status might not be <code>ACTIVE</code>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1425,7 +1508,8 @@
             ]
         },
         "ReturnConsumedCapacity": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Determines the level of detail about provisioned throughput consumption that is returned in the response:</p> <ul> <li> <p><i>INDEXES</i> - The response includes the aggregate <i>ConsumedCapacity</i> for the operation, together with <i>ConsumedCapacity</i> for each table and secondary index that was accessed.</p> <p>Note that some operations, such as <i>GetItem</i> and <i>BatchGetItem</i>, do not access any indexes at all. In these cases, specifying <i>INDEXES</i> will only return <i>ConsumedCapacity</i> information for table(s).</p> </li> <li><p><i>TOTAL</i> - The response includes only the aggregate <i>ConsumedCapacity</i> for the operation.</p></li> <li><p><i>NONE</i> - No <i>ConsumedCapacity</i> details are included in the response.</p></li> </ul>"
         },
         "ReturnItemCollectionMetrics": {
             "type": "string"
@@ -1438,6 +1522,7 @@
         },
         "ScanInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>Scan</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -1522,6 +1607,7 @@
         },
         "ScanOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>Scan</i> operation.</p>",
             "members": [
                 {
                     "name": "Items",
@@ -1556,7 +1642,9 @@
             "type": "integer"
         },
         "SecondaryIndexesCapacityMap": {
-            "type": "map"
+            "type": "map",
+            "key": "IndexName",
+            "value": "Capacity"
         },
         "Select": {
             "type": "string"
@@ -1569,6 +1657,7 @@
         },
         "StreamSpecification": {
             "type": "structure",
+            "documentation": "<p>Represents the DynamoDB Streams configuration for a table in DynamoDB.</p>",
             "members": [
                 {
                     "name": "StreamEnabled",
@@ -1597,6 +1686,7 @@
         },
         "TableDescription": {
             "type": "structure",
+            "documentation": "<p>Represents the properties of a table.</p>",
             "members": [
                 {
                     "name": "AttributeDefinitions",
@@ -1685,6 +1775,7 @@
         },
         "UpdateGlobalSecondaryIndexAction": {
             "type": "structure",
+            "documentation": "<p>Represents the new provisioned throughput settings to be applied to a global secondary index.</p>",
             "members": [
                 {
                     "name": "IndexName",
@@ -1699,6 +1790,7 @@
         },
         "UpdateItemInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an <i>UpdateItem</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -1763,6 +1855,7 @@
         },
         "UpdateItemOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <i>UpdateItem</i> operation.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -1781,6 +1874,7 @@
         },
         "UpdateTableInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an <i>UpdateTable</i> operation.</p>",
             "members": [
                 {
                     "name": "AttributeDefinitions",
@@ -1810,6 +1904,7 @@
         },
         "UpdateTableOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <i>UpdateTable</i> operation.</p>",
             "members": [
                 {
                     "name": "TableDescription",
@@ -1819,6 +1914,7 @@
         },
         "WriteRequest": {
             "type": "structure",
+            "documentation": "<p>Represents an operation to perform - either <i>DeleteItem</i> or <i>PutItem</i>. You can only request one of these operations, not both, in a single <i>WriteRequest</i>. If you do need to perform both of these operations, you will need to provide two separate <i>WriteRequest</i> objects.</p>",
             "members": [
                 {
                     "name": "PutRequest",

--- a/libcloudcore/data/aws/dynamodbstreams/service.json
+++ b/libcloudcore/data/aws/dynamodbstreams/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -66,13 +70,16 @@
     },
     "shapes": {
         "AttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "AttributeName": {
             "type": "string"
         },
         "AttributeValue": {
             "type": "structure",
+            "documentation": "<p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed. </p>",
             "members": [
                 {
                     "name": "S",
@@ -141,6 +148,7 @@
         },
         "DescribeStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeStream</i> operation.</p>",
             "members": [
                 {
                     "name": "StreamArn",
@@ -161,6 +169,7 @@
         },
         "DescribeStreamOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeStream</i> operation.</p>",
             "members": [
                 {
                     "name": "StreamDescription",
@@ -174,6 +183,7 @@
         },
         "ExpiredIteratorException": {
             "type": "structure",
+            "documentation": "<p>The shard iterator has expired and can no longer be used to retrieve stream records. A shard iterator expires 15 minutes after it is retrieved using the <i>GetShardIterator</i> action.</p>",
             "members": [
                 {
                     "name": "message",
@@ -184,6 +194,7 @@
         },
         "GetRecordsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>GetRecords</i> operation.</p>",
             "members": [
                 {
                     "name": "ShardIterator",
@@ -199,6 +210,7 @@
         },
         "GetRecordsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>GetRecords</i> operation.</p>",
             "members": [
                 {
                     "name": "Records",
@@ -214,6 +226,7 @@
         },
         "GetShardIteratorInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>GetShardIterator</i> operation.</p>",
             "members": [
                 {
                     "name": "StreamArn",
@@ -239,6 +252,7 @@
         },
         "GetShardIteratorOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>GetShardIterator</i> operation.</p>",
             "members": [
                 {
                     "name": "ShardIterator",
@@ -249,6 +263,7 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>An error occurred on the server side.</p>",
             "members": [
                 {
                     "name": "message",
@@ -266,6 +281,7 @@
         },
         "KeySchemaElement": {
             "type": "structure",
+            "documentation": "<p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <i>KeySchemaElement</i> represents exactly one attribute of the primary key. For example, a hash type primary key would be represented by one <i>KeySchemaElement</i>. A hash-and-range type primary key would require one <i>KeySchemaElement</i> for the hash attribute, and another <i>KeySchemaElement</i> for the range attribute.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -284,6 +300,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Your request rate is too high. The AWS SDKs for DynamoDB automatically retry requests that receive this exception. Your request is eventually successful, unless your retry queue is too large to finish. Reduce the frequency of requests and use exponential backoff. For more information, go to <a href=\"http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#APIRetries\">Error Retries and Exponential Backoff</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -298,6 +315,7 @@
         },
         "ListStreamsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ListStreams</i> operation.</p>",
             "members": [
                 {
                     "name": "TableName",
@@ -318,6 +336,7 @@
         },
         "ListStreamsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>ListStreams</i> operation.</p>",
             "members": [
                 {
                     "name": "Streams",
@@ -332,7 +351,9 @@
             ]
         },
         "MapAttributeValue": {
-            "type": "map"
+            "type": "map",
+            "key": "AttributeName",
+            "value": "AttributeValue"
         },
         "NullAttributeValue": {
             "type": "boolean"
@@ -355,6 +376,7 @@
         },
         "Record": {
             "type": "structure",
+            "documentation": "<p>A description of a unique event within a stream.</p>",
             "members": [
                 {
                     "name": "eventID",
@@ -394,6 +416,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The operation tried to access a nonexistent stream. </p>",
             "members": [
                 {
                     "name": "message",
@@ -407,6 +430,7 @@
         },
         "SequenceNumberRange": {
             "type": "structure",
+            "documentation": "<p>The beginning and ending sequence numbers for the stream records contained within a shard.</p>",
             "members": [
                 {
                     "name": "StartingSequenceNumber",
@@ -422,6 +446,7 @@
         },
         "Shard": {
             "type": "structure",
+            "documentation": "<p>A uniquely identified group of stream records within a stream.</p>",
             "members": [
                 {
                     "name": "ShardId",
@@ -455,6 +480,7 @@
         },
         "Stream": {
             "type": "structure",
+            "documentation": "<p>Represents all of the data describing a particular stream.</p>",
             "members": [
                 {
                     "name": "StreamArn",
@@ -478,6 +504,7 @@
         },
         "StreamDescription": {
             "type": "structure",
+            "documentation": "<p>Represents all of the data describing a particular stream.</p>",
             "members": [
                 {
                     "name": "StreamArn",
@@ -532,6 +559,7 @@
         },
         "StreamRecord": {
             "type": "structure",
+            "documentation": "<p>A description of a single data modification that was performed on an item in a DynamoDB table.</p>",
             "members": [
                 {
                     "name": "Keys",
@@ -586,6 +614,7 @@
         },
         "TrimmedDataAccessException": {
             "type": "structure",
+            "documentation": "<p>The operation attempted to read past the oldest stream record in a shard.</p> <p>In DynamoDB Streams, there is a 24 hour limit on data retention. Stream records whose age exceeds this limit are subject to removal (trimming) from the stream. You might receive a TrimmedDataAccessException if:</p> <ul> <li>You request a shard iterator with a sequence number older than the trim point (24 hours).</li> <li>You obtain a shard iterator, but before you use the iterator in a <i>GetRecords</i> request, a stream record in the shard exceeds the 24 hour period and is trimmed. This causes the iterator to access a record that no longer exists.</li> </ul>",
             "members": [
                 {
                     "name": "message",

--- a/libcloudcore/data/aws/ec2/service.json
+++ b/libcloudcore/data/aws/ec2/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://ec2.amazonaws.com/doc/2015-04-15"
         }
@@ -1524,6 +1527,7 @@
         },
         "AccountAttribute": {
             "type": "structure",
+            "documentation": "<p>Describes an account attribute.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -1552,6 +1556,7 @@
         },
         "AccountAttributeValue": {
             "type": "structure",
+            "documentation": "<p>Describes a value of an account attribute.</p>",
             "members": [
                 {
                     "name": "AttributeValue",
@@ -1567,6 +1572,7 @@
         },
         "ActiveInstance": {
             "type": "structure",
+            "documentation": "<p>Describes a running instance in a Spot fleet.</p>",
             "members": [
                 {
                     "name": "InstanceType",
@@ -1594,6 +1600,7 @@
         },
         "Address": {
             "type": "structure",
+            "documentation": "<p>Describes an Elastic IP address.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -2000,6 +2007,7 @@
         },
         "AttributeBooleanValue": {
             "type": "structure",
+            "documentation": "<p>The value to use when a resource attribute accepts a Boolean value.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -2011,6 +2019,7 @@
         },
         "AttributeValue": {
             "type": "structure",
+            "documentation": "<p>The value to use for a resource attribute.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -2137,6 +2146,7 @@
         },
         "AvailabilityZone": {
             "type": "structure",
+            "documentation": "<p>Describes an Availability Zone.</p>",
             "members": [
                 {
                     "name": "ZoneName",
@@ -2170,6 +2180,7 @@
         },
         "AvailabilityZoneMessage": {
             "type": "structure",
+            "documentation": "<p>Describes a message about an Availability Zone.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -2191,6 +2202,7 @@
         },
         "BlockDeviceMapping": {
             "type": "structure",
+            "documentation": "<p>Describes a block device mapping.</p>",
             "members": [
                 {
                     "name": "VirtualName",
@@ -2267,6 +2279,7 @@
         },
         "BundleTask": {
             "type": "structure",
+            "documentation": "<p>Describes a bundle task.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -2320,6 +2333,7 @@
         },
         "BundleTaskError": {
             "type": "structure",
+            "documentation": "<p>Describes an error for <a>BundleInstance</a>.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -2473,6 +2487,7 @@
         },
         "CancelSpotFleetRequestsError": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot fleet error.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -2490,6 +2505,7 @@
         },
         "CancelSpotFleetRequestsErrorItem": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot fleet request that was not successfully canceled.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -2511,6 +2527,7 @@
         },
         "CancelSpotFleetRequestsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for CancelSpotFleetRequests.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -2534,6 +2551,7 @@
         },
         "CancelSpotFleetRequestsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of CancelSpotFleetRequests.</p>",
             "members": [
                 {
                     "name": "UnsuccessfulFleetRequests",
@@ -2551,6 +2569,7 @@
         },
         "CancelSpotFleetRequestsSuccessItem": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot fleet request that was successfully canceled.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -2581,6 +2600,7 @@
         },
         "CancelSpotInstanceRequestsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for CancelSpotInstanceRequests.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -2598,6 +2618,7 @@
         },
         "CancelSpotInstanceRequestsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of CancelSpotInstanceRequests.</p>",
             "members": [
                 {
                     "name": "CancelledSpotInstanceRequests",
@@ -2609,6 +2630,7 @@
         },
         "CancelledSpotInstanceRequest": {
             "type": "structure",
+            "documentation": "<p>Describes a request to cancel a Spot Instance.</p>",
             "members": [
                 {
                     "name": "SpotInstanceRequestId",
@@ -2630,6 +2652,7 @@
         },
         "ClassicLinkInstance": {
             "type": "structure",
+            "documentation": "<p>Describes a linked EC2-Classic instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -2663,6 +2686,7 @@
         },
         "ClientData": {
             "type": "structure",
+            "documentation": "<p>Describes the client-specific data.</p>",
             "members": [
                 {
                     "name": "UploadStart",
@@ -2733,6 +2757,7 @@
         },
         "ConversionTask": {
             "type": "structure",
+            "documentation": "<p>Describes a conversion task.</p>",
             "members": [
                 {
                     "name": "ConversionTaskId",
@@ -3499,6 +3524,7 @@
         },
         "CreateSpotDatafeedSubscriptionRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for CreateSpotDatafeedSubscription.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -3522,6 +3548,7 @@
         },
         "CreateSpotDatafeedSubscriptionResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of CreateSpotDatafeedSubscription.</p>",
             "members": [
                 {
                     "name": "SpotDatafeedSubscription",
@@ -3593,6 +3620,7 @@
         },
         "CreateVolumePermission": {
             "type": "structure",
+            "documentation": "<p>Describes the user or group to be added or removed from the permissions for a volume.</p>",
             "members": [
                 {
                     "name": "UserId",
@@ -3614,6 +3642,7 @@
         },
         "CreateVolumePermissionModifications": {
             "type": "structure",
+            "documentation": "<p>Describes modifications to the permissions for a volume.</p>",
             "members": [
                 {
                     "name": "Add",
@@ -3895,6 +3924,7 @@
         },
         "CustomerGateway": {
             "type": "structure",
+            "documentation": "<p>Describes a customer gateway.</p>",
             "members": [
                 {
                     "name": "CustomerGatewayId",
@@ -4194,6 +4224,7 @@
         },
         "DeleteSpotDatafeedSubscriptionRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DeleteSpotDatafeedSubscription.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -5803,6 +5834,7 @@
         },
         "DescribeSpotDatafeedSubscriptionRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotDatafeedSubscription.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -5814,6 +5846,7 @@
         },
         "DescribeSpotDatafeedSubscriptionResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotDatafeedSubscription.</p>",
             "members": [
                 {
                     "name": "SpotDatafeedSubscription",
@@ -5825,6 +5858,7 @@
         },
         "DescribeSpotFleetInstancesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotFleetInstances.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -5854,6 +5888,7 @@
         },
         "DescribeSpotFleetInstancesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotFleetInstances.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -5877,6 +5912,7 @@
         },
         "DescribeSpotFleetRequestHistoryRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotFleetRequestHistory.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -5918,6 +5954,7 @@
         },
         "DescribeSpotFleetRequestHistoryResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotFleetRequestHistory.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -5953,6 +5990,7 @@
         },
         "DescribeSpotFleetRequestsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotFleetRequests.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -5982,6 +6020,7 @@
         },
         "DescribeSpotFleetRequestsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotFleetRequests.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestConfigs",
@@ -5999,6 +6038,7 @@
         },
         "DescribeSpotInstanceRequestsRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotInstanceRequests.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -6022,6 +6062,7 @@
         },
         "DescribeSpotInstanceRequestsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotInstanceRequests.</p>",
             "members": [
                 {
                     "name": "SpotInstanceRequests",
@@ -6033,6 +6074,7 @@
         },
         "DescribeSpotPriceHistoryRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for DescribeSpotPriceHistory.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -6092,6 +6134,7 @@
         },
         "DescribeSpotPriceHistoryResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of DescribeSpotPriceHistory.</p>",
             "members": [
                 {
                     "name": "SpotPriceHistory",
@@ -6770,6 +6813,7 @@
         },
         "DhcpConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes a DHCP configuration option.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -6791,6 +6835,7 @@
         },
         "DhcpOptions": {
             "type": "structure",
+            "documentation": "<p>Describes a set of DHCP options.</p>",
             "members": [
                 {
                     "name": "DhcpOptionsId",
@@ -6903,6 +6948,7 @@
         },
         "DiskImage": {
             "type": "structure",
+            "documentation": "<p>Describes a disk image.</p>",
             "members": [
                 {
                     "name": "Image",
@@ -6923,6 +6969,7 @@
         },
         "DiskImageDescription": {
             "type": "structure",
+            "documentation": "<p>Describes a disk image.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -6952,6 +6999,7 @@
         },
         "DiskImageDetail": {
             "type": "structure",
+            "documentation": "<p>Describes a disk image.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -6982,6 +7030,7 @@
         },
         "DiskImageVolumeDescription": {
             "type": "structure",
+            "documentation": "<p>Describes a disk image volume.</p>",
             "members": [
                 {
                     "name": "Size",
@@ -7005,6 +7054,7 @@
         },
         "EbsBlockDevice": {
             "type": "structure",
+            "documentation": "<p>Describes a block device for an EBS volume.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -7046,6 +7096,7 @@
         },
         "EbsInstanceBlockDevice": {
             "type": "structure",
+            "documentation": "<p>Describes a parameter used to set up an EBS volume in a block device mapping.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -7155,6 +7206,7 @@
         },
         "EventInformation": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot fleet event.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -7188,6 +7240,7 @@
         },
         "ExportTask": {
             "type": "structure",
+            "documentation": "<p>Describes an instance export task.</p>",
             "members": [
                 {
                     "name": "ExportTaskId",
@@ -7240,6 +7293,7 @@
         },
         "ExportToS3Task": {
             "type": "structure",
+            "documentation": "<p>Describes the format and location for an instance export task.</p>",
             "members": [
                 {
                     "name": "DiskImageFormat",
@@ -7269,6 +7323,7 @@
         },
         "ExportToS3TaskSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes an instance export task.</p>",
             "members": [
                 {
                     "name": "DiskImageFormat",
@@ -7298,6 +7353,7 @@
         },
         "Filter": {
             "type": "structure",
+            "documentation": "<p>A filter name and value pair that is used to return a more specific list of results. Filters can be used to match a set of resources by various criteria, such as tags, attributes, or IDs.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -7321,6 +7377,7 @@
         },
         "FlowLog": {
             "type": "structure",
+            "documentation": "<p>Describes a flow log.</p>",
             "members": [
                 {
                     "name": "CreationTime",
@@ -7472,6 +7529,7 @@
         },
         "GroupIdentifier": {
             "type": "structure",
+            "documentation": "<p>Describes a security group.</p>",
             "members": [
                 {
                     "name": "GroupName",
@@ -7497,6 +7555,7 @@
         },
         "HistoryRecord": {
             "type": "structure",
+            "documentation": "<p>Describes an event in the history of the Spot fleet request.</p>",
             "members": [
                 {
                     "name": "Timestamp",
@@ -7527,6 +7586,7 @@
         },
         "IamInstanceProfile": {
             "type": "structure",
+            "documentation": "<p>Describes an IAM instance profile.</p>",
             "members": [
                 {
                     "name": "Arn",
@@ -7544,6 +7604,7 @@
         },
         "IamInstanceProfileSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes an IAM instance profile.</p>",
             "members": [
                 {
                     "name": "Arn",
@@ -7561,6 +7622,7 @@
         },
         "IcmpTypeCode": {
             "type": "structure",
+            "documentation": "<p>Describes the ICMP type and code.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -7578,6 +7640,7 @@
         },
         "Image": {
             "type": "structure",
+            "documentation": "<p>Describes an image.</p>",
             "members": [
                 {
                     "name": "ImageId",
@@ -7721,6 +7784,7 @@
         },
         "ImageAttribute": {
             "type": "structure",
+            "documentation": "<p>Describes an image attribute.</p>",
             "members": [
                 {
                     "name": "ImageId",
@@ -7776,6 +7840,7 @@
         },
         "ImageDiskContainer": {
             "type": "structure",
+            "documentation": "<p>Describes the disk container object for an import image task.</p>",
             "members": [
                 {
                     "name": "Description",
@@ -7956,6 +8021,7 @@
         },
         "ImportImageTask": {
             "type": "structure",
+            "documentation": "<p>Describes an import image task.</p>",
             "members": [
                 {
                     "name": "ImportTaskId",
@@ -8031,6 +8097,7 @@
         },
         "ImportInstanceLaunchSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes the launch specification for VM import.</p>",
             "members": [
                 {
                     "name": "Architecture",
@@ -8148,6 +8215,7 @@
         },
         "ImportInstanceTaskDetails": {
             "type": "structure",
+            "documentation": "<p>Describes an import instance task.</p>",
             "members": [
                 {
                     "name": "Volumes",
@@ -8177,6 +8245,7 @@
         },
         "ImportInstanceVolumeDetailItem": {
             "type": "structure",
+            "documentation": "<p>Describes an import volume task.</p>",
             "members": [
                 {
                     "name": "BytesConverted",
@@ -8326,6 +8395,7 @@
         },
         "ImportSnapshotTask": {
             "type": "structure",
+            "documentation": "<p>Describes an import snapshot task.</p>",
             "members": [
                 {
                     "name": "ImportTaskId",
@@ -8403,6 +8473,7 @@
         },
         "ImportVolumeTaskDetails": {
             "type": "structure",
+            "documentation": "<p>Describes an import volume task.</p>",
             "members": [
                 {
                     "name": "BytesConverted",
@@ -8438,6 +8509,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>Describes an instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -8665,6 +8737,7 @@
         },
         "InstanceAttribute": {
             "type": "structure",
+            "documentation": "<p>Describes an instance attribute.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -8756,6 +8829,7 @@
         },
         "InstanceBlockDeviceMapping": {
             "type": "structure",
+            "documentation": "<p>Describes a block device mapping.</p>",
             "members": [
                 {
                     "name": "DeviceName",
@@ -8777,6 +8851,7 @@
         },
         "InstanceBlockDeviceMappingSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes a block device mapping entry.</p>",
             "members": [
                 {
                     "name": "DeviceName",
@@ -8810,6 +8885,7 @@
         },
         "InstanceCount": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance listing state.</p>",
             "members": [
                 {
                     "name": "State",
@@ -8831,6 +8907,7 @@
         },
         "InstanceExportDetails": {
             "type": "structure",
+            "documentation": "<p>Describes an instance to export.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -8859,6 +8936,7 @@
         },
         "InstanceMonitoring": {
             "type": "structure",
+            "documentation": "<p>Describes the monitoring information of the instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -8880,6 +8958,7 @@
         },
         "InstanceNetworkInterface": {
             "type": "structure",
+            "documentation": "<p>Describes a network interface.</p>",
             "members": [
                 {
                     "name": "NetworkInterfaceId",
@@ -8969,6 +9048,7 @@
         },
         "InstanceNetworkInterfaceAssociation": {
             "type": "structure",
+            "documentation": "<p>Describes association information for an Elastic IP address.</p>",
             "members": [
                 {
                     "name": "PublicIp",
@@ -8992,6 +9072,7 @@
         },
         "InstanceNetworkInterfaceAttachment": {
             "type": "structure",
+            "documentation": "<p>Describes a network interface attachment.</p>",
             "members": [
                 {
                     "name": "AttachmentId",
@@ -9031,6 +9112,7 @@
         },
         "InstanceNetworkInterfaceSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes a network interface.</p>",
             "members": [
                 {
                     "name": "NetworkInterfaceId",
@@ -9101,6 +9183,7 @@
         },
         "InstancePrivateIpAddress": {
             "type": "structure",
+            "documentation": "<p>Describes a private IP address.</p>",
             "members": [
                 {
                     "name": "PrivateIpAddress",
@@ -9134,6 +9217,7 @@
         },
         "InstanceState": {
             "type": "structure",
+            "documentation": "<p>Describes the current state of the instance.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -9151,6 +9235,7 @@
         },
         "InstanceStateChange": {
             "type": "structure",
+            "documentation": "<p>Describes an instance state change.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -9181,6 +9266,7 @@
         },
         "InstanceStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of an instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -9222,6 +9308,7 @@
         },
         "InstanceStatusDetails": {
             "type": "structure",
+            "documentation": "<p>Describes the instance status.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -9249,6 +9336,7 @@
         },
         "InstanceStatusEvent": {
             "type": "structure",
+            "documentation": "<p>Describes a scheduled event for an instance.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -9286,6 +9374,7 @@
         },
         "InstanceStatusSummary": {
             "type": "structure",
+            "documentation": "<p>Describes the status of an instance.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -9313,6 +9402,7 @@
         },
         "InternetGateway": {
             "type": "structure",
+            "documentation": "<p>Describes an Internet gateway.</p>",
             "members": [
                 {
                     "name": "InternetGatewayId",
@@ -9336,6 +9426,7 @@
         },
         "InternetGatewayAttachment": {
             "type": "structure",
+            "documentation": "<p>Describes the attachment of a VPC to an Internet gateway.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -9361,6 +9452,7 @@
         },
         "IpPermission": {
             "type": "structure",
+            "documentation": "<p>Describes a security group rule.</p>",
             "members": [
                 {
                     "name": "IpProtocol",
@@ -9406,6 +9498,7 @@
         },
         "IpRange": {
             "type": "structure",
+            "documentation": "<p>Describes an IP range.</p>",
             "members": [
                 {
                     "name": "CidrIp",
@@ -9425,6 +9518,7 @@
         },
         "KeyPair": {
             "type": "structure",
+            "documentation": "<p>Describes a key pair.</p>",
             "members": [
                 {
                     "name": "KeyName",
@@ -9448,6 +9542,7 @@
         },
         "KeyPairInfo": {
             "type": "structure",
+            "documentation": "<p>Describes a key pair.</p>",
             "members": [
                 {
                     "name": "KeyName",
@@ -9469,6 +9564,7 @@
         },
         "LaunchPermission": {
             "type": "structure",
+            "documentation": "<p>Describes a launch permission.</p>",
             "members": [
                 {
                     "name": "UserId",
@@ -9490,6 +9586,7 @@
         },
         "LaunchPermissionModifications": {
             "type": "structure",
+            "documentation": "<p>Describes a launch permission modification.</p>",
             "members": [
                 {
                     "name": "Add",
@@ -9505,6 +9602,7 @@
         },
         "LaunchSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes the launch specification for an instance.</p>",
             "members": [
                 {
                     "name": "ImageId",
@@ -10017,6 +10115,7 @@
         },
         "Monitoring": {
             "type": "structure",
+            "documentation": "<p>Describes the monitoring for the instance.</p>",
             "members": [
                 {
                     "name": "State",
@@ -10068,6 +10167,7 @@
         },
         "MovingAddressStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a moving Elastic IP address.</p>",
             "members": [
                 {
                     "name": "PublicIp",
@@ -10089,6 +10189,7 @@
         },
         "NetworkAcl": {
             "type": "structure",
+            "documentation": "<p>Describes a network ACL.</p>",
             "members": [
                 {
                     "name": "NetworkAclId",
@@ -10130,6 +10231,7 @@
         },
         "NetworkAclAssociation": {
             "type": "structure",
+            "documentation": "<p>Describes an association between a network ACL and a subnet.</p>",
             "members": [
                 {
                     "name": "NetworkAclAssociationId",
@@ -10157,6 +10259,7 @@
         },
         "NetworkAclEntry": {
             "type": "structure",
+            "documentation": "<p>Describes an entry in a network ACL.</p>",
             "members": [
                 {
                     "name": "RuleNumber",
@@ -10212,6 +10315,7 @@
         },
         "NetworkInterface": {
             "type": "structure",
+            "documentation": "<p>Describes a network interface.</p>",
             "members": [
                 {
                     "name": "NetworkInterfaceId",
@@ -10325,6 +10429,7 @@
         },
         "NetworkInterfaceAssociation": {
             "type": "structure",
+            "documentation": "<p>Describes association information for an Elastic IP address.</p>",
             "members": [
                 {
                     "name": "PublicIp",
@@ -10360,6 +10465,7 @@
         },
         "NetworkInterfaceAttachment": {
             "type": "structure",
+            "documentation": "<p>Describes a network interface attachment.</p>",
             "members": [
                 {
                     "name": "AttachmentId",
@@ -10407,6 +10513,7 @@
         },
         "NetworkInterfaceAttachmentChanges": {
             "type": "structure",
+            "documentation": "<p>Describes an attachment change.</p>",
             "members": [
                 {
                     "name": "AttachmentId",
@@ -10435,6 +10542,7 @@
         },
         "NetworkInterfacePrivateIpAddress": {
             "type": "structure",
+            "documentation": "<p>Describes the private IP address of a network interface.</p>",
             "members": [
                 {
                     "name": "PrivateIpAddress",
@@ -10481,6 +10589,7 @@
         },
         "Placement": {
             "type": "structure",
+            "documentation": "<p>Describes the placement for the instance.</p>",
             "members": [
                 {
                     "name": "AvailabilityZone",
@@ -10504,6 +10613,7 @@
         },
         "PlacementGroup": {
             "type": "structure",
+            "documentation": "<p>Describes a placement group.</p>",
             "members": [
                 {
                     "name": "GroupName",
@@ -10544,6 +10654,7 @@
         },
         "PortRange": {
             "type": "structure",
+            "documentation": "<p>Describes a range of ports.</p>",
             "members": [
                 {
                     "name": "From",
@@ -10561,6 +10672,7 @@
         },
         "PrefixList": {
             "type": "structure",
+            "documentation": "<p>Describes prefixes for AWS services. </p>",
             "members": [
                 {
                     "name": "PrefixListId",
@@ -10584,6 +10696,7 @@
         },
         "PrefixListId": {
             "type": "structure",
+            "documentation": "<p>The ID of the prefix.</p>",
             "members": [
                 {
                     "name": "PrefixListId",
@@ -10603,6 +10716,7 @@
         },
         "PriceSchedule": {
             "type": "structure",
+            "documentation": "<p>Describes the price for a Reserved Instance.</p>",
             "members": [
                 {
                     "name": "Term",
@@ -10636,6 +10750,7 @@
         },
         "PriceScheduleSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes the price for a Reserved Instance.</p>",
             "members": [
                 {
                     "name": "Term",
@@ -10663,6 +10778,7 @@
         },
         "PricingDetail": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance offering.</p>",
             "members": [
                 {
                     "name": "Price",
@@ -10684,6 +10800,7 @@
         },
         "PrivateIpAddressSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes a secondary private IP address for a network interface.</p>",
             "members": [
                 {
                     "name": "PrivateIpAddress",
@@ -10709,6 +10826,7 @@
         },
         "ProductCode": {
             "type": "structure",
+            "documentation": "<p>Describes a product code.</p>",
             "members": [
                 {
                     "name": "ProductCodeId",
@@ -10741,6 +10859,7 @@
         },
         "PropagatingVgw": {
             "type": "structure",
+            "documentation": "<p>Describes a virtual private gateway propagating route.</p>",
             "members": [
                 {
                     "name": "GatewayId",
@@ -10822,6 +10941,7 @@
         },
         "RecurringCharge": {
             "type": "structure",
+            "documentation": "<p>Describes a recurring charge.</p>",
             "members": [
                 {
                     "name": "Frequency",
@@ -10846,6 +10966,7 @@
         },
         "Region": {
             "type": "structure",
+            "documentation": "<p>Describes a region.</p>",
             "members": [
                 {
                     "name": "RegionName",
@@ -11228,6 +11349,7 @@
         },
         "RequestSpotFleetRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for RequestSpotFleet.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -11245,6 +11367,7 @@
         },
         "RequestSpotFleetResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the output of RequestSpotFleet.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -11256,6 +11379,7 @@
         },
         "RequestSpotInstancesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the parameters for RequestSpotInstances.</p>",
             "members": [
                 {
                     "name": "DryRun",
@@ -11319,6 +11443,7 @@
         },
         "RequestSpotInstancesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the output of RequestSpotInstances.</p>",
             "members": [
                 {
                     "name": "SpotInstanceRequests",
@@ -11330,6 +11455,7 @@
         },
         "Reservation": {
             "type": "structure",
+            "documentation": "<p>Describes a reservation.</p>",
             "members": [
                 {
                     "name": "ReservationId",
@@ -11369,6 +11495,7 @@
         },
         "ReservedInstanceLimitPrice": {
             "type": "structure",
+            "documentation": "<p>Describes the limit price of a Reserved Instance offering.</p>",
             "members": [
                 {
                     "name": "Amount",
@@ -11389,6 +11516,7 @@
         },
         "ReservedInstances": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance.</p>",
             "members": [
                 {
                     "name": "ReservedInstancesId",
@@ -11490,6 +11618,7 @@
         },
         "ReservedInstancesConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes the configuration settings for the modified Reserved Instances.</p>",
             "members": [
                 {
                     "name": "AvailabilityZone",
@@ -11523,6 +11652,7 @@
         },
         "ReservedInstancesId": {
             "type": "structure",
+            "documentation": "<p>Describes the ID of a Reserved Instance.</p>",
             "members": [
                 {
                     "name": "ReservedInstancesId",
@@ -11542,6 +11672,7 @@
         },
         "ReservedInstancesListing": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance listing.</p>",
             "members": [
                 {
                     "name": "ReservedInstancesListingId",
@@ -11611,6 +11742,7 @@
         },
         "ReservedInstancesModification": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance modification.</p>",
             "members": [
                 {
                     "name": "ReservedInstancesModificationId",
@@ -11699,6 +11831,7 @@
         },
         "ReservedInstancesOffering": {
             "type": "structure",
+            "documentation": "<p>Describes a Reserved Instance offering.</p>",
             "members": [
                 {
                     "name": "ReservedInstancesOfferingId",
@@ -12045,6 +12178,7 @@
         },
         "Route": {
             "type": "structure",
+            "documentation": "<p>Describes a route in a route table.</p>",
             "members": [
                 {
                     "name": "DestinationCidrBlock",
@@ -12114,6 +12248,7 @@
         },
         "RouteTable": {
             "type": "structure",
+            "documentation": "<p>Describes a route table.</p>",
             "members": [
                 {
                     "name": "RouteTableId",
@@ -12155,6 +12290,7 @@
         },
         "RouteTableAssociation": {
             "type": "structure",
+            "documentation": "<p>Describes an association between a route table and a subnet.</p>",
             "members": [
                 {
                     "name": "RouteTableAssociationId",
@@ -12195,6 +12331,7 @@
         },
         "RunInstancesMonitoringEnabled": {
             "type": "structure",
+            "documentation": "<p>Describes the monitoring for the instance.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -12338,6 +12475,7 @@
         },
         "S3Storage": {
             "type": "structure",
+            "documentation": "<p>Describes the storage parameters for S3 and S3 buckets for an instance store-backed AMI.</p>",
             "members": [
                 {
                     "name": "Bucket",
@@ -12372,6 +12510,7 @@
         },
         "SecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Describes a security group</p>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -12440,6 +12579,7 @@
         },
         "Snapshot": {
             "type": "structure",
+            "documentation": "<p>Describes a snapshot.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -12520,6 +12660,7 @@
         },
         "SnapshotDetail": {
             "type": "structure",
+            "documentation": "<p>Describes the snapshot created from the imported disk.</p>",
             "members": [
                 {
                     "name": "DiskImageSize",
@@ -12588,6 +12729,7 @@
         },
         "SnapshotDiskContainer": {
             "type": "structure",
+            "documentation": "<p>The disk container object for the import snapshot request.</p>",
             "members": [
                 {
                     "name": "Description",
@@ -12623,6 +12765,7 @@
         },
         "SnapshotTaskDetail": {
             "type": "structure",
+            "documentation": "<p>Details about the import snapshot task.</p>",
             "members": [
                 {
                     "name": "DiskImageSize",
@@ -12682,6 +12825,7 @@
         },
         "SpotDatafeedSubscription": {
             "type": "structure",
+            "documentation": "<p>Describes the data feed for a Spot Instance.</p>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -12717,6 +12861,7 @@
         },
         "SpotFleetLaunchSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes the launch specification for an instance.</p>",
             "members": [
                 {
                     "name": "ImageId",
@@ -12810,6 +12955,7 @@
         },
         "SpotFleetMonitoring": {
             "type": "structure",
+            "documentation": "<p>Describes whether monitoring is enabled.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -12821,6 +12967,7 @@
         },
         "SpotFleetRequestConfig": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot fleet request.</p>",
             "members": [
                 {
                     "name": "SpotFleetRequestId",
@@ -12844,6 +12991,7 @@
         },
         "SpotFleetRequestConfigData": {
             "type": "structure",
+            "documentation": "<p>Describes the configuration of a Spot fleet request.</p>",
             "members": [
                 {
                     "name": "ClientToken",
@@ -12901,6 +13049,7 @@
         },
         "SpotInstanceRequest": {
             "type": "structure",
+            "documentation": "<p>Describe a Spot Instance request.</p>",
             "members": [
                 {
                     "name": "SpotInstanceRequestId",
@@ -13013,6 +13162,7 @@
         },
         "SpotInstanceStateFault": {
             "type": "structure",
+            "documentation": "<p>Describes a Spot Instance state change.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -13030,6 +13180,7 @@
         },
         "SpotInstanceStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a Spot Instance request.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -13056,6 +13207,7 @@
         },
         "SpotPlacement": {
             "type": "structure",
+            "documentation": "<p>Describes Spot Instance placement.</p>",
             "members": [
                 {
                     "name": "AvailabilityZone",
@@ -13073,6 +13225,7 @@
         },
         "SpotPrice": {
             "type": "structure",
+            "documentation": "<p>Describes the maximum hourly price (bid) for any Spot Instance launched to fulfill the request.</p>",
             "members": [
                 {
                     "name": "InstanceType",
@@ -13149,6 +13302,7 @@
         },
         "StateReason": {
             "type": "structure",
+            "documentation": "<p>Describes a state change.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -13209,6 +13363,7 @@
         },
         "Storage": {
             "type": "structure",
+            "documentation": "<p>Describes the storage location for an instance store-backed AMI.</p>",
             "members": [
                 {
                     "name": "S3",
@@ -13222,6 +13377,7 @@
         },
         "Subnet": {
             "type": "structure",
+            "documentation": "<p>Describes a subnet.</p>",
             "members": [
                 {
                     "name": "SubnetId",
@@ -13295,6 +13451,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Describes a tag.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -13312,6 +13469,7 @@
         },
         "TagDescription": {
             "type": "structure",
+            "documentation": "<p>Describes a tag.</p>",
             "members": [
                 {
                     "name": "ResourceId",
@@ -13431,6 +13589,7 @@
         },
         "UnsuccessfulItem": {
             "type": "structure",
+            "documentation": "<p>Information about items that were not successfully processed in a batch call.</p>",
             "members": [
                 {
                     "name": "ResourceId",
@@ -13448,6 +13607,7 @@
         },
         "UnsuccessfulItemError": {
             "type": "structure",
+            "documentation": "<p>Information about the error that occured. For more information about errors, see <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html\">Error Codes</a>.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -13469,6 +13629,7 @@
         },
         "UserBucket": {
             "type": "structure",
+            "documentation": "<p>Describes the S3 bucket for the disk image.</p>",
             "members": [
                 {
                     "name": "S3Bucket",
@@ -13484,6 +13645,7 @@
         },
         "UserBucketDetails": {
             "type": "structure",
+            "documentation": "<p>Describes the S3 bucket for the disk image.</p>",
             "members": [
                 {
                     "name": "S3Bucket",
@@ -13501,6 +13663,7 @@
         },
         "UserData": {
             "type": "structure",
+            "documentation": "<p>Describes the user data to be made available to an instance.</p>",
             "members": [
                 {
                     "name": "Data",
@@ -13516,6 +13679,7 @@
         },
         "UserIdGroupPair": {
             "type": "structure",
+            "documentation": "<p>Describes a security group and AWS account ID pair. </p>",
             "members": [
                 {
                     "name": "UserId",
@@ -13551,6 +13715,7 @@
         },
         "VgwTelemetry": {
             "type": "structure",
+            "documentation": "<p>Describes telemetry for a VPN tunnel.</p>",
             "members": [
                 {
                     "name": "OutsideIpAddress",
@@ -13593,6 +13758,7 @@
         },
         "Volume": {
             "type": "structure",
+            "documentation": "<p>Describes a volume.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -13670,6 +13836,7 @@
         },
         "VolumeAttachment": {
             "type": "structure",
+            "documentation": "<p>Describes volume attachment details.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -13721,6 +13888,7 @@
         },
         "VolumeDetail": {
             "type": "structure",
+            "documentation": "<p>Describes an EBS volume.</p>",
             "members": [
                 {
                     "name": "Size",
@@ -13743,6 +13911,7 @@
         },
         "VolumeStatusAction": {
             "type": "structure",
+            "documentation": "<p>Describes a volume status operation code.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -13776,6 +13945,7 @@
         },
         "VolumeStatusDetails": {
             "type": "structure",
+            "documentation": "<p>Describes a volume status.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -13797,6 +13967,7 @@
         },
         "VolumeStatusEvent": {
             "type": "structure",
+            "documentation": "<p>Describes a volume status event.</p>",
             "members": [
                 {
                     "name": "EventType",
@@ -13836,6 +14007,7 @@
         },
         "VolumeStatusInfo": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a volume.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -13856,6 +14028,7 @@
         },
         "VolumeStatusItem": {
             "type": "structure",
+            "documentation": "<p>Describes the volume status.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -13901,6 +14074,7 @@
         },
         "Vpc": {
             "type": "structure",
+            "documentation": "<p>Describes a VPC.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -13948,6 +14122,7 @@
         },
         "VpcAttachment": {
             "type": "structure",
+            "documentation": "<p>Describes an attachment between a virtual private gateway and a VPC.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -13972,6 +14147,7 @@
         },
         "VpcClassicLink": {
             "type": "structure",
+            "documentation": "<p>Describes whether a VPC is enabled for ClassicLink.</p>",
             "members": [
                 {
                     "name": "VpcId",
@@ -14003,6 +14179,7 @@
         },
         "VpcEndpoint": {
             "type": "structure",
+            "documentation": "<p>Describes a VPC endpoint.</p>",
             "members": [
                 {
                     "name": "VpcEndpointId",
@@ -14062,6 +14239,7 @@
         },
         "VpcPeeringConnection": {
             "type": "structure",
+            "documentation": "<p>Describes a VPC peering connection.</p>",
             "members": [
                 {
                     "name": "AccepterVpcInfo",
@@ -14107,6 +14285,7 @@
         },
         "VpcPeeringConnectionStateReason": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a VPC peering connection.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -14127,6 +14306,7 @@
         },
         "VpcPeeringConnectionVpcInfo": {
             "type": "structure",
+            "documentation": "<p>Describes a VPC in a VPC peering connection.</p>",
             "members": [
                 {
                     "name": "CidrBlock",
@@ -14153,6 +14333,7 @@
         },
         "VpnConnection": {
             "type": "structure",
+            "documentation": "<p>Describes a VPN connection.</p>",
             "members": [
                 {
                     "name": "VpnConnectionId",
@@ -14226,6 +14407,7 @@
         },
         "VpnConnectionOptions": {
             "type": "structure",
+            "documentation": "<p>Describes VPN connection options.</p>",
             "members": [
                 {
                     "name": "StaticRoutesOnly",
@@ -14237,6 +14419,7 @@
         },
         "VpnConnectionOptionsSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes VPN connection options.</p>",
             "members": [
                 {
                     "name": "StaticRoutesOnly",
@@ -14248,6 +14431,7 @@
         },
         "VpnGateway": {
             "type": "structure",
+            "documentation": "<p>Describes a virtual private gateway.</p>",
             "members": [
                 {
                     "name": "VpnGatewayId",
@@ -14300,6 +14484,7 @@
         },
         "VpnStaticRoute": {
             "type": "structure",
+            "documentation": "<p>Describes a static route for a VPN connection.</p>",
             "members": [
                 {
                     "name": "DestinationCidrBlock",
@@ -14370,6 +14555,7 @@
         },
         "RequestSpotLaunchSpecification": {
             "type": "structure",
+            "documentation": "<p>Describes the launch specification for an instance.</p>",
             "members": [
                 {
                     "name": "ImageId",

--- a/libcloudcore/data/aws/ecs/service.json
+++ b/libcloudcore/data/aws/ecs/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -286,6 +290,7 @@
         },
         "ClientException": {
             "type": "structure",
+            "documentation": "<p>These errors are usually caused by something the client did, such as use an action or resource on behalf of a user that doesn't have permission to use the action or resource, or specify an identifier that is not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -295,6 +300,7 @@
         },
         "Cluster": {
             "type": "structure",
+            "documentation": "<p>A regional grouping of one or more container instances on which you can run task requests. Each account receives a default cluster the first time you use the Amazon ECS service, but you may also create other clusters. Clusters may contain more than one instance type simultaneously.</p>",
             "members": [
                 {
                     "name": "clusterArn",
@@ -335,14 +341,17 @@
         },
         "ClusterContainsContainerInstancesException": {
             "type": "structure",
+            "documentation": "<p>You cannot delete a cluster that has registered container instances. You must first deregister the container instances before you can delete the cluster. For more information, see <a>DeregisterContainerInstance</a>.</p>",
             "members": []
         },
         "ClusterContainsServicesException": {
             "type": "structure",
+            "documentation": "<p>You cannot delete a cluster that contains services. You must first update the service to reduce its desired task count to 0 and then delete the service. For more information, see <a>UpdateService</a> and <a>DeleteService</a>.</p>",
             "members": []
         },
         "ClusterNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified cluster could not be found. You can view your available clusters with <a>ListClusters</a>. Amazon ECS clusters are region-specific.</p>",
             "members": []
         },
         "Clusters": {
@@ -351,6 +360,7 @@
         },
         "Container": {
             "type": "structure",
+            "documentation": "<p>A docker container that is part of a task.</p>",
             "members": [
                 {
                     "name": "containerArn",
@@ -391,6 +401,7 @@
         },
         "ContainerDefinition": {
             "type": "structure",
+            "documentation": "<p>Container definitions are used in task definitions to describe the different containers that are launched as part of a task.</p>",
             "members": [
                 {
                     "name": "name",
@@ -460,6 +471,7 @@
         },
         "ContainerInstance": {
             "type": "structure",
+            "documentation": "<p>An Amazon EC2 instance that is running the Amazon ECS agent and has been registered with a cluster.</p>",
             "members": [
                 {
                     "name": "containerInstanceArn",
@@ -519,6 +531,7 @@
         },
         "ContainerOverride": {
             "type": "structure",
+            "documentation": "<p>The overrides that should be sent to a container.</p>",
             "members": [
                 {
                     "name": "name",
@@ -661,6 +674,7 @@
         },
         "Deployment": {
             "type": "structure",
+            "documentation": "<p>The details of an Amazon ECS service deployment.</p>",
             "members": [
                 {
                     "name": "id",
@@ -931,6 +945,7 @@
         },
         "Failure": {
             "type": "structure",
+            "documentation": "<p>A failed resource.</p>",
             "members": [
                 {
                     "name": "arn",
@@ -950,6 +965,7 @@
         },
         "HostVolumeProperties": {
             "type": "structure",
+            "documentation": "<p>Details on a container instance host volume.</p>",
             "members": [
                 {
                     "name": "sourcePath",
@@ -963,10 +979,12 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "<p>The specified parameter is invalid. Review the available parameters for the API request.</p>",
             "members": []
         },
         "KeyValuePair": {
             "type": "structure",
+            "documentation": "<p>A key and value pair object.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1222,6 +1240,7 @@
         },
         "LoadBalancer": {
             "type": "structure",
+            "documentation": "<p>Details on a load balancer that is used with a service.</p>",
             "members": [
                 {
                     "name": "loadBalancerName",
@@ -1249,10 +1268,12 @@
         },
         "MissingVersionException": {
             "type": "structure",
+            "documentation": "<p>Amazon ECS is unable to determine the current version of the Amazon ECS container agent on the container instance and does not have enough information to proceed with an update. This could be because the agent running on the container instance is an older or custom version that does not use our version information.</p>",
             "members": []
         },
         "MountPoint": {
             "type": "structure",
+            "documentation": "<p>Details on a volume mount point that is used in a container definition.</p>",
             "members": [
                 {
                     "name": "sourceVolume",
@@ -1277,6 +1298,7 @@
         },
         "NetworkBinding": {
             "type": "structure",
+            "documentation": "<p>Details on the network bindings between a container and its host container instance.</p>",
             "members": [
                 {
                     "name": "bindIP",
@@ -1306,10 +1328,12 @@
         },
         "NoUpdateAvailableException": {
             "type": "structure",
+            "documentation": "<p>There is no update available for this Amazon ECS container agent. This could be because the agent is already running the latest version, or it is so old that there is no update path to the current version.</p>",
             "members": []
         },
         "PortMapping": {
             "type": "structure",
+            "documentation": "<p>Port mappings allow containers to access ports on the host container instance to send or receive traffic. Port mappings are specified as part of the container definition.</p>",
             "members": [
                 {
                     "name": "containerPort",
@@ -1407,6 +1431,7 @@
         },
         "Resource": {
             "type": "structure",
+            "documentation": "<p>Describes the resources available for a container instance.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1491,6 +1516,7 @@
         },
         "ServerException": {
             "type": "structure",
+            "documentation": "<p>These errors are usually caused by a server-side issue.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1500,6 +1526,7 @@
         },
         "Service": {
             "type": "structure",
+            "documentation": "<p>Details on a service within a cluster</p>",
             "members": [
                 {
                     "name": "serviceArn",
@@ -1565,6 +1592,7 @@
         },
         "ServiceEvent": {
             "type": "structure",
+            "documentation": "<p>Details on an event associated with a service.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1589,10 +1617,12 @@
         },
         "ServiceNotActiveException": {
             "type": "structure",
+            "documentation": "<p>The specified service is not active. You cannot update a service that is not active. If you have previously deleted a service, you can recreate it with <a>CreateService</a>.</p>",
             "members": []
         },
         "ServiceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified service could not be found. You can view your available services with <a>ListServices</a>. Amazon ECS services are cluster-specific and region-specific.</p>",
             "members": []
         },
         "Services": {
@@ -1765,6 +1795,7 @@
         },
         "Task": {
             "type": "structure",
+            "documentation": "<p>Details on a task in a cluster.</p>",
             "members": [
                 {
                     "name": "taskArn",
@@ -1815,6 +1846,7 @@
         },
         "TaskDefinition": {
             "type": "structure",
+            "documentation": "<p>Details of a task definition.</p>",
             "members": [
                 {
                     "name": "taskDefinitionArn",
@@ -1853,6 +1885,7 @@
         },
         "TaskOverride": {
             "type": "structure",
+            "documentation": "<p>The overrides associated with a task.</p>",
             "members": [
                 {
                     "name": "containerOverrides",
@@ -1897,6 +1930,7 @@
         },
         "UpdateInProgressException": {
             "type": "structure",
+            "documentation": "<p>There is already a current Amazon ECS container agent update in progress on the specified container instance. If the container agent becomes disconnected while it is in a transitional stage, such as <code>PENDING</code> or <code>STAGING</code>, the update process can get stuck in that state. However, when the agent reconnects, it will resume where it stopped previously.</p>",
             "members": []
         },
         "UpdateServiceRequest": {
@@ -1936,6 +1970,7 @@
         },
         "VersionInfo": {
             "type": "structure",
+            "documentation": "<p>The Docker and Amazon ECS container agent version information on a container instance.</p>",
             "members": [
                 {
                     "name": "agentVersion",
@@ -1956,6 +1991,7 @@
         },
         "Volume": {
             "type": "structure",
+            "documentation": "<p>A data volume used in a task definition.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1971,6 +2007,7 @@
         },
         "VolumeFrom": {
             "type": "structure",
+            "documentation": "<p>Details on a data volume from another container.</p>",
             "members": [
                 {
                     "name": "sourceContainer",

--- a/libcloudcore/data/aws/efs/service.json
+++ b/libcloudcore/data/aws/efs/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -118,6 +122,7 @@
         },
         "BadRequest": {
             "type": "structure",
+            "documentation": "<p>Returned if the request is malformed or contains an error such as an invalid parameter value or a missing required parameter.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -227,6 +232,7 @@
         },
         "DependencyTimeout": {
             "type": "structure",
+            "documentation": "<p>The service timed out trying to fulfill the request, and the client should try the call again.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -413,6 +419,7 @@
         },
         "FileSystemAlreadyExists": {
             "type": "structure",
+            "documentation": "<p>Returned if the file system you are trying to create already exists, with the creation token you provided.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -430,6 +437,7 @@
         },
         "FileSystemDescription": {
             "type": "structure",
+            "documentation": "<p>This object provides description of a file system.</p>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -482,6 +490,7 @@
         },
         "FileSystemInUse": {
             "type": "structure",
+            "documentation": "<p>Returned if a file system has mount targets. </p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -495,6 +504,7 @@
         },
         "FileSystemLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>Returned if the AWS account has already created maximum number of file systems allowed per account. </p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -508,6 +518,7 @@
         },
         "FileSystemNotFound": {
             "type": "structure",
+            "documentation": "<p>Returned if the specified <code>FileSystemId</code> does not exist in the requester's AWS account.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -521,6 +532,7 @@
         },
         "FileSystemSize": {
             "type": "structure",
+            "documentation": "<p>This object provides the latest known metered size, in bytes, of data stored in the file system, in its <code>Value</code> field, and the time at which that size was determined in its <code>Timestamp</code> field. Note that the value does not represent the size of a consistent snapshot of the file system, but it is eventually consistent when there are no writes to the file system. That is, the value will represent the actual size only if the file system is not modified for a period longer than a couple of hours. Otherwise, the value is not necessarily the exact size the file system was at any instant in time.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -539,6 +551,7 @@
         },
         "IncorrectFileSystemLifeCycleState": {
             "type": "structure",
+            "documentation": "<p>Returned if the file system's life cycle state is not \"created\".</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -552,6 +565,7 @@
         },
         "IncorrectMountTargetState": {
             "type": "structure",
+            "documentation": "<p>Returned if the mount target is not in the correct state for the operation.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -565,6 +579,7 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>Returned if an error occurred on the server side.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -581,6 +596,7 @@
         },
         "IpAddressInUse": {
             "type": "structure",
+            "documentation": "<p>Returned if the request specified an <code>IpAddress</code> that is already in use in the subnet.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -620,6 +636,7 @@
         },
         "MountTargetConflict": {
             "type": "structure",
+            "documentation": "<p>Returned if the mount target would violate one of the specified restrictions based on the file system's existing mount targets.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -636,6 +653,7 @@
         },
         "MountTargetDescription": {
             "type": "structure",
+            "documentation": "<p>This object provides description of a mount target.</p>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -683,6 +701,7 @@
         },
         "MountTargetNotFound": {
             "type": "structure",
+            "documentation": "<p>Returned if there is no mount target with the specified ID is found in the caller's account.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -699,6 +718,7 @@
         },
         "NetworkInterfaceLimitExceeded": {
             "type": "structure",
+            "documentation": "<p> The calling account has reached the ENI limit for the specific AWS region. Client should try to delete some ENIs or get its account limit raised. For more information, go to <a href=\"http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Appendix_Limits.html\">Amazon VPC Limits</a> in the Amazon Virtual Private Cloud User Guide (see the Network interfaces per VPC entry in the table). </p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -712,6 +732,7 @@
         },
         "NoFreeAddressesInSubnet": {
             "type": "structure",
+            "documentation": "<p>Returned if <code>IpAddress</code> was not specified in the request and there are no free IP addresses in the subnet.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -728,6 +749,7 @@
         },
         "SecurityGroupLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>Returned if the size of <code>SecurityGroups</code> specified in the request is greater than five.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -741,6 +763,7 @@
         },
         "SecurityGroupNotFound": {
             "type": "structure",
+            "documentation": "<p>Returned if one of the specified security groups does not exist in the subnet's VPC.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -761,6 +784,7 @@
         },
         "SubnetNotFound": {
             "type": "structure",
+            "documentation": "<p>Returned if there is no subnet with ID <code>SubnetId</code> provided in the request.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -774,6 +798,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>A tag is a pair of key and value. The allowed characters in keys and values are letters, whitespace, and numbers, representable in UTF-8, and the characters '+', '-', '=', '.', '_', ':', and '/'. </p>",
             "members": [
                 {
                     "name": "Key",

--- a/libcloudcore/data/aws/elasticache/service.json
+++ b/libcloudcore/data/aws/elasticache/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://elasticache.amazonaws.com/doc/2015-02-02/"
         }
@@ -362,6 +365,7 @@
         },
         "AddTagsToResourceMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an <i>AddTagsToResource</i> action.</p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -377,14 +381,17 @@
         },
         "AuthorizationAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon EC2 security group is already authorized for the specified cache security group.</p>",
             "members": []
         },
         "AuthorizationNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon EC2 security group is not authorized for the specified cache security group.</p>",
             "members": []
         },
         "AuthorizeCacheSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of an <i>AuthorizeCacheSecurityGroupIngress</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -408,6 +415,7 @@
         },
         "AvailabilityZone": {
             "type": "structure",
+            "documentation": "<p>Describes an Availability Zone in which the cache cluster is launched.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -431,6 +439,7 @@
         },
         "CacheCluster": {
             "type": "structure",
+            "documentation": "<p>Contains all of the attributes of a specific cache cluster.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -542,6 +551,7 @@
         },
         "CacheClusterAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>You already have a cache cluster with the given identifier.</p>",
             "members": []
         },
         "CacheClusterList": {
@@ -550,6 +560,7 @@
         },
         "CacheClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeCacheClusters</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -565,10 +576,12 @@
         },
         "CacheClusterNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested cache cluster ID does not refer to an existing cache cluster.</p>",
             "members": []
         },
         "CacheEngineVersion": {
             "type": "structure",
+            "documentation": "<p>Provides all of the details about a particular cache engine version.</p>",
             "members": [
                 {
                     "name": "Engine",
@@ -603,6 +616,7 @@
         },
         "CacheEngineVersionMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>DescribeCacheEngineVersions</a> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -618,6 +632,7 @@
         },
         "CacheNode": {
             "type": "structure",
+            "documentation": "<p>Represents an individual cache node within a cache cluster. Each cache node runs its own instance of the cluster's protocol-compliant caching software - either Memcached or Redis.</p> <p>Valid node types are as follows:</p> <ul> <li>General purpose: <ul> <li>Current generation: <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code>, <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code></li> <li>Previous generation: <code>cache.t1.micro</code>, <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code></li> </ul></li> <li>Compute optimized: <code>cache.c1.xlarge</code></li> <li>Memory optimized <ul> <li>Current generation: <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code></li> <li>Previous generation: <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code></li> </ul></li> </ul> <p><b>Notes:</b></p> <ul> <li>All t2 instances are created in an Amazon Virtual Private Cloud (VPC).</li> <li>Redis backup/restore is not supported for t2 instances.</li> <li>Redis Append-only files (AOF) functionality is not supported for t1 or t2 instances.</li> </ul> <p>For a complete listing of cache node types and specifications, see <a href=\"http://aws.amazon.com/elasticache/details\">Amazon ElastiCache Product Features and Details</a> and <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Memcached.html#CacheParameterGroups.Memcached.NodeSpecific\">Cache Node Type-Specific Parameters for Memcached</a> or <a href=\"http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheParameterGroups.Redis.html#CacheParameterGroups.Redis.NodeSpecific\">Cache Node Type-Specific Parameters for Redis</a>. </p>",
             "members": [
                 {
                     "name": "CacheNodeId",
@@ -666,6 +681,7 @@
         },
         "CacheNodeTypeSpecificParameter": {
             "type": "structure",
+            "documentation": "<p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cache cluster, a <i>cache.m1.large</i> cache node type would have a larger <i>maxmemory</i> value than a <i>cache.m1.small</i> type.</p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -715,6 +731,7 @@
         },
         "CacheNodeTypeSpecificValue": {
             "type": "structure",
+            "documentation": "<p>A value that applies only to a certain cache node type.</p>",
             "members": [
                 {
                     "name": "CacheNodeType",
@@ -734,6 +751,7 @@
         },
         "CacheParameterGroup": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>CreateCacheParameterGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -754,10 +772,12 @@
         },
         "CacheParameterGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>A cache parameter group with the requested name already exists.</p>",
             "members": []
         },
         "CacheParameterGroupDetails": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeCacheParameters</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -782,6 +802,7 @@
         },
         "CacheParameterGroupNameMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of one of the following actions:</p> <ul> <li> <i>ModifyCacheParameterGroup</i> </li> <li> <i>ResetCacheParameterGroup</i> </li> </ul>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -792,14 +813,17 @@
         },
         "CacheParameterGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The requested cache parameter group name does not refer to an existing cache parameter group.</p>",
             "members": []
         },
         "CacheParameterGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the maximum number of cache security groups.</p>",
             "members": []
         },
         "CacheParameterGroupStatus": {
             "type": "structure",
+            "documentation": "<p>The status of the cache parameter group.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -820,6 +844,7 @@
         },
         "CacheParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeCacheParameterGroups</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -835,6 +860,7 @@
         },
         "CacheSecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Represents the output of one of the following actions:</p> <ul> <li> <i>AuthorizeCacheSecurityGroupIngress</i> </li> <li> <i>CreateCacheSecurityGroup</i> </li> <li> <i>RevokeCacheSecurityGroupIngress</i> </li> </ul>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -860,10 +886,12 @@
         },
         "CacheSecurityGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>A cache security group with the specified name already exists.</p>",
             "members": []
         },
         "CacheSecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p>Represents a cache cluster's status within a particular cache security group.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -883,6 +911,7 @@
         },
         "CacheSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeCacheSecurityGroups</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -902,10 +931,12 @@
         },
         "CacheSecurityGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The requested cache security group name does not refer to an existing cache security group.</p>",
             "members": []
         },
         "CacheSecurityGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of cache security groups.</p>",
             "members": []
         },
         "CacheSecurityGroups": {
@@ -914,6 +945,7 @@
         },
         "CacheSubnetGroup": {
             "type": "structure",
+            "documentation": "<p>Represents the output of one of the following actions:</p> <ul> <li> <i>CreateCacheSubnetGroup</i> </li> <li> <i>ModifyCacheSubnetGroup</i> </li> </ul>",
             "members": [
                 {
                     "name": "CacheSubnetGroupName",
@@ -939,14 +971,17 @@
         },
         "CacheSubnetGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The requested cache subnet group name is already in use by an existing cache subnet group.</p>",
             "members": []
         },
         "CacheSubnetGroupInUse": {
             "type": "structure",
+            "documentation": "<p>The requested cache subnet group is currently in use.</p>",
             "members": []
         },
         "CacheSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeCacheSubnetGroups</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -962,10 +997,12 @@
         },
         "CacheSubnetGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested cache subnet group name does not refer to an existing cache subnet group.</p>",
             "members": []
         },
         "CacheSubnetGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of cache subnet groups.</p>",
             "members": []
         },
         "CacheSubnetGroups": {
@@ -974,6 +1011,7 @@
         },
         "CacheSubnetQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of subnets in a cache subnet group.</p>",
             "members": []
         },
         "ClusterIdList": {
@@ -982,10 +1020,12 @@
         },
         "ClusterQuotaForCustomerExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of cache clusters per customer.</p>",
             "members": []
         },
         "CopySnapshotMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CopySnapshotMessage</i> action.</p>",
             "members": [
                 {
                     "name": "SourceSnapshotName",
@@ -1001,6 +1041,7 @@
         },
         "CreateCacheClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateCacheCluster</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -1116,6 +1157,7 @@
         },
         "CreateCacheParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateCacheParameterGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -1136,6 +1178,7 @@
         },
         "CreateCacheSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateCacheSecurityGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -1151,6 +1194,7 @@
         },
         "CreateCacheSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateCacheSubnetGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSubnetGroupName",
@@ -1171,6 +1215,7 @@
         },
         "CreateReplicationGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateReplicationGroup</i> action.</p>",
             "members": [
                 {
                     "name": "ReplicationGroupId",
@@ -1286,6 +1331,7 @@
         },
         "CreateSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>CreateSnapshot</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -1301,6 +1347,7 @@
         },
         "DeleteCacheClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteCacheCluster</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -1316,6 +1363,7 @@
         },
         "DeleteCacheParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteCacheParameterGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -1326,6 +1374,7 @@
         },
         "DeleteCacheSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteCacheSecurityGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -1336,6 +1385,7 @@
         },
         "DeleteCacheSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteCacheSubnetGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSubnetGroupName",
@@ -1346,6 +1396,7 @@
         },
         "DeleteReplicationGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteReplicationGroup</i> action.</p>",
             "members": [
                 {
                     "name": "ReplicationGroupId",
@@ -1366,6 +1417,7 @@
         },
         "DeleteSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DeleteSnapshot</i> action.</p>",
             "members": [
                 {
                     "name": "SnapshotName",
@@ -1376,6 +1428,7 @@
         },
         "DescribeCacheClustersMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheClusters</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -1401,6 +1454,7 @@
         },
         "DescribeCacheEngineVersionsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheEngineVersions</i> action.</p>",
             "members": [
                 {
                     "name": "Engine",
@@ -1436,6 +1490,7 @@
         },
         "DescribeCacheParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheParameterGroups</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -1456,6 +1511,7 @@
         },
         "DescribeCacheParametersMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheParameters</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -1481,6 +1537,7 @@
         },
         "DescribeCacheSecurityGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheSecurityGroups</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -1501,6 +1558,7 @@
         },
         "DescribeCacheSubnetGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeCacheSubnetGroups</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSubnetGroupName",
@@ -1521,6 +1579,7 @@
         },
         "DescribeEngineDefaultParametersMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeEngineDefaultParameters</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupFamily",
@@ -1541,6 +1600,7 @@
         },
         "DescribeEventsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeEvents</i> action.</p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -1581,6 +1641,7 @@
         },
         "DescribeReplicationGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeReplicationGroups</i> action.</p>",
             "members": [
                 {
                     "name": "ReplicationGroupId",
@@ -1601,6 +1662,7 @@
         },
         "DescribeReservedCacheNodesMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeReservedCacheNodes</i> action.</p>",
             "members": [
                 {
                     "name": "ReservedCacheNodeId",
@@ -1646,6 +1708,7 @@
         },
         "DescribeReservedCacheNodesOfferingsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeReservedCacheNodesOfferings</i> action.</p>",
             "members": [
                 {
                     "name": "ReservedCacheNodesOfferingId",
@@ -1686,6 +1749,7 @@
         },
         "DescribeSnapshotsListMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeSnapshots</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1701,6 +1765,7 @@
         },
         "DescribeSnapshotsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>DescribeSnapshotsMessage</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -1734,6 +1799,7 @@
         },
         "EC2SecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Provides ownership and status information for an Amazon EC2 security group.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -1758,6 +1824,7 @@
         },
         "Endpoint": {
             "type": "structure",
+            "documentation": "<p>Represents the information required for client programs to connect to a cache node.</p>",
             "members": [
                 {
                     "name": "Address",
@@ -1773,6 +1840,7 @@
         },
         "EngineDefaults": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeEngineDefaultParameters</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupFamily",
@@ -1798,6 +1866,7 @@
         },
         "Event": {
             "type": "structure",
+            "documentation": "<p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a cache cluster, adding or removing a cache node, or rebooting a node.</p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -1827,6 +1896,7 @@
         },
         "EventsMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeEvents</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1842,6 +1912,7 @@
         },
         "InsufficientCacheClusterCapacityFault": {
             "type": "structure",
+            "documentation": "<p>The requested cache node type is not available in the specified Availability Zone.</p>",
             "members": []
         },
         "Integer": {
@@ -1852,22 +1923,27 @@
         },
         "InvalidARNFault": {
             "type": "structure",
+            "documentation": "<p>The requested Amazon Resource Name (ARN) does not refer to an existing resource.</p>",
             "members": []
         },
         "InvalidCacheClusterStateFault": {
             "type": "structure",
+            "documentation": "<p>The requested cache cluster is not in the <i>available</i> state.</p>",
             "members": []
         },
         "InvalidCacheParameterGroupStateFault": {
             "type": "structure",
+            "documentation": "<p>The current state of the cache parameter group does not allow the requested action to occur. </p>",
             "members": []
         },
         "InvalidCacheSecurityGroupStateFault": {
             "type": "structure",
+            "documentation": "<p>The current state of the cache security group does not allow deletion.</p>",
             "members": []
         },
         "InvalidParameterCombinationException": {
             "type": "structure",
+            "documentation": "<p>Two or more incompatible parameters were specified.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1878,6 +1954,7 @@
         },
         "InvalidParameterValueException": {
             "type": "structure",
+            "documentation": "<p>The value for a parameter is invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1888,18 +1965,22 @@
         },
         "InvalidReplicationGroupStateFault": {
             "type": "structure",
+            "documentation": "<p>The requested replication group is not in the <i>available</i> state.</p>",
             "members": []
         },
         "InvalidSnapshotStateFault": {
             "type": "structure",
+            "documentation": "<p>The current state of the snapshot does not allow the requested action to occur.</p>",
             "members": []
         },
         "InvalidSubnet": {
             "type": "structure",
+            "documentation": "<p>An invalid subnet identifier was specified.</p>",
             "members": []
         },
         "InvalidVPCNetworkStateFault": {
             "type": "structure",
+            "documentation": "<p>The VPC network is in an invalid state.</p>",
             "members": []
         },
         "KeyList": {
@@ -1908,6 +1989,7 @@
         },
         "ListTagsForResourceMessage": {
             "type": "structure",
+            "documentation": "<p>The input parameters for the <i>ListTagsForResource</i> action.</p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -1918,6 +2000,7 @@
         },
         "ModifyCacheClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ModifyCacheCluster</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -2003,6 +2086,7 @@
         },
         "ModifyCacheParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ModifyCacheParameterGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -2018,6 +2102,7 @@
         },
         "ModifyCacheSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ModifyCacheSubnetGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSubnetGroupName",
@@ -2038,6 +2123,7 @@
         },
         "ModifyReplicationGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ModifyReplicationGroups</i> action.</p>",
             "members": [
                 {
                     "name": "ReplicationGroupId",
@@ -2123,6 +2209,7 @@
         },
         "NodeGroup": {
             "type": "structure",
+            "documentation": "<p>Represents a collection of cache nodes in a replication group.</p>",
             "members": [
                 {
                     "name": "NodeGroupId",
@@ -2151,6 +2238,7 @@
         },
         "NodeGroupMember": {
             "type": "structure",
+            "documentation": "<p>Represents a single node within a node group.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -2184,14 +2272,17 @@
         },
         "NodeQuotaForClusterExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of cache nodes in a single cache cluster.</p>",
             "members": []
         },
         "NodeQuotaForCustomerExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the allowed number of cache nodes per customer. </p>",
             "members": []
         },
         "NodeSnapshot": {
             "type": "structure",
+            "documentation": "<p>Represents an individual cache node in a snapshot of a cache cluster.</p>",
             "members": [
                 {
                     "name": "CacheNodeId",
@@ -2221,6 +2312,7 @@
         },
         "NotificationConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes a notification topic and its status. Notification topics are used for publishing ElastiCache events to subscribers using Amazon Simple Notification Service (SNS).</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -2236,6 +2328,7 @@
         },
         "Parameter": {
             "type": "structure",
+            "documentation": "<p>Describes an individual setting that controls some aspect of ElastiCache behavior.</p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -2281,6 +2374,7 @@
         },
         "ParameterNameValue": {
             "type": "structure",
+            "documentation": "<p>Describes a name-value pair that is used to update the value of a parameter.</p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -2307,6 +2401,7 @@
         },
         "PendingModifiedValues": {
             "type": "structure",
+            "documentation": "<p>A group of settings that will be applied to the cache cluster in the future, or that are currently being applied.</p>",
             "members": [
                 {
                     "name": "NumCacheNodes",
@@ -2331,6 +2426,7 @@
         },
         "PurchaseReservedCacheNodesOfferingMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>PurchaseReservedCacheNodesOffering</i> action.</p>",
             "members": [
                 {
                     "name": "ReservedCacheNodesOfferingId",
@@ -2351,6 +2447,7 @@
         },
         "RebootCacheClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>RebootCacheCluster</i> action.</p>",
             "members": [
                 {
                     "name": "CacheClusterId",
@@ -2366,6 +2463,7 @@
         },
         "RecurringCharge": {
             "type": "structure",
+            "documentation": "<p>Contains the specific price and frequency of a recurring charges for a reserved cache node, or for a reserved cache node offering.</p>",
             "members": [
                 {
                     "name": "RecurringChargeAmount",
@@ -2385,6 +2483,7 @@
         },
         "RemoveTagsFromResourceMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>RemoveTagsFromResource</i> action.</p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -2400,6 +2499,7 @@
         },
         "ReplicationGroup": {
             "type": "structure",
+            "documentation": "<p>Contains all of the attributes of a specific replication group.</p>",
             "members": [
                 {
                     "name": "ReplicationGroupId",
@@ -2445,6 +2545,7 @@
         },
         "ReplicationGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>The specified replication group already exists.</p>",
             "members": []
         },
         "ReplicationGroupList": {
@@ -2453,6 +2554,7 @@
         },
         "ReplicationGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeReplicationGroups</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2468,10 +2570,12 @@
         },
         "ReplicationGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The specified replication group does not exist.</p>",
             "members": []
         },
         "ReplicationGroupPendingModifiedValues": {
             "type": "structure",
+            "documentation": "<p>The settings to be applied to the replication group, either immediately or during the next maintenance window.</p>",
             "members": [
                 {
                     "name": "PrimaryClusterId",
@@ -2487,6 +2591,7 @@
         },
         "ReservedCacheNode": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>PurchaseReservedCacheNodesOffering</i> action.</p>",
             "members": [
                 {
                     "name": "ReservedCacheNodeId",
@@ -2552,6 +2657,7 @@
         },
         "ReservedCacheNodeAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>You already have a reservation with the given identifier.</p>",
             "members": []
         },
         "ReservedCacheNodeList": {
@@ -2560,6 +2666,7 @@
         },
         "ReservedCacheNodeMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeReservedCacheNodes</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2575,14 +2682,17 @@
         },
         "ReservedCacheNodeNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested reserved cache node was not found.</p>",
             "members": []
         },
         "ReservedCacheNodeQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the user's cache node quota.</p>",
             "members": []
         },
         "ReservedCacheNodesOffering": {
             "type": "structure",
+            "documentation": "<p>Describes all of the attributes of a reserved cache node offering.</p>",
             "members": [
                 {
                     "name": "ReservedCacheNodesOfferingId",
@@ -2632,6 +2742,7 @@
         },
         "ReservedCacheNodesOfferingMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <i>DescribeReservedCacheNodesOfferings</i> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2647,10 +2758,12 @@
         },
         "ReservedCacheNodesOfferingNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested cache node offering does not exist.</p>",
             "members": []
         },
         "ResetCacheParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>ResetCacheParameterGroup</i> action.</p>",
             "members": [
                 {
                     "name": "CacheParameterGroupName",
@@ -2671,6 +2784,7 @@
         },
         "RevokeCacheSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the input of a <i>RevokeCacheSecurityGroupIngress</i> action.</p>",
             "members": [
                 {
                     "name": "CacheSecurityGroupName",
@@ -2695,6 +2809,7 @@
         },
         "SecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p>Represents a single cache security group and its status.</p>",
             "members": [
                 {
                     "name": "SecurityGroupId",
@@ -2714,6 +2829,7 @@
         },
         "Snapshot": {
             "type": "structure",
+            "documentation": "<p>Represents a copy of an entire cache cluster as of the time when the snapshot was taken.</p>",
             "members": [
                 {
                     "name": "SnapshotName",
@@ -2819,6 +2935,7 @@
         },
         "SnapshotAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>You already have a snapshot with the given name.</p>",
             "members": []
         },
         "SnapshotArnsList": {
@@ -2827,6 +2944,7 @@
         },
         "SnapshotFeatureNotSupportedFault": {
             "type": "structure",
+            "documentation": "<p>You attempted one of the following actions:</p> <ul> <li> <p>Creating a snapshot of a Redis cache cluster running on a <i>t1.micro</i> cache node.</p> </li> <li> <p>Creating a snapshot of a cache cluster that is running Memcached rather than Redis.</p> </li> </ul> <p>Neither of these are supported by ElastiCache.</p>",
             "members": []
         },
         "SnapshotList": {
@@ -2835,10 +2953,12 @@
         },
         "SnapshotNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested snapshot name does not refer to an existing snapshot.</p>",
             "members": []
         },
         "SnapshotQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would exceed the maximum number of snapshots.</p>",
             "members": []
         },
         "SourceType": {
@@ -2849,6 +2969,7 @@
         },
         "Subnet": {
             "type": "structure",
+            "documentation": "<p>Represents the subnet associated with a cache cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with ElastiCache.</p>",
             "members": [
                 {
                     "name": "SubnetIdentifier",
@@ -2868,6 +2989,7 @@
         },
         "SubnetInUse": {
             "type": "structure",
+            "documentation": "<p>The requested subnet is being used by another cache subnet group.</p>",
             "members": []
         },
         "SubnetList": {
@@ -2879,6 +3001,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>A cost allocation Tag that can be added to an ElastiCache cluster or replication group. Tags are composed of a Key/Value pair. A tag with a null Value is permitted.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -2898,6 +3021,7 @@
         },
         "TagListMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the output from the <i>AddTagsToResource</i>, <i>ListTagsOnResource</i>, and <i>RemoveTagsFromResource</i> actions.</p>",
             "members": [
                 {
                     "name": "TagList",
@@ -2908,10 +3032,12 @@
         },
         "TagNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested tag was not found on this resource.</p>",
             "members": []
         },
         "TagQuotaPerResourceExceeded": {
             "type": "structure",
+            "documentation": "<p>The request cannot be processed because it would cause the resource to have more than the allowed number of tags. The maximum number of tags permitted on a resource is 10.</p>",
             "members": []
         },
         "AuthorizeCacheSecurityGroupIngressResult": {

--- a/libcloudcore/data/aws/elasticbeanstalk/service.json
+++ b/libcloudcore/data/aws/elasticbeanstalk/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://elasticbeanstalk.amazonaws.com/docs/2010-12-01/"
         }
@@ -272,6 +275,7 @@
     "shapes": {
         "AbortEnvironmentUpdateMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -290,6 +294,7 @@
         },
         "ApplicationDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the properties of an application.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -329,6 +334,7 @@
         },
         "ApplicationDescriptionMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a single description of an application.</p>",
             "members": [
                 {
                     "name": "Application",
@@ -339,6 +345,7 @@
         },
         "ApplicationDescriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a list of application descriptions.</p>",
             "members": [
                 {
                     "name": "Applications",
@@ -356,6 +363,7 @@
         },
         "ApplicationVersionDescription": {
             "type": "structure",
+            "documentation": "<p> Describes the properties of an application version. </p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -395,6 +403,7 @@
         },
         "ApplicationVersionDescriptionMessage": {
             "type": "structure",
+            "documentation": "<p> Result message wrapping a single description of an application version. </p>",
             "members": [
                 {
                     "name": "ApplicationVersion",
@@ -405,6 +414,7 @@
         },
         "ApplicationVersionDescriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message wrapping a list of application version descriptions.</p>",
             "members": [
                 {
                     "name": "ApplicationVersions",
@@ -418,6 +428,7 @@
         },
         "AutoScalingGroup": {
             "type": "structure",
+            "documentation": "<p> Describes an Auto Scaling launch configuration. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -440,6 +451,7 @@
         },
         "CheckDNSAvailabilityMessage": {
             "type": "structure",
+            "documentation": "<p>Results message indicating whether a CNAME is available.</p>",
             "members": [
                 {
                     "name": "CNAMEPrefix",
@@ -450,6 +462,7 @@
         },
         "CheckDNSAvailabilityResultMessage": {
             "type": "structure",
+            "documentation": "<p>Indicates if the specified CNAME is available.</p>",
             "members": [
                 {
                     "name": "Available",
@@ -474,6 +487,7 @@
         },
         "ConfigurationOptionDescription": {
             "type": "structure",
+            "documentation": "<p> Describes the possible values for a configuration option. </p>",
             "members": [
                 {
                     "name": "Namespace",
@@ -548,6 +562,7 @@
         },
         "ConfigurationOptionSetting": {
             "type": "structure",
+            "documentation": "<p> A specification identifying an individual configuration option along with its current value. For a list of possible option values, go to <a href=\"http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html\">Option Values</a> in the <i>AWS Elastic Beanstalk Developer Guide</i>. </p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -586,6 +601,7 @@
         },
         "ConfigurationOptionsDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the settings for a specified configuration set.</p>",
             "members": [
                 {
                     "name": "SolutionStackName",
@@ -601,6 +617,7 @@
         },
         "ConfigurationSettingsDescription": {
             "type": "structure",
+            "documentation": "<p> Describes the settings for a configuration set. </p>",
             "members": [
                 {
                     "name": "SolutionStackName",
@@ -655,6 +672,7 @@
         },
         "ConfigurationSettingsDescriptions": {
             "type": "structure",
+            "documentation": "<p>The results from a request to change the configuration settings of an environment.</p>",
             "members": [
                 {
                     "name": "ConfigurationSettings",
@@ -665,6 +683,7 @@
         },
         "ConfigurationSettingsValidationMessages": {
             "type": "structure",
+            "documentation": "<p>Provides a list of validation messages.</p>",
             "members": [
                 {
                     "name": "Messages",
@@ -682,6 +701,7 @@
         },
         "CreateApplicationMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -697,6 +717,7 @@
         },
         "CreateApplicationVersionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -727,6 +748,7 @@
         },
         "CreateConfigurationTemplateMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -767,6 +789,7 @@
         },
         "CreateEnvironmentMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -827,6 +850,7 @@
         },
         "CreateStorageLocationResultMessage": {
             "type": "structure",
+            "documentation": "<p>Results of a <a>CreateStorageLocationResult</a> call.</p>",
             "members": [
                 {
                     "name": "S3Bucket",
@@ -846,6 +870,7 @@
         },
         "DeleteApplicationMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -861,6 +886,7 @@
         },
         "DeleteApplicationVersionMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -881,6 +907,7 @@
         },
         "DeleteConfigurationTemplateMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -896,6 +923,7 @@
         },
         "DeleteEnvironmentConfigurationMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -914,6 +942,7 @@
         },
         "DescribeApplicationVersionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a list of configuration descriptions.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -929,6 +958,7 @@
         },
         "DescribeApplicationsMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationNames",
@@ -939,6 +969,7 @@
         },
         "DescribeConfigurationOptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containig a list of application version descriptions. </p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -969,6 +1000,7 @@
         },
         "DescribeConfigurationSettingsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing all of the configuration settings for a specified solution stack or configuration template.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -989,6 +1021,7 @@
         },
         "DescribeEnvironmentResourcesMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1004,6 +1037,7 @@
         },
         "DescribeEnvironmentsMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1039,6 +1073,7 @@
         },
         "DescribeEventsMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1108,6 +1143,7 @@
         },
         "EnvironmentDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the properties of an environment.</p>",
             "members": [
                 {
                     "name": "EnvironmentName",
@@ -1197,6 +1233,7 @@
         },
         "EnvironmentDescriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a list of environment descriptions.</p>",
             "members": [
                 {
                     "name": "Environments",
@@ -1217,6 +1254,7 @@
         },
         "EnvironmentInfoDescription": {
             "type": "structure",
+            "documentation": "<p>The information retrieved from the Amazon EC2 instances.</p>",
             "members": [
                 {
                     "name": "InfoType",
@@ -1256,6 +1294,7 @@
         },
         "EnvironmentResourceDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the AWS resources in use by this environment. This data is live.</p>",
             "members": [
                 {
                     "name": "EnvironmentName",
@@ -1296,6 +1335,7 @@
         },
         "EnvironmentResourceDescriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a list of environment resource descriptions. </p>",
             "members": [
                 {
                     "name": "EnvironmentResources",
@@ -1306,6 +1346,7 @@
         },
         "EnvironmentResourcesDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the AWS resources in use by this environment. This data is not live data.</p>",
             "members": [
                 {
                     "name": "LoadBalancer",
@@ -1319,6 +1360,7 @@
         },
         "EnvironmentTier": {
             "type": "structure",
+            "documentation": "<p> Describes the properties of an environment tier </p>",
             "members": [
                 {
                     "name": "Name",
@@ -1342,6 +1384,7 @@
         },
         "EventDescription": {
             "type": "structure",
+            "documentation": "<p>Describes an event.</p>",
             "members": [
                 {
                     "name": "EventDate",
@@ -1391,6 +1434,7 @@
         },
         "EventDescriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Result message wrapping a list of event descriptions.</p>",
             "members": [
                 {
                     "name": "Events",
@@ -1421,6 +1465,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>The description of an Amazon EC2 instance.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1435,6 +1480,7 @@
         },
         "InsufficientPrivilegesException": {
             "type": "structure",
+            "documentation": "<p>Unable to perform the specified operation because the user does not have enough privileges for one of more downstream aws services</p>",
             "members": []
         },
         "Integer": {
@@ -1442,6 +1488,7 @@
         },
         "LaunchConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes an Auto Scaling launch configuration.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1456,6 +1503,7 @@
         },
         "ListAvailableSolutionStacksResultMessage": {
             "type": "structure",
+            "documentation": "<p>A list of available AWS Elastic Beanstalk solution stacks. </p>",
             "members": [
                 {
                     "name": "SolutionStacks",
@@ -1471,6 +1519,7 @@
         },
         "Listener": {
             "type": "structure",
+            "documentation": "<p>Describes the properties of a Listener for the LoadBalancer.</p>",
             "members": [
                 {
                     "name": "Protocol",
@@ -1486,6 +1535,7 @@
         },
         "LoadBalancer": {
             "type": "structure",
+            "documentation": "<p>Describes a LoadBalancer.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1496,6 +1546,7 @@
         },
         "LoadBalancerDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the details of a LoadBalancer.</p>",
             "members": [
                 {
                     "name": "LoadBalancerName",
@@ -1530,6 +1581,7 @@
         },
         "OperationInProgressException": {
             "type": "structure",
+            "documentation": "<p>Unable to perform the specified operation because another operation is already in progress affecting an an element in this activity.</p>",
             "members": []
         },
         "OptionNamespace": {
@@ -1546,6 +1598,7 @@
         },
         "OptionRestrictionRegex": {
             "type": "structure",
+            "documentation": "<p> A regular expression representing a restriction on a string configuration option value. </p>",
             "members": [
                 {
                     "name": "Pattern",
@@ -1561,6 +1614,7 @@
         },
         "OptionSpecification": {
             "type": "structure",
+            "documentation": "<p> A specification identifying an individual configuration option. </p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -1585,6 +1639,7 @@
         },
         "Queue": {
             "type": "structure",
+            "documentation": "<p>Describes a queue.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1604,6 +1659,7 @@
         },
         "RebuildEnvironmentMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1625,6 +1681,7 @@
         },
         "RequestEnvironmentInfoMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1654,6 +1711,7 @@
         },
         "RestartAppServerMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1669,6 +1727,7 @@
         },
         "RetrieveEnvironmentInfoMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1689,6 +1748,7 @@
         },
         "RetrieveEnvironmentInfoResultMessage": {
             "type": "structure",
+            "documentation": "<p>Result message containing a description of the requested environment info.</p>",
             "members": [
                 {
                     "name": "EnvironmentInfo",
@@ -1705,6 +1765,7 @@
         },
         "S3Location": {
             "type": "structure",
+            "documentation": "<p>A specification of a location in Amazon S3.</p>",
             "members": [
                 {
                     "name": "S3Bucket",
@@ -1720,10 +1781,12 @@
         },
         "S3LocationNotInServiceRegionException": {
             "type": "structure",
+            "documentation": "<p>The specified S3 bucket does not belong to the S3 region in which the service is running.</p>",
             "members": []
         },
         "S3SubscriptionRequiredException": {
             "type": "structure",
+            "documentation": "<p>The caller does not have a subscription to Amazon S3.</p>",
             "members": []
         },
         "SampleTimestamp": {
@@ -1731,6 +1794,7 @@
         },
         "SolutionStackDescription": {
             "type": "structure",
+            "documentation": "<p> Describes the solution stack. </p>",
             "members": [
                 {
                     "name": "SolutionStackName",
@@ -1753,10 +1817,12 @@
         },
         "SourceBundleDeletionException": {
             "type": "structure",
+            "documentation": "<p>Unable to delete the Amazon S3 source bundle associated with the application version, although the application version deleted successfully.</p>",
             "members": []
         },
         "SourceConfiguration": {
             "type": "structure",
+            "documentation": "<p>A specification for an environment configuration</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1775,6 +1841,7 @@
         },
         "SwapEnvironmentCNAMEsMessage": {
             "type": "structure",
+            "documentation": "<p>Swaps the CNAMEs of two environments.</p>",
             "members": [
                 {
                     "name": "SourceEnvironmentId",
@@ -1800,6 +1867,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Describes a tag applied to a resource in an environment.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1828,6 +1896,7 @@
         },
         "TerminateEnvironmentMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -1860,26 +1929,32 @@
         },
         "TooManyApplicationVersionsException": {
             "type": "structure",
+            "documentation": "<p>The caller has exceeded the limit on the number of application versions associated with their account.</p>",
             "members": []
         },
         "TooManyApplicationsException": {
             "type": "structure",
+            "documentation": "<p>The caller has exceeded the limit on the number of applications associated with their account.</p>",
             "members": []
         },
         "TooManyBucketsException": {
             "type": "structure",
+            "documentation": "<p>The web service attempted to create a bucket in an Amazon S3 account that already has 100 buckets.</p>",
             "members": []
         },
         "TooManyConfigurationTemplatesException": {
             "type": "structure",
+            "documentation": "<p>The caller has exceeded the limit on the number of configuration templates associated with their account.</p>",
             "members": []
         },
         "TooManyEnvironmentsException": {
             "type": "structure",
+            "documentation": "<p>The caller has exceeded the limit of allowed environments associated with the account.</p>",
             "members": []
         },
         "Trigger": {
             "type": "structure",
+            "documentation": "<p>Describes a trigger.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1894,6 +1969,7 @@
         },
         "UpdateApplicationMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1909,6 +1985,7 @@
         },
         "UpdateApplicationVersionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1929,6 +2006,7 @@
         },
         "UpdateConfigurationTemplateMessage": {
             "type": "structure",
+            "documentation": "<p>The result message containing the options for the specified solution stack.</p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -1962,6 +2040,7 @@
         },
         "UpdateEnvironmentMessage": {
             "type": "structure",
+            "documentation": "<p>This documentation target is not reported in the API reference.</p>",
             "members": [
                 {
                     "name": "EnvironmentId",
@@ -2015,6 +2094,7 @@
         },
         "ValidateConfigurationSettingsMessage": {
             "type": "structure",
+            "documentation": "<p>A list of validation messages for a specified configuration template. </p>",
             "members": [
                 {
                     "name": "ApplicationName",
@@ -2040,6 +2120,7 @@
         },
         "ValidationMessage": {
             "type": "structure",
+            "documentation": "<p> An error or warning for a desired configuration option value. </p>",
             "members": [
                 {
                     "name": "Message",

--- a/libcloudcore/data/aws/elastictranscoder/service.json
+++ b/libcloudcore/data/aws/elastictranscoder/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -191,10 +195,12 @@
         },
         "AccessDeniedException": {
             "type": "structure",
+            "documentation": "<p> General authentication failure. The request was not signed correctly. </p>",
             "members": []
         },
         "Artwork": {
             "type": "structure",
+            "documentation": "<p>The file to be used as album art. There can be multiple artworks associated with an audio file, to a maximum of 20.</p> <p>To remove artwork or leave the artwork empty, you can either set <code>Artwork</code> to null, or set the <code>Merge Policy</code> to \"Replace\" and use an empty <code>Artwork</code> array.</p> <p>To pass through existing artwork unchanged, set the <code>Merge Policy</code> to \"Prepend\", \"Append\", or \"Fallback\", and use an empty <code>Artwork</code> array.</p>",
             "members": [
                 {
                     "name": "InputKey",
@@ -260,6 +266,7 @@
         },
         "AudioCodecOptions": {
             "type": "structure",
+            "documentation": "<p>Options associated with your audio codec.</p>",
             "members": [
                 {
                     "name": "Profile",
@@ -291,6 +298,7 @@
         },
         "AudioParameters": {
             "type": "structure",
+            "documentation": "<p>Parameters required for transcoding audio.</p>",
             "members": [
                 {
                     "name": "Codec",
@@ -338,6 +346,7 @@
         },
         "CancelJobRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>CancelJobRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -350,10 +359,12 @@
         },
         "CancelJobResponse": {
             "type": "structure",
+            "documentation": "<p>The response body contains a JSON object. If the job is successfully canceled, the value of <code>Success</code> is <code>true</code>.</p>",
             "members": []
         },
         "CaptionFormat": {
             "type": "structure",
+            "documentation": "<p>The file format of the output captions. If you leave this value blank, Elastic Transcoder returns an error.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -387,6 +398,7 @@
         },
         "CaptionSource": {
             "type": "structure",
+            "documentation": "<p>A source file for the input sidecar captions used during the transcoding process.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -421,6 +433,7 @@
         },
         "Captions": {
             "type": "structure",
+            "documentation": "<p>The captions to be created, if any.</p>",
             "members": [
                 {
                     "name": "MergePolicy",
@@ -441,6 +454,7 @@
         },
         "Clip": {
             "type": "structure",
+            "documentation": "<p>Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.</p>",
             "members": [
                 {
                     "name": "TimeSpan",
@@ -453,7 +467,9 @@
             "type": "string"
         },
         "CodecOptions": {
-            "type": "map"
+            "type": "map",
+            "key": "CodecOption",
+            "value": "CodecOption"
         },
         "Composition": {
             "type": "list",
@@ -461,6 +477,7 @@
         },
         "CreateJobOutput": {
             "type": "structure",
+            "documentation": "<p>The <code>CreateJobOutput</code> structure.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -525,6 +542,7 @@
         },
         "CreateJobPlaylist": {
             "type": "structure",
+            "documentation": "<p>Information about the master playlist.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -559,6 +577,7 @@
         },
         "CreateJobRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>CreateJobRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "PipelineId",
@@ -598,6 +617,7 @@
         },
         "CreateJobResponse": {
             "type": "structure",
+            "documentation": "<p>The CreateJobResponse structure.</p>",
             "members": [
                 {
                     "name": "Job",
@@ -608,6 +628,7 @@
         },
         "CreatePipelineRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>CreatePipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -653,6 +674,7 @@
         },
         "CreatePipelineResponse": {
             "type": "structure",
+            "documentation": "<p>When you create a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>",
             "members": [
                 {
                     "name": "Pipeline",
@@ -668,6 +690,7 @@
         },
         "CreatePresetRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>CreatePresetRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -703,6 +726,7 @@
         },
         "CreatePresetResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>CreatePresetResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Preset",
@@ -718,6 +742,7 @@
         },
         "DeletePipelineRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>DeletePipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -730,10 +755,12 @@
         },
         "DeletePipelineResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>DeletePipelineResponse</code> structure.</p>",
             "members": []
         },
         "DeletePresetRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>DeletePresetRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -746,6 +773,7 @@
         },
         "DeletePresetResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>DeletePresetResponse</code> structure.</p>",
             "members": []
         },
         "Description": {
@@ -753,6 +781,7 @@
         },
         "DetectedProperties": {
             "type": "structure",
+            "documentation": "<p>The detected properties of the input file. Elastic Transcoder identifies these values from the input file.</p>",
             "members": [
                 {
                     "name": "Width",
@@ -789,6 +818,7 @@
         },
         "Encryption": {
             "type": "structure",
+            "documentation": "<p>The encryption settings, if any, that are used for decrypting your input files or encrypting your output files. If your input file is encrypted, you must specify the mode that Elastic Transcoder will use to decrypt your file, otherwise you must specify the mode you want Elastic Transcoder to use to encrypt your output files.</p>",
             "members": [
                 {
                     "name": "Mode",
@@ -839,6 +869,7 @@
         },
         "HlsContentProtection": {
             "type": "structure",
+            "documentation": "<p>The HLS content protection settings, if any, that you want Elastic Transcoder to apply to your output files.</p>",
             "members": [
                 {
                     "name": "Method",
@@ -890,10 +921,12 @@
         },
         "InternalServiceException": {
             "type": "structure",
+            "documentation": "<p>Elastic Transcoder encountered an unexpected exception while trying to fulfill the request.</p>",
             "members": []
         },
         "Job": {
             "type": "structure",
+            "documentation": "<p>A section of the response body that provides information about the job that is created.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -954,6 +987,7 @@
         },
         "JobAlbumArt": {
             "type": "structure",
+            "documentation": "<p>The .jpg or .png file associated with an audio file.</p>",
             "members": [
                 {
                     "name": "MergePolicy",
@@ -972,6 +1006,7 @@
         },
         "JobInput": {
             "type": "structure",
+            "documentation": "<p>Information about the file that you're transcoding.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1017,6 +1052,7 @@
         },
         "JobOutput": {
             "type": "structure",
+            "documentation": "<p><important>Outputs recommended instead.</important>If you specified one output for a job, information about that output. If you specified multiple outputs for a job, the <code>Output</code> object lists information about the first output. This duplicates the information that is listed for the first output in the <code>Outputs</code> object.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1134,6 +1170,7 @@
         },
         "JobWatermark": {
             "type": "structure",
+            "documentation": "<p>Watermarks can be in .png or .jpg format. If you want to display a watermark that is not rectangular, use the .png format, which supports transparency.</p>",
             "members": [
                 {
                     "name": "PresetWatermarkId",
@@ -1180,10 +1217,12 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Too many operations for a given AWS account. For example, the number of pipelines exceeds the maximum allowed.</p>",
             "members": []
         },
         "ListJobsByPipelineRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ListJobsByPipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "PipelineId",
@@ -1210,6 +1249,7 @@
         },
         "ListJobsByPipelineResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>ListJobsByPipelineResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Jobs",
@@ -1225,6 +1265,7 @@
         },
         "ListJobsByStatusRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ListJobsByStatusRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -1251,6 +1292,7 @@
         },
         "ListJobsByStatusResponse": {
             "type": "structure",
+            "documentation": "<p> The <code>ListJobsByStatusResponse</code> structure. </p>",
             "members": [
                 {
                     "name": "Jobs",
@@ -1266,6 +1308,7 @@
         },
         "ListPipelinesRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ListPipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Ascending",
@@ -1285,6 +1328,7 @@
         },
         "ListPipelinesResponse": {
             "type": "structure",
+            "documentation": "<p>A list of the pipelines associated with the current AWS account.</p>",
             "members": [
                 {
                     "name": "Pipelines",
@@ -1300,6 +1344,7 @@
         },
         "ListPresetsRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ListPresetsRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Ascending",
@@ -1319,6 +1364,7 @@
         },
         "ListPresetsResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>ListPresetsResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Presets",
@@ -1346,6 +1392,7 @@
         },
         "Notifications": {
             "type": "structure",
+            "documentation": "<p>The Amazon Simple Notification Service (Amazon SNS) topic or topics to notify in order to report job status.</p> <important>To receive notifications, you must also subscribe to the new topic in the Amazon SNS console.</important>",
             "members": [
                 {
                     "name": "Progressing",
@@ -1390,6 +1437,7 @@
         },
         "Permission": {
             "type": "structure",
+            "documentation": "<p>The <code>Permission</code> structure.</p>",
             "members": [
                 {
                     "name": "GranteeType",
@@ -1414,6 +1462,7 @@
         },
         "Pipeline": {
             "type": "structure",
+            "documentation": "<p>The pipeline (queue) that is used to manage jobs.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1474,6 +1523,7 @@
         },
         "PipelineOutputConfig": {
             "type": "structure",
+            "documentation": "<p>The <code>PipelineOutputConfig</code> structure.</p>",
             "members": [
                 {
                     "name": "Bucket",
@@ -1504,6 +1554,7 @@
         },
         "PlayReadyDrm": {
             "type": "structure",
+            "documentation": "<p>The PlayReady DRM settings, if any, that you want Elastic Transcoder to apply to the output files associated with this playlist.</p> <p>PlayReady DRM encrypts your media files using <code>AES-CTR</code> encryption.</p> <p>If you use DRM for an <code>HLSv3</code> playlist, your outputs must have a master playlist.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -1542,6 +1593,7 @@
         },
         "Playlist": {
             "type": "structure",
+            "documentation": "<p> Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for which the value of Container is <code>fmp4</code> (Fragmented MP4) or <code>ts</code> (MPEG-TS), Playlists contains information about the master playlists that you want Elastic Transcoder to create. We recommend that you create only one master playlist per output format. The maximum number of master playlists in a job is 30. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -1589,6 +1641,7 @@
         },
         "Preset": {
             "type": "structure",
+            "documentation": "<p>Presets are templates that contain most of the settings for transcoding media files from one format to another. Elastic Transcoder includes some default presets for common formats, for example, several iPod and iPhone versions. You can also create your own presets for formats that aren't included among the default presets. You specify which preset you want to use when you create a job.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1645,6 +1698,7 @@
         },
         "PresetWatermark": {
             "type": "structure",
+            "documentation": "<p>Settings for the size, location, and opacity of graphics that you want Elastic Transcoder to overlay over videos that are transcoded using this preset. You can specify settings for up to four watermarks. Watermarks appear in the specified size and location, and with the specified opacity for the duration of the transcoded video.</p> <p>Watermarks can be in .png or .jpg format. If you want to display a watermark that is not rectangular, use the .png format, which supports transparency.</p> <p>When you create a job that uses this preset, you specify the .png or .jpg graphics that you want Elastic Transcoder to include in the transcoded videos. You can specify fewer graphics in the job than you specify watermark settings in the preset, which allows you to use the same preset for up to four watermarks that have different dimensions.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1711,6 +1765,7 @@
         },
         "ReadJobRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadJobRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1723,6 +1778,7 @@
         },
         "ReadJobResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadJobResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Job",
@@ -1733,6 +1789,7 @@
         },
         "ReadPipelineRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadPipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1745,6 +1802,7 @@
         },
         "ReadPipelineResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadPipelineResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Pipeline",
@@ -1760,6 +1818,7 @@
         },
         "ReadPresetRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadPresetRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1772,6 +1831,7 @@
         },
         "ReadPresetResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>ReadPresetResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Preset",
@@ -1785,10 +1845,12 @@
         },
         "ResourceInUseException": {
             "type": "structure",
+            "documentation": "<p> The resource you are attempting to change is in use. For example, you are attempting to delete a pipeline that is currently in use. </p>",
             "members": []
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p> The requested resource does not exist or is not available. For example, the pipeline to which you're trying to add a job doesn't exist or is still being created. </p>",
             "members": []
         },
         "Role": {
@@ -1821,6 +1883,7 @@
         },
         "TestRoleRequest": {
             "type": "structure",
+            "documentation": "<p> The <code>TestRoleRequest</code> structure. </p>",
             "members": [
                 {
                     "name": "Role",
@@ -1846,6 +1909,7 @@
         },
         "TestRoleResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>TestRoleResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Success",
@@ -1867,6 +1931,7 @@
         },
         "Thumbnails": {
             "type": "structure",
+            "documentation": "<p>Thumbnails for videos.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -1918,6 +1983,7 @@
         },
         "TimeSpan": {
             "type": "structure",
+            "documentation": "<p>Settings that determine when a clip begins and how long it lasts.</p>",
             "members": [
                 {
                     "name": "StartTime",
@@ -1933,6 +1999,7 @@
         },
         "Timing": {
             "type": "structure",
+            "documentation": "<p>Details about the timing of a job.</p>",
             "members": [
                 {
                     "name": "SubmitTimeMillis",
@@ -1953,6 +2020,7 @@
         },
         "UpdatePipelineNotificationsRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>UpdatePipelineNotificationsRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1970,6 +2038,7 @@
         },
         "UpdatePipelineNotificationsResponse": {
             "type": "structure",
+            "documentation": "<p>The <code>UpdatePipelineNotificationsResponse</code> structure.</p>",
             "members": [
                 {
                     "name": "Pipeline",
@@ -1980,6 +2049,7 @@
         },
         "UpdatePipelineRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>UpdatePipelineRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -2026,6 +2096,7 @@
         },
         "UpdatePipelineResponse": {
             "type": "structure",
+            "documentation": "<p>When you update a pipeline, Elastic Transcoder returns the values that you specified in the request. </p>",
             "members": [
                 {
                     "name": "Pipeline",
@@ -2040,6 +2111,7 @@
         },
         "UpdatePipelineStatusRequest": {
             "type": "structure",
+            "documentation": "<p>The <code>UpdatePipelineStatusRequest</code> structure.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -2057,6 +2129,7 @@
         },
         "UpdatePipelineStatusResponse": {
             "type": "structure",
+            "documentation": "When you update status for a pipeline, Elastic Transcoder returns the values that you specified in the request.",
             "members": [
                 {
                     "name": "Pipeline",
@@ -2066,10 +2139,13 @@
             ]
         },
         "UserMetadata": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "ValidationException": {
             "type": "structure",
+            "documentation": "<p>One or more required parameter values were not provided in the request.</p>",
             "members": []
         },
         "VerticalAlign": {
@@ -2083,6 +2159,7 @@
         },
         "VideoParameters": {
             "type": "structure",
+            "documentation": "<p>The <code>VideoParameters</code> structure.</p>",
             "members": [
                 {
                     "name": "Codec",
@@ -2163,6 +2240,7 @@
         },
         "Warning": {
             "type": "structure",
+            "documentation": "<p>Elastic Transcoder returns a warning if the resources used by your pipeline are not in the same region as the pipeline.</p> <p>Using resources in the same region, such as your Amazon S3 buckets, Amazon SNS notification topics, and AWS KMS key, reduces processing time and prevents cross-regional charges.</p>",
             "members": [
                 {
                     "name": "Code",

--- a/libcloudcore/data/aws/elb/service.json
+++ b/libcloudcore/data/aws/elb/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/"
         }
@@ -287,6 +290,7 @@
     "shapes": {
         "AccessLog": {
             "type": "structure",
+            "documentation": "<p>Information about the <code>AccessLog</code> attribute.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -324,6 +328,7 @@
         },
         "AccessPointNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified load balancer does not exist.</p>",
             "members": []
         },
         "AccessPointPort": {
@@ -375,6 +380,7 @@
         },
         "AdditionalAttribute": {
             "type": "structure",
+            "documentation": "<p>This data type is reserved.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -398,6 +404,7 @@
         },
         "AppCookieStickinessPolicy": {
             "type": "structure",
+            "documentation": "<p>Information about a policy for application-controlled session stickiness.</p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -479,6 +486,7 @@
         },
         "BackendServerDescription": {
             "type": "structure",
+            "documentation": "<p>Information about the configuration of a back-end server.</p>",
             "members": [
                 {
                     "name": "InstancePort",
@@ -501,6 +509,7 @@
         },
         "CertificateNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified SSL ID does not refer to a valid SSL certificate in AWS Identity and Access Management (IAM).</p>",
             "members": []
         },
         "ConfigureHealthCheckInput": {
@@ -530,6 +539,7 @@
         },
         "ConnectionDraining": {
             "type": "structure",
+            "documentation": "<p>Information about the <code>ConnectionDraining</code> attribute.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -551,6 +561,7 @@
         },
         "ConnectionSettings": {
             "type": "structure",
+            "documentation": "<p>Information about the <code>ConnectionSettings</code> attribute.</p>",
             "members": [
                 {
                     "name": "IdleTimeout",
@@ -716,6 +727,7 @@
         },
         "CrossZoneLoadBalancing": {
             "type": "structure",
+            "documentation": "<p>Information about the <code>CrossZoneLoadBalancing</code> attribute.</p>",
             "members": [
                 {
                     "name": "Enabled",
@@ -768,6 +780,7 @@
         },
         "DeleteLoadBalancerPolicyInput": {
             "type": "structure",
+            "documentation": "=",
             "members": [
                 {
                     "name": "LoadBalancerName",
@@ -985,18 +998,22 @@
         },
         "DuplicateAccessPointNameException": {
             "type": "structure",
+            "documentation": "<p>The specified load balancer name already exists for this account.</p>",
             "members": []
         },
         "DuplicateListenerException": {
             "type": "structure",
+            "documentation": "<p>A listener already exists for the specified <code>LoadBalancerName</code> and <code>LoadBalancerPort</code>, but with a different <code>InstancePort</code>, <code>Protocol</code>, or <code>SSLCertificateId</code>.</p>",
             "members": []
         },
         "DuplicatePolicyNameException": {
             "type": "structure",
+            "documentation": "<p>A policy with the specified name already exists for this load balancer.</p>",
             "members": []
         },
         "DuplicateTagKeysException": {
             "type": "structure",
+            "documentation": "<p>A tag key was specified more than once.</p>",
             "members": []
         },
         "EndPointPort": {
@@ -1004,6 +1021,7 @@
         },
         "HealthCheck": {
             "type": "structure",
+            "documentation": "<p>Information about a health check.</p>",
             "members": [
                 {
                     "name": "Target",
@@ -1049,6 +1067,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>The ID of a back-end instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -1065,6 +1084,7 @@
         },
         "InstanceState": {
             "type": "structure",
+            "documentation": "<p>Information about the state of a back-end instance.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -1098,22 +1118,27 @@
         },
         "InvalidConfigurationRequestException": {
             "type": "structure",
+            "documentation": "<p>The requested configuration change is not valid.</p>",
             "members": []
         },
         "InvalidEndPointException": {
             "type": "structure",
+            "documentation": "<p>The specified endpoint is not valid.</p>",
             "members": []
         },
         "InvalidSchemeException": {
             "type": "structure",
+            "documentation": "<p>The specified value for the schema is not valid. You can only specify a scheme for load balancers in a VPC.</p>",
             "members": []
         },
         "InvalidSecurityGroupException": {
             "type": "structure",
+            "documentation": "<p>One or more of the specified security groups do not exist.</p>",
             "members": []
         },
         "InvalidSubnetException": {
             "type": "structure",
+            "documentation": "<p>The specified VPC has no associated Internet gateway.</p>",
             "members": []
         },
         "LBCookieStickinessPolicies": {
@@ -1122,6 +1147,7 @@
         },
         "LBCookieStickinessPolicy": {
             "type": "structure",
+            "documentation": "<p>Information about a policy for duration-based session stickiness.</p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -1137,6 +1163,7 @@
         },
         "Listener": {
             "type": "structure",
+            "documentation": "<p>Information about a listener.</p> <p>For information about the protocols and the ports supported by Elastic Load Balancing, see <a href=\"http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-listener-config.html\">Listener Configurations for Elastic Load Balancing</a> in the <i>Elastic Load Balancing Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "Protocol",
@@ -1167,6 +1194,7 @@
         },
         "ListenerDescription": {
             "type": "structure",
+            "documentation": "<p>The policies enabled for a listener.</p>",
             "members": [
                 {
                     "name": "Listener",
@@ -1185,6 +1213,7 @@
         },
         "ListenerNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The load balancer does not have a listener configured at the specified port.</p>",
             "members": []
         },
         "Listeners": {
@@ -1193,10 +1222,12 @@
         },
         "LoadBalancerAttributeNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The specified load balancer attribute does not exist.</p>",
             "members": []
         },
         "LoadBalancerAttributes": {
             "type": "structure",
+            "documentation": "<p>The attributes for a load balancer.</p>",
             "members": [
                 {
                     "name": "CrossZoneLoadBalancing",
@@ -1227,6 +1258,7 @@
         },
         "LoadBalancerDescription": {
             "type": "structure",
+            "documentation": "<p>Information about a load balancer.</p>",
             "members": [
                 {
                     "name": "LoadBalancerName",
@@ -1362,6 +1394,7 @@
         },
         "Policies": {
             "type": "structure",
+            "documentation": "<p>The policies for a load balancer.</p>",
             "members": [
                 {
                     "name": "AppCookieStickinessPolicies",
@@ -1382,6 +1415,7 @@
         },
         "PolicyAttribute": {
             "type": "structure",
+            "documentation": "<p>Information about a policy attribute.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -1397,6 +1431,7 @@
         },
         "PolicyAttributeDescription": {
             "type": "structure",
+            "documentation": "<p>Information about a policy attribute.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -1416,6 +1451,7 @@
         },
         "PolicyAttributeTypeDescription": {
             "type": "structure",
+            "documentation": "<p>Information about a policy attribute type.</p>",
             "members": [
                 {
                     "name": "AttributeName",
@@ -1454,6 +1490,7 @@
         },
         "PolicyDescription": {
             "type": "structure",
+            "documentation": "<p>Information about a policy.</p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -1485,10 +1522,12 @@
         },
         "PolicyNotFoundException": {
             "type": "structure",
+            "documentation": "<p>One or more of the specified policies do not exist.</p>",
             "members": []
         },
         "PolicyTypeDescription": {
             "type": "structure",
+            "documentation": "<p>Information about a policy type.</p>",
             "members": [
                 {
                     "name": "PolicyTypeName",
@@ -1520,6 +1559,7 @@
         },
         "PolicyTypeNotFoundException": {
             "type": "structure",
+            "documentation": "<p>One or more of the specified policy types do not exist.</p>",
             "members": []
         },
         "Ports": {
@@ -1694,6 +1734,7 @@
         },
         "SourceSecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Information about a source security group.</p>",
             "members": [
                 {
                     "name": "OwnerAlias",
@@ -1718,6 +1759,7 @@
         },
         "SubnetNotFoundException": {
             "type": "structure",
+            "documentation": "<p>One or more of the specified subnets do not exist.</p>",
             "members": []
         },
         "Subnets": {
@@ -1726,6 +1768,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Information about a tag.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1741,6 +1784,7 @@
         },
         "TagDescription": {
             "type": "structure",
+            "documentation": "<p>The tags associated with a load balancer.</p>",
             "members": [
                 {
                     "name": "LoadBalancerName",
@@ -1767,6 +1811,7 @@
         },
         "TagKeyOnly": {
             "type": "structure",
+            "documentation": "<p>The key of a tag.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1784,14 +1829,17 @@
         },
         "TooManyAccessPointsException": {
             "type": "structure",
+            "documentation": "<p>The quota for the number of load balancers has been reached.</p>",
             "members": []
         },
         "TooManyPoliciesException": {
             "type": "structure",
+            "documentation": "<p>The quota for the number of policies for this load balancer has been reached.</p>",
             "members": []
         },
         "TooManyTagsException": {
             "type": "structure",
+            "documentation": "<p>The quota for the number of tags that can be assigned to a load balancer has been reached.</p>",
             "members": []
         },
         "UnhealthyThreshold": {

--- a/libcloudcore/data/aws/emr/service.json
+++ b/libcloudcore/data/aws/emr/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -175,6 +179,7 @@
         },
         "AddInstanceGroupsInput": {
             "type": "structure",
+            "documentation": "<p>Input to an AddInstanceGroups call.</p>",
             "members": [
                 {
                     "name": "InstanceGroups",
@@ -190,6 +195,7 @@
         },
         "AddInstanceGroupsOutput": {
             "type": "structure",
+            "documentation": "<p>Output from an AddInstanceGroups call.</p>",
             "members": [
                 {
                     "name": "JobFlowId",
@@ -205,6 +211,7 @@
         },
         "AddJobFlowStepsInput": {
             "type": "structure",
+            "documentation": "<p> The input argument to the <a>AddJobFlowSteps</a> operation. </p>",
             "members": [
                 {
                     "name": "JobFlowId",
@@ -220,6 +227,7 @@
         },
         "AddJobFlowStepsOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>AddJobFlowSteps</a> operation. </p>",
             "members": [
                 {
                     "name": "StepIds",
@@ -230,6 +238,7 @@
         },
         "AddTagsInput": {
             "type": "structure",
+            "documentation": "<p>This input identifies a cluster and a list of tags to attach. </p>",
             "members": [
                 {
                     "name": "ResourceId",
@@ -245,10 +254,12 @@
         },
         "AddTagsOutput": {
             "type": "structure",
+            "documentation": "<p>This output indicates the result of adding tags to a resource. </p>",
             "members": []
         },
         "Application": {
             "type": "structure",
+            "documentation": "<p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-mapr.html\">Launch a Job Flow on the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li>\"mapr-m3\" - launch the job flow using MapR M3 Edition.</li> <li>\"mapr-m5\" - launch the job flow using MapR M5 Edition.</li> <li>\"mapr\" with the user arguments specifying \"--edition,m3\" or \"--edition,m5\" - launch the job flow using MapR M3 or M5 Edition, respectively.</li> </ul> <note><p>In Amazon EMR releases 4.0 and greater, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p></note>",
             "members": [
                 {
                     "name": "Name",
@@ -281,6 +292,7 @@
         },
         "BootstrapActionConfig": {
             "type": "structure",
+            "documentation": "<p>Configuration of a bootstrap action.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -300,6 +312,7 @@
         },
         "BootstrapActionDetail": {
             "type": "structure",
+            "documentation": "<p>Reports the configuration of a bootstrap action in a job flow.</p>",
             "members": [
                 {
                     "name": "BootstrapActionConfig",
@@ -314,6 +327,7 @@
         },
         "Cluster": {
             "type": "structure",
+            "documentation": "<p>The detailed description of the cluster.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -409,6 +423,7 @@
         },
         "ClusterStateChangeReason": {
             "type": "structure",
+            "documentation": "<p>The reason that the cluster changed to its current state.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -431,6 +446,7 @@
         },
         "ClusterStatus": {
             "type": "structure",
+            "documentation": "<p>The detailed status of the cluster.</p>",
             "members": [
                 {
                     "name": "State",
@@ -451,6 +467,7 @@
         },
         "ClusterSummary": {
             "type": "structure",
+            "documentation": "<p>The summary description of the cluster.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -480,6 +497,7 @@
         },
         "ClusterTimeline": {
             "type": "structure",
+            "documentation": "<p>Represents the timeline of the cluster's lifecycle.</p>",
             "members": [
                 {
                     "name": "CreationDateTime",
@@ -500,6 +518,7 @@
         },
         "Command": {
             "type": "structure",
+            "documentation": "<p>An entity describing an executable that runs on a cluster.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -524,6 +543,7 @@
         },
         "Configuration": {
             "type": "structure",
+            "documentation": "<note><p>Amazon EMR releases 4.x or later.</p></note> <p>Specifies a hardware and software configuration of the EMR cluster. This includes configurations for applications and software bundled with Amazon EMR. The Configuration object is a JSON object which is defined by a classification and a set of properties. Configurations can be nested, so a configuration may have its own Configuration objects listed.</p>",
             "members": [
                 {
                     "name": "Classification",
@@ -551,6 +571,7 @@
         },
         "DescribeClusterInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which cluster to describe.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -561,6 +582,7 @@
         },
         "DescribeClusterOutput": {
             "type": "structure",
+            "documentation": "<p>This output contains the description of the cluster.</p>",
             "members": [
                 {
                     "name": "Cluster",
@@ -571,6 +593,7 @@
         },
         "DescribeJobFlowsInput": {
             "type": "structure",
+            "documentation": "<p> The input for the <a>DescribeJobFlows</a> operation. </p>",
             "members": [
                 {
                     "name": "CreatedAfter",
@@ -596,6 +619,7 @@
         },
         "DescribeJobFlowsOutput": {
             "type": "structure",
+            "documentation": "<p> The output for the <a>DescribeJobFlows</a> operation. </p>",
             "members": [
                 {
                     "name": "JobFlows",
@@ -606,6 +630,7 @@
         },
         "DescribeStepInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which step to describe.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -621,6 +646,7 @@
         },
         "DescribeStepOutput": {
             "type": "structure",
+            "documentation": "<p>This output contains the description of the cluster step.</p>",
             "members": [
                 {
                     "name": "Step",
@@ -635,6 +661,7 @@
         },
         "Ec2InstanceAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides information about the EC2 instances in a cluster grouped by category. For example, key name, subnet ID, IAM instance profile, and so on.</p>",
             "members": [
                 {
                     "name": "Ec2KeyName",
@@ -686,6 +713,7 @@
         },
         "HadoopJarStepConfig": {
             "type": "structure",
+            "documentation": "<p>A job flow step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail. </p>",
             "members": [
                 {
                     "name": "Properties",
@@ -711,6 +739,7 @@
         },
         "HadoopStepConfig": {
             "type": "structure",
+            "documentation": "<p>A cluster step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail. </p>",
             "members": [
                 {
                     "name": "Jar",
@@ -736,6 +765,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>Represents an EC2 instance provisioned as part of cluster.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -776,6 +806,7 @@
         },
         "InstanceGroup": {
             "type": "structure",
+            "documentation": "<p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -831,6 +862,7 @@
         },
         "InstanceGroupConfig": {
             "type": "structure",
+            "documentation": "<p>Configuration defining a new instance group.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -875,6 +907,7 @@
         },
         "InstanceGroupDetail": {
             "type": "structure",
+            "documentation": "<p>Detailed information about an instance group. </p>",
             "members": [
                 {
                     "name": "InstanceGroupId",
@@ -965,6 +998,7 @@
         },
         "InstanceGroupModifyConfig": {
             "type": "structure",
+            "documentation": "<p>Modify an instance group size.</p>",
             "members": [
                 {
                     "name": "InstanceGroupId",
@@ -992,6 +1026,7 @@
         },
         "InstanceGroupStateChangeReason": {
             "type": "structure",
+            "documentation": "<p>The status change reason details for the instance group.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -1010,6 +1045,7 @@
         },
         "InstanceGroupStatus": {
             "type": "structure",
+            "documentation": "<p>The details of the instance group status.</p>",
             "members": [
                 {
                     "name": "State",
@@ -1030,6 +1066,7 @@
         },
         "InstanceGroupTimeline": {
             "type": "structure",
+            "documentation": "<p>The timeline of the instance group lifecycle.</p>",
             "members": [
                 {
                     "name": "CreationDateTime",
@@ -1070,6 +1107,7 @@
         },
         "InstanceStateChangeReason": {
             "type": "structure",
+            "documentation": "<p>The details of the status change reason for the instance.</p>",
             "members": [
                 {
                     "name": "Code",
@@ -1088,6 +1126,7 @@
         },
         "InstanceStatus": {
             "type": "structure",
+            "documentation": "<p>The instance status details.</p>",
             "members": [
                 {
                     "name": "State",
@@ -1108,6 +1147,7 @@
         },
         "InstanceTimeline": {
             "type": "structure",
+            "documentation": "<p>The timeline of the instance lifecycle.</p>",
             "members": [
                 {
                     "name": "CreationDateTime",
@@ -1134,10 +1174,12 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>Indicates that an error occurred while processing the request and that the request was not completed.</p>",
             "members": []
         },
         "InternalServerException": {
             "type": "structure",
+            "documentation": "<p>This exception occurs when there is an internal failure in the EMR service.</p>",
             "members": [
                 {
                     "name": "Message",
@@ -1148,6 +1190,7 @@
         },
         "InvalidRequestException": {
             "type": "structure",
+            "documentation": "<p>This exception occurs when there is something wrong with user input.</p>",
             "members": [
                 {
                     "name": "ErrorCode",
@@ -1163,6 +1206,7 @@
         },
         "JobFlowDetail": {
             "type": "structure",
+            "documentation": "<p> A description of a job flow.</p>",
             "members": [
                 {
                     "name": "JobFlowId",
@@ -1231,7 +1275,8 @@
             "of": "JobFlowDetail"
         },
         "JobFlowExecutionState": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p> The type of instance. </p> <enumValues> <value name=\"JobFlowExecutionState$COMPLETED\"> <p>A small instance</p> </value> <value name=\"JobFlowExecutionState$FAILED\"> <p>A large instance</p> </value> </enumValues>"
         },
         "JobFlowExecutionStateList": {
             "type": "list",
@@ -1239,6 +1284,7 @@
         },
         "JobFlowExecutionStatusDetail": {
             "type": "structure",
+            "documentation": "<p>Describes the status of the job flow.</p>",
             "members": [
                 {
                     "name": "State",
@@ -1274,6 +1320,7 @@
         },
         "JobFlowInstancesConfig": {
             "type": "structure",
+            "documentation": "<p>A description of the Amazon EC2 instance running the job flow. A valid JobFlowInstancesConfig must contain at least InstanceGroups, which is the recommended configuration. However, a valid alternative is to have MasterInstanceType, SlaveInstanceType, and InstanceCount (all three must be present).</p>",
             "members": [
                 {
                     "name": "MasterInstanceType",
@@ -1349,6 +1396,7 @@
         },
         "JobFlowInstancesDetail": {
             "type": "structure",
+            "documentation": "<p>Specify the type of Amazon EC2 instances to run the job flow on.</p>",
             "members": [
                 {
                     "name": "MasterInstanceType",
@@ -1419,6 +1467,7 @@
         },
         "KeyValue": {
             "type": "structure",
+            "documentation": "<p>A key value pair.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -1438,6 +1487,7 @@
         },
         "ListBootstrapActionsInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which bootstrap actions to retrieve.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -1453,6 +1503,7 @@
         },
         "ListBootstrapActionsOutput": {
             "type": "structure",
+            "documentation": "<p>This output contains the boostrap actions detail .</p>",
             "members": [
                 {
                     "name": "BootstrapActions",
@@ -1468,6 +1519,7 @@
         },
         "ListClustersInput": {
             "type": "structure",
+            "documentation": "<p>This input determines how the ListClusters action filters the list of clusters that it returns.</p>",
             "members": [
                 {
                     "name": "CreatedAfter",
@@ -1493,6 +1545,7 @@
         },
         "ListClustersOutput": {
             "type": "structure",
+            "documentation": "<p>This contains a ClusterSummaryList with the cluster details; for example, the cluster IDs, names, and status.</p>",
             "members": [
                 {
                     "name": "Clusters",
@@ -1508,6 +1561,7 @@
         },
         "ListInstanceGroupsInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which instance groups to retrieve.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -1523,6 +1577,7 @@
         },
         "ListInstanceGroupsOutput": {
             "type": "structure",
+            "documentation": "<p>This input determines which instance groups to retrieve.</p>",
             "members": [
                 {
                     "name": "InstanceGroups",
@@ -1538,6 +1593,7 @@
         },
         "ListInstancesInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which instances to list.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -1563,6 +1619,7 @@
         },
         "ListInstancesOutput": {
             "type": "structure",
+            "documentation": "<p>This output contains the list of instances.</p>",
             "members": [
                 {
                     "name": "Instances",
@@ -1578,6 +1635,7 @@
         },
         "ListStepsInput": {
             "type": "structure",
+            "documentation": "<p>This input determines which steps to list.</p>",
             "members": [
                 {
                     "name": "ClusterId",
@@ -1603,6 +1661,7 @@
         },
         "ListStepsOutput": {
             "type": "structure",
+            "documentation": "<p>This output contains the list of steps.</p>",
             "members": [
                 {
                     "name": "Steps",
@@ -1624,6 +1683,7 @@
         },
         "ModifyInstanceGroupsInput": {
             "type": "structure",
+            "documentation": "<p>Change the size of some instance groups.</p>",
             "members": [
                 {
                     "name": "InstanceGroups",
@@ -1638,6 +1698,7 @@
         },
         "PlacementType": {
             "type": "structure",
+            "documentation": "<p>The Amazon EC2 location for the job flow.</p>",
             "members": [
                 {
                     "name": "AvailabilityZone",
@@ -1648,6 +1709,7 @@
         },
         "RemoveTagsInput": {
             "type": "structure",
+            "documentation": "<p>This input identifies a cluster and a list of tags to remove. </p>",
             "members": [
                 {
                     "name": "ResourceId",
@@ -1663,6 +1725,7 @@
         },
         "RemoveTagsOutput": {
             "type": "structure",
+            "documentation": "<p>This output indicates the result of removing tags from a resource. </p>",
             "members": []
         },
         "ResourceId": {
@@ -1670,6 +1733,7 @@
         },
         "RunJobFlowInput": {
             "type": "structure",
+            "documentation": "<p> Input to the <a>RunJobFlow</a> operation. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -1755,6 +1819,7 @@
         },
         "RunJobFlowOutput": {
             "type": "structure",
+            "documentation": "<p> The result of the <a>RunJobFlow</a> operation. </p>",
             "members": [
                 {
                     "name": "JobFlowId",
@@ -1765,6 +1830,7 @@
         },
         "ScriptBootstrapActionConfig": {
             "type": "structure",
+            "documentation": "<p>Configuration of the script to run during a bootstrap action.</p>",
             "members": [
                 {
                     "name": "Path",
@@ -1784,6 +1850,7 @@
         },
         "SetTerminationProtectionInput": {
             "type": "structure",
+            "documentation": "<p> The input argument to the <a>TerminationProtection</a> operation. </p>",
             "members": [
                 {
                     "name": "JobFlowIds",
@@ -1799,6 +1866,7 @@
         },
         "SetVisibleToAllUsersInput": {
             "type": "structure",
+            "documentation": "<p>The input to the SetVisibleToAllUsers action.</p>",
             "members": [
                 {
                     "name": "JobFlowIds",
@@ -1814,6 +1882,7 @@
         },
         "Step": {
             "type": "structure",
+            "documentation": "<p>This represents a step in a cluster.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1844,6 +1913,7 @@
         },
         "StepConfig": {
             "type": "structure",
+            "documentation": "<p>Specification of a job flow step.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1868,6 +1938,7 @@
         },
         "StepDetail": {
             "type": "structure",
+            "documentation": "<p>Combines the execution state and configuration of a step.</p>",
             "members": [
                 {
                     "name": "StepConfig",
@@ -1890,6 +1961,7 @@
         },
         "StepExecutionStatusDetail": {
             "type": "structure",
+            "documentation": "<p>The execution state of a step.</p>",
             "members": [
                 {
                     "name": "State",
@@ -1930,6 +2002,7 @@
         },
         "StepStateChangeReason": {
             "type": "structure",
+            "documentation": "<p>The details of the step state change reason. </p>",
             "members": [
                 {
                     "name": "Code",
@@ -1952,6 +2025,7 @@
         },
         "StepStatus": {
             "type": "structure",
+            "documentation": "<p>The execution status details of the cluster step. </p>",
             "members": [
                 {
                     "name": "State",
@@ -1972,6 +2046,7 @@
         },
         "StepSummary": {
             "type": "structure",
+            "documentation": "<p>The summary of the cluster step.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -2006,6 +2081,7 @@
         },
         "StepTimeline": {
             "type": "structure",
+            "documentation": "<p>The timeline of the cluster step lifecycle. </p>",
             "members": [
                 {
                     "name": "CreationDateTime",
@@ -2032,10 +2108,13 @@
             "of": "String"
         },
         "StringMap": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "SupportedProductConfig": {
             "type": "structure",
+            "documentation": "<p>The list of supported product configurations which allow user-supplied arguments. EMR accepts these arguments and forwards them to the corresponding installation script as bootstrap action arguments. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -2055,6 +2134,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>A key/value pair containing user-defined metadata that you can associate with an Amazon EMR resource. Tags make it easier to associate clusters in various ways, such as grouping clu\\ sters to track your Amazon EMR resource allocation costs. For more information, see <a href=\"http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-plan-tags.html\">Tagging Amazon EMR Resources</a>. </p>",
             "members": [
                 {
                     "name": "Key",
@@ -2074,6 +2154,7 @@
         },
         "TerminateJobFlowsInput": {
             "type": "structure",
+            "documentation": "<p> Input to the <a>TerminateJobFlows</a> operation. </p>",
             "members": [
                 {
                     "name": "JobFlowIds",

--- a/libcloudcore/data/aws/glacier/service.json
+++ b/libcloudcore/data/aws/glacier/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -274,6 +278,7 @@
     "shapes": {
         "AbortMultipartUploadInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to abort a multipart upload identified by the upload ID. </p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart Upload</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -300,6 +305,7 @@
         },
         "AbortVaultLockInput": {
             "type": "structure",
+            "documentation": "<p>The input values for <code>AbortVaultLock</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -322,6 +328,7 @@
         },
         "AddTagsToVaultInput": {
             "type": "structure",
+            "documentation": "<p>The input values for <code>AddTagsToVault</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -346,6 +353,7 @@
         },
         "ArchiveCreationOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html\">Upload Archive</a>. For conceptual information, go to <a href=\"http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in Amazon Glacier</a>.</p>",
             "members": [
                 {
                     "name": "location",
@@ -372,6 +380,7 @@
         },
         "CompleteMultipartUploadInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to complete a multipart upload operation. This informs Amazon Glacier that all the archive parts have been uploaded and Amazon Glacier can now assemble the archive from the uploaded parts. After assembling and saving the archive to the vault, Amazon Glacier returns the URI path of the newly created archive resource.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -412,6 +421,7 @@
         },
         "CompleteVaultLockInput": {
             "type": "structure",
+            "documentation": "<p>The input values for <code>CompleteVaultLock</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -438,6 +448,7 @@
         },
         "CreateVaultInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to create a vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -457,6 +468,7 @@
         },
         "CreateVaultOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "location",
@@ -469,6 +481,7 @@
         },
         "DataRetrievalPolicy": {
             "type": "structure",
+            "documentation": "<p>Data retrieval policy.</p>",
             "members": [
                 {
                     "name": "Rules",
@@ -479,6 +492,7 @@
         },
         "DataRetrievalRule": {
             "type": "structure",
+            "documentation": "<p>Data retrieval policy rule.</p>",
             "members": [
                 {
                     "name": "Strategy",
@@ -501,6 +515,7 @@
         },
         "DeleteArchiveInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for deleting an archive from an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -527,6 +542,7 @@
         },
         "DeleteVaultAccessPolicyInput": {
             "type": "structure",
+            "documentation": "<p>DeleteVaultAccessPolicy input.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -546,6 +562,7 @@
         },
         "DeleteVaultInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for deleting a vault from Amazon Glacier.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -565,6 +582,7 @@
         },
         "DeleteVaultNotificationsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for deleting a vault notification configuration from an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -584,6 +602,7 @@
         },
         "DescribeJobInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving a job description.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -610,6 +629,7 @@
         },
         "DescribeVaultInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving metadata for a specific vault in Amazon Glacier.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -629,6 +649,7 @@
         },
         "DescribeVaultOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "VaultARN",
@@ -664,6 +685,7 @@
         },
         "GetDataRetrievalPolicyInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetDataRetrievalPolicy.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -676,6 +698,7 @@
         },
         "GetDataRetrievalPolicyOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to the <code>GetDataRetrievalPolicy</code> request.</p>",
             "members": [
                 {
                     "name": "Policy",
@@ -686,6 +709,7 @@
         },
         "GetJobOutputInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for downloading output of an Amazon Glacier job.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -719,6 +743,7 @@
         },
         "GetJobOutputOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "body",
@@ -770,6 +795,7 @@
         },
         "GetVaultAccessPolicyInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetVaultAccessPolicy.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -789,6 +815,7 @@
         },
         "GetVaultAccessPolicyOutput": {
             "type": "structure",
+            "documentation": "<p>Output for GetVaultAccessPolicy.</p>",
             "members": [
                 {
                     "name": "policy",
@@ -799,6 +826,7 @@
         },
         "GetVaultLockInput": {
             "type": "structure",
+            "documentation": "<p>The input values for <code>GetVaultLock</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -818,6 +846,7 @@
         },
         "GetVaultLockOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "Policy",
@@ -843,6 +872,7 @@
         },
         "GetVaultNotificationsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving the notification configuration set on an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -862,6 +892,7 @@
         },
         "GetVaultNotificationsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "vaultNotificationConfig",
@@ -872,6 +903,7 @@
         },
         "GlacierJobDescription": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon Glacier job.</p>",
             "members": [
                 {
                     "name": "JobId",
@@ -962,6 +994,7 @@
         },
         "InitiateJobInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for initiating an Amazon Glacier job.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -986,6 +1019,7 @@
         },
         "InitiateJobOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "location",
@@ -1005,6 +1039,7 @@
         },
         "InitiateMultipartUploadInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for initiating a multipart upload to an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1038,6 +1073,7 @@
         },
         "InitiateMultipartUploadOutput": {
             "type": "structure",
+            "documentation": "<p>The Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "location",
@@ -1057,6 +1093,7 @@
         },
         "InitiateVaultLockInput": {
             "type": "structure",
+            "documentation": "<p>The input values for <code>InitiateVaultLock</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1081,6 +1118,7 @@
         },
         "InitiateVaultLockOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "lockId",
@@ -1093,6 +1131,7 @@
         },
         "InvalidParameterValueException": {
             "type": "structure",
+            "documentation": "<p>Returned if a parameter of the request is incorrectly specified. </p>",
             "members": [
                 {
                     "name": "type",
@@ -1112,6 +1151,7 @@
         },
         "InventoryRetrievalJobDescription": {
             "type": "structure",
+            "documentation": "<p>Describes the options for a range inventory retrieval job.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -1142,6 +1182,7 @@
         },
         "InventoryRetrievalJobInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for specifying a range inventory retrieval job.</p>",
             "members": [
                 {
                     "name": "StartDate",
@@ -1171,6 +1212,7 @@
         },
         "JobParameters": {
             "type": "structure",
+            "documentation": "<p>Provides options for defining a job.</p>",
             "members": [
                 {
                     "name": "Format",
@@ -1211,6 +1253,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Returned if the request results in a vault or account limit being exceeded.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1230,6 +1273,7 @@
         },
         "ListJobsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving a job list for an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1277,6 +1321,7 @@
         },
         "ListJobsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "JobList",
@@ -1292,6 +1337,7 @@
         },
         "ListMultipartUploadsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon Glacier vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1325,6 +1371,7 @@
         },
         "ListMultipartUploadsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "UploadsList",
@@ -1340,6 +1387,7 @@
         },
         "ListPartsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options for retrieving a list of parts of an archive that have been uploaded in a specific multipart upload.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1380,6 +1428,7 @@
         },
         "ListPartsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "MultipartUploadId",
@@ -1420,6 +1469,7 @@
         },
         "ListTagsForVaultInput": {
             "type": "structure",
+            "documentation": "<p>The input value for <code>ListTagsForVaultInput</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1439,6 +1489,7 @@
         },
         "ListTagsForVaultOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "Tags",
@@ -1449,6 +1500,7 @@
         },
         "ListVaultsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to retrieve the vault list owned by the calling user's account. The list provides metadata information for each vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1475,6 +1527,7 @@
         },
         "ListVaultsOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "VaultList",
@@ -1490,6 +1543,7 @@
         },
         "MissingParameterValueException": {
             "type": "structure",
+            "documentation": "<p>Returned if a required header or parameter is missing from the request.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1520,6 +1574,7 @@
         },
         "PartListElement": {
             "type": "structure",
+            "documentation": "<p>A list of the part sizes of the multipart upload.</p>",
             "members": [
                 {
                     "name": "RangeInBytes",
@@ -1535,6 +1590,7 @@
         },
         "PolicyEnforcedException": {
             "type": "structure",
+            "documentation": "<p>Returned if a retrieval job would exceed the current data policy's retrieval rate limit. For more information about data retrieval policies,</p>",
             "members": [
                 {
                     "name": "type",
@@ -1555,6 +1611,7 @@
         },
         "RemoveTagsFromVaultInput": {
             "type": "structure",
+            "documentation": "<p>The input value for <code>RemoveTagsFromVaultInput</code>.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1579,6 +1636,7 @@
         },
         "RequestTimeoutException": {
             "type": "structure",
+            "documentation": "<p>Returned if, when uploading an archive, Amazon Glacier times out while receiving the upload.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1598,6 +1656,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>Returned if the specified resource, such as a vault, upload ID, or job ID, does not exist.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1617,6 +1676,7 @@
         },
         "ServiceUnavailableException": {
             "type": "structure",
+            "documentation": "<p>Returned if the service cannot complete the request.</p>",
             "members": [
                 {
                     "name": "type",
@@ -1636,6 +1696,7 @@
         },
         "SetDataRetrievalPolicyInput": {
             "type": "structure",
+            "documentation": "<p>SetDataRetrievalPolicy input.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1653,6 +1714,7 @@
         },
         "SetVaultAccessPolicyInput": {
             "type": "structure",
+            "documentation": "<p>SetVaultAccessPolicy input.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1677,6 +1739,7 @@
         },
         "SetVaultNotificationsInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to configure notifications that will be sent when specific events happen to a vault.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1716,13 +1779,16 @@
             "of": "string"
         },
         "TagMap": {
-            "type": "map"
+            "type": "map",
+            "key": "TagKey",
+            "value": "TagValue"
         },
         "TagValue": {
             "type": "string"
         },
         "UploadArchiveInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to add an archive to a vault.</p>",
             "members": [
                 {
                     "name": "vaultName",
@@ -1761,6 +1827,7 @@
         },
         "UploadListElement": {
             "type": "structure",
+            "documentation": "<p>A list of in-progress multipart uploads for a vault.</p>",
             "members": [
                 {
                     "name": "MultipartUploadId",
@@ -1791,6 +1858,7 @@
         },
         "UploadMultipartPartInput": {
             "type": "structure",
+            "documentation": "<p>Provides options to upload a part of an archive in a multipart upload operation.</p>",
             "members": [
                 {
                     "name": "accountId",
@@ -1836,6 +1904,7 @@
         },
         "UploadMultipartPartOutput": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Glacier response to your request.</p>",
             "members": [
                 {
                     "name": "checksum",
@@ -1852,6 +1921,7 @@
         },
         "VaultAccessPolicy": {
             "type": "structure",
+            "documentation": "<p>Contains the vault access policy. </p>",
             "members": [
                 {
                     "name": "Policy",
@@ -1866,6 +1936,7 @@
         },
         "VaultLockPolicy": {
             "type": "structure",
+            "documentation": "<p>Contains the vault lock policy. </p>",
             "members": [
                 {
                     "name": "Policy",
@@ -1876,6 +1947,7 @@
         },
         "VaultNotificationConfig": {
             "type": "structure",
+            "documentation": "<p>Represents a vault's notification configuration.</p>",
             "members": [
                 {
                     "name": "SNSTopic",

--- a/libcloudcore/data/aws/iam/service.json
+++ b/libcloudcore/data/aws/iam/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "https://iam.amazonaws.com/doc/2010-05-08/"
         }
@@ -856,6 +859,7 @@
     "shapes": {
         "AccessKey": {
             "type": "structure",
+            "documentation": "<p>Contains information about an AWS access key.</p> <p> This data type is used as a response element in the <a>CreateAccessKey</a> and <a>ListAccessKeys</a> actions. </p> <note>The <code>SecretAccessKey</code> value is returned only in response to <a>CreateAccessKey</a>. You can get a secret access key only when you first create an access key; you cannot recover the secret access key later. If you lose a secret access key, you must create a new access key. </note>",
             "members": [
                 {
                     "name": "UserName",
@@ -886,6 +890,7 @@
         },
         "AccessKeyLastUsed": {
             "type": "structure",
+            "documentation": "<p>Contains information about the last time an AWS access key was used.</p> <p>This data type is used as a response element in the <a>GetAccessKeyLastUsed</a> action.</p>",
             "members": [
                 {
                     "name": "LastUsedDate",
@@ -906,6 +911,7 @@
         },
         "AccessKeyMetadata": {
             "type": "structure",
+            "documentation": "<p>Contains information about an AWS access key, without its secret key.</p> <p>This data type is used as a response element in the <a>ListAccessKeys</a> action.</p>",
             "members": [
                 {
                     "name": "UserName",
@@ -1018,6 +1024,7 @@
         },
         "AttachedPolicy": {
             "type": "structure",
+            "documentation": "<p>Contains information about an attached policy.</p> <p>An attached policy is a managed policy that has been attached to a user, group, or role. This data type is used as a response element in the <a>ListAttachedGroupPolicies</a>, <a>ListAttachedRolePolicies</a>, <a>ListAttachedUserPolicies</a>, and <a>GetAccountAuthorizationDetails</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -1060,6 +1067,7 @@
         },
         "CreateAccessKeyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateAccessKey</a> request. </p>",
             "members": [
                 {
                     "name": "AccessKey",
@@ -1095,6 +1103,7 @@
         },
         "CreateGroupResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateGroup</a> request. </p>",
             "members": [
                 {
                     "name": "Group",
@@ -1120,6 +1129,7 @@
         },
         "CreateInstanceProfileResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateInstanceProfile</a> request. </p>",
             "members": [
                 {
                     "name": "InstanceProfile",
@@ -1150,6 +1160,7 @@
         },
         "CreateLoginProfileResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateLoginProfile</a> request. </p>",
             "members": [
                 {
                     "name": "LoginProfile",
@@ -1180,6 +1191,7 @@
         },
         "CreateOpenIDConnectProviderResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateOpenIDConnectProvider</a> request. </p>",
             "members": [
                 {
                     "name": "OpenIDConnectProviderArn",
@@ -1215,6 +1227,7 @@
         },
         "CreatePolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreatePolicy</a> request. </p>",
             "members": [
                 {
                     "name": "Policy",
@@ -1244,6 +1257,7 @@
         },
         "CreatePolicyVersionResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreatePolicyVersion</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyVersion",
@@ -1274,6 +1288,7 @@
         },
         "CreateRoleResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateRole</a> request. </p>",
             "members": [
                 {
                     "name": "Role",
@@ -1299,6 +1314,7 @@
         },
         "CreateSAMLProviderResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateSAMLProvider</a> request. </p>",
             "members": [
                 {
                     "name": "SAMLProviderArn",
@@ -1324,6 +1340,7 @@
         },
         "CreateUserResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateUser</a> request. </p>",
             "members": [
                 {
                     "name": "User",
@@ -1349,6 +1366,7 @@
         },
         "CreateVirtualMFADeviceResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>CreateVirtualMFADevice</a> request. </p>",
             "members": [
                 {
                     "name": "VirtualMFADevice",
@@ -1359,6 +1377,7 @@
         },
         "CredentialReportExpiredException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the most recent credential report has expired. To generate a new credential report, use <a>GenerateCredentialReport</a>. For more information about credential report expiration, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/credential-reports.html\">Getting Credential Reports</a> in the <i>Using IAM</i> guide.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1368,6 +1387,7 @@
         },
         "CredentialReportNotPresentException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the credential report does not exist. To generate a credential report, use <a>GenerateCredentialReport</a>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1377,6 +1397,7 @@
         },
         "CredentialReportNotReadyException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the credential report is still being generated.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1426,6 +1447,7 @@
         },
         "DeleteConflictException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted to delete a resource that has attached subordinate entities. The error message describes these entities. </p>",
             "members": [
                 {
                     "name": "message",
@@ -1665,6 +1687,7 @@
         },
         "DuplicateCertificateException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the same certificate is associated with an IAM user in the account. </p>",
             "members": [
                 {
                     "name": "message",
@@ -1674,6 +1697,7 @@
         },
         "DuplicateSSHPublicKeyException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the SSH public key is already associated with the specified IAM user.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1708,6 +1732,7 @@
         },
         "EntityAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted to create a resource that already exists.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1717,6 +1742,7 @@
         },
         "EntityTemporarilyUnmodifiableException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it referenced an entity that is temporarily unmodifiable, such as a user name that was deleted and then recreated. The error indicates that the request is likely to succeed if you try again after waiting several minutes. The error message describes the entity. </p>",
             "members": [
                 {
                     "name": "message",
@@ -1729,6 +1755,7 @@
         },
         "GenerateCredentialReportResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GenerateCredentialReport</a> request. </p>",
             "members": [
                 {
                     "name": "State",
@@ -1754,6 +1781,7 @@
         },
         "GetAccessKeyLastUsedResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetAccessKeyLastUsed</a> request. It is also returned as a member of the <a>AccessKeyMetaData</a> structure returned by the <a>ListAccessKeys</a> action.</p>",
             "members": [
                 {
                     "name": "UserName",
@@ -1789,6 +1817,7 @@
         },
         "GetAccountAuthorizationDetailsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetAccountAuthorizationDetails</a> request. </p>",
             "members": [
                 {
                     "name": "UserDetailList",
@@ -1824,6 +1853,7 @@
         },
         "GetAccountPasswordPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetAccountPasswordPolicy</a> request. </p>",
             "members": [
                 {
                     "name": "PasswordPolicy",
@@ -1833,6 +1863,7 @@
         },
         "GetAccountSummaryResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetAccountSummary</a> request. </p>",
             "members": [
                 {
                     "name": "SummaryMap",
@@ -1843,6 +1874,7 @@
         },
         "GetCredentialReportResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetCredentialReport</a> request. </p>",
             "members": [
                 {
                     "name": "Content",
@@ -1878,6 +1910,7 @@
         },
         "GetGroupPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetGroupPolicy</a> request. </p>",
             "members": [
                 {
                     "name": "GroupName",
@@ -1918,6 +1951,7 @@
         },
         "GetGroupResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetGroup</a> request. </p>",
             "members": [
                 {
                     "name": "Group",
@@ -1953,6 +1987,7 @@
         },
         "GetInstanceProfileResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetInstanceProfile</a> request. </p>",
             "members": [
                 {
                     "name": "InstanceProfile",
@@ -1973,6 +2008,7 @@
         },
         "GetLoginProfileResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetLoginProfile</a> request. </p>",
             "members": [
                 {
                     "name": "LoginProfile",
@@ -1993,6 +2029,7 @@
         },
         "GetOpenIDConnectProviderResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetOpenIDConnectProvider</a> request. </p>",
             "members": [
                 {
                     "name": "Url",
@@ -2027,6 +2064,7 @@
         },
         "GetPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetPolicy</a> request. </p>",
             "members": [
                 {
                     "name": "Policy",
@@ -2051,6 +2089,7 @@
         },
         "GetPolicyVersionResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetPolicyVersion</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyVersion",
@@ -2076,6 +2115,7 @@
         },
         "GetRolePolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetRolePolicy</a> request. </p>",
             "members": [
                 {
                     "name": "RoleName",
@@ -2106,6 +2146,7 @@
         },
         "GetRoleResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetRole</a> request. </p>",
             "members": [
                 {
                     "name": "Role",
@@ -2126,6 +2167,7 @@
         },
         "GetSAMLProviderResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetSAMLProvider</a> request. </p>",
             "members": [
                 {
                     "name": "SAMLMetadataDocument",
@@ -2166,6 +2208,7 @@
         },
         "GetSSHPublicKeyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetSSHPublicKey</a> request.</p>",
             "members": [
                 {
                     "name": "SSHPublicKey",
@@ -2186,6 +2229,7 @@
         },
         "GetServerCertificateResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetServerCertificate</a> request. </p>",
             "members": [
                 {
                     "name": "ServerCertificate",
@@ -2211,6 +2255,7 @@
         },
         "GetUserPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetUserPolicy</a> request. </p>",
             "members": [
                 {
                     "name": "UserName",
@@ -2241,6 +2286,7 @@
         },
         "GetUserResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetUser</a> request. </p>",
             "members": [
                 {
                     "name": "User",
@@ -2251,6 +2297,7 @@
         },
         "Group": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM group entity.</p> <p> This data type is used as a response element in the following actions:</p> <ul> <li> <a>CreateGroup</a> </li> <li> <a>GetGroup</a> </li> <li> <a>ListGroups</a> </li> </ul>",
             "members": [
                 {
                     "name": "Path",
@@ -2281,6 +2328,7 @@
         },
         "GroupDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM group, including all of the group's policies. </p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>",
             "members": [
                 {
                     "name": "Path",
@@ -2320,6 +2368,7 @@
         },
         "InstanceProfile": {
             "type": "structure",
+            "documentation": "<p>Contains information about an instance profile.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateInstanceProfile</a> </p> </li> <li> <p> <a>GetInstanceProfile</a> </p> </li> <li> <p> <a>ListInstanceProfiles</a> </p> </li> <li> <p> <a>ListInstanceProfilesForRole</a> </p> </li> </ul>",
             "members": [
                 {
                     "name": "Path",
@@ -2355,6 +2404,7 @@
         },
         "InvalidAuthenticationCodeException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the authentication code was not recognized. The error message describes the specific error. </p>",
             "members": [
                 {
                     "name": "message",
@@ -2364,6 +2414,7 @@
         },
         "InvalidCertificateException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the certificate is invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2373,6 +2424,7 @@
         },
         "InvalidInputException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because an invalid or out-of-range value was supplied for an input parameter.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2382,6 +2434,7 @@
         },
         "InvalidPublicKeyException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the public key is malformed or otherwise invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2391,6 +2444,7 @@
         },
         "InvalidUserTypeException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the type of user for the transaction was incorrect.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2400,6 +2454,7 @@
         },
         "KeyPairMismatchException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the public key certificate and the private key do not match.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2409,6 +2464,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted to create resources beyond the current AWS account limits. The error message describes the limit exceeded. </p>",
             "members": [
                 {
                     "name": "message",
@@ -2438,6 +2494,7 @@
         },
         "ListAccessKeysResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListAccessKeys</a> request. </p>",
             "members": [
                 {
                     "name": "AccessKeyMetadata",
@@ -2473,6 +2530,7 @@
         },
         "ListAccountAliasesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListAccountAliases</a> request. </p>",
             "members": [
                 {
                     "name": "AccountAliases",
@@ -2518,6 +2576,7 @@
         },
         "ListAttachedGroupPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListAttachedGroupPolicies</a> request. </p>",
             "members": [
                 {
                     "name": "AttachedPolicies",
@@ -2563,6 +2622,7 @@
         },
         "ListAttachedRolePoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListAttachedRolePolicies</a> request. </p>",
             "members": [
                 {
                     "name": "AttachedPolicies",
@@ -2608,6 +2668,7 @@
         },
         "ListAttachedUserPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListAttachedUserPolicies</a> request. </p>",
             "members": [
                 {
                     "name": "AttachedPolicies",
@@ -2657,6 +2718,7 @@
         },
         "ListEntitiesForPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListEntitiesForPolicy</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyGroups",
@@ -2707,6 +2769,7 @@
         },
         "ListGroupPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListGroupPolicies</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyNames",
@@ -2747,6 +2810,7 @@
         },
         "ListGroupsForUserResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListGroupsForUser</a> request. </p>",
             "members": [
                 {
                     "name": "Groups",
@@ -2787,6 +2851,7 @@
         },
         "ListGroupsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListGroups</a> request. </p>",
             "members": [
                 {
                     "name": "Groups",
@@ -2827,6 +2892,7 @@
         },
         "ListInstanceProfilesForRoleResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListInstanceProfilesForRole</a> request. </p>",
             "members": [
                 {
                     "name": "InstanceProfiles",
@@ -2867,6 +2933,7 @@
         },
         "ListInstanceProfilesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListInstanceProfiles</a> request. </p>",
             "members": [
                 {
                     "name": "InstanceProfiles",
@@ -2907,6 +2974,7 @@
         },
         "ListMFADevicesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListMFADevices</a> request. </p>",
             "members": [
                 {
                     "name": "MFADevices",
@@ -2931,6 +2999,7 @@
         },
         "ListOpenIDConnectProvidersResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListOpenIDConnectProviders</a> request. </p>",
             "members": [
                 {
                     "name": "OpenIDConnectProviderList",
@@ -2971,6 +3040,7 @@
         },
         "ListPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListPolicies</a> request. </p>",
             "members": [
                 {
                     "name": "Policies",
@@ -3010,6 +3080,7 @@
         },
         "ListPolicyVersionsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListPolicyVersions</a> request. </p>",
             "members": [
                 {
                     "name": "Versions",
@@ -3050,6 +3121,7 @@
         },
         "ListRolePoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListRolePolicies</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyNames",
@@ -3090,6 +3162,7 @@
         },
         "ListRolesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListRoles</a> request. </p>",
             "members": [
                 {
                     "name": "Roles",
@@ -3114,6 +3187,7 @@
         },
         "ListSAMLProvidersResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListSAMLProviders</a> request. </p>",
             "members": [
                 {
                     "name": "SAMLProviderList",
@@ -3144,6 +3218,7 @@
         },
         "ListSSHPublicKeysResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListSSHPublicKeys</a> request.</p>",
             "members": [
                 {
                     "name": "SSHPublicKeys",
@@ -3184,6 +3259,7 @@
         },
         "ListServerCertificatesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListServerCertificates</a> request. </p>",
             "members": [
                 {
                     "name": "ServerCertificateMetadataList",
@@ -3224,6 +3300,7 @@
         },
         "ListSigningCertificatesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListSigningCertificates</a> request. </p>",
             "members": [
                 {
                     "name": "Certificates",
@@ -3264,6 +3341,7 @@
         },
         "ListUserPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListUserPolicies</a> request. </p>",
             "members": [
                 {
                     "name": "PolicyNames",
@@ -3304,6 +3382,7 @@
         },
         "ListUsersResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListUsers</a> request. </p>",
             "members": [
                 {
                     "name": "Users",
@@ -3344,6 +3423,7 @@
         },
         "ListVirtualMFADevicesResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>ListVirtualMFADevices</a> request. </p>",
             "members": [
                 {
                     "name": "VirtualMFADevices",
@@ -3364,6 +3444,7 @@
         },
         "LoginProfile": {
             "type": "structure",
+            "documentation": "<p>Contains the user name and password create date for a user.</p> <p> This data type is used as a response element in the <a>CreateLoginProfile</a> and <a>GetLoginProfile</a> actions. </p>",
             "members": [
                 {
                     "name": "UserName",
@@ -3384,6 +3465,7 @@
         },
         "MFADevice": {
             "type": "structure",
+            "documentation": "<p>Contains information about an MFA device.</p> <p>This data type is used as a response element in the <a>ListMFADevices</a> action.</p>",
             "members": [
                 {
                     "name": "UserName",
@@ -3404,6 +3486,7 @@
         },
         "MalformedCertificateException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the certificate was malformed or expired. The error message describes the specific error. </p>",
             "members": [
                 {
                     "name": "message",
@@ -3413,6 +3496,7 @@
         },
         "MalformedPolicyDocumentException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the policy document was malformed. The error message describes the specific error. </p>",
             "members": [
                 {
                     "name": "message",
@@ -3422,6 +3506,7 @@
         },
         "ManagedPolicyDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about a managed policy, including the policy's ARN, versions, and the number of principal entities (users, groups, and roles) that the policy is attached to.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p> <p>For more information about managed policies, see <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -3485,6 +3570,7 @@
         },
         "NoSuchEntityException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it referenced an entity that does not exist. The error message describes the entity. </p>",
             "members": [
                 {
                     "name": "message",
@@ -3494,6 +3580,7 @@
         },
         "OpenIDConnectProviderListEntry": {
             "type": "structure",
+            "documentation": "<p>Contains the Amazon Resource Name (ARN) for an IAM OpenID Connect provider.</p>",
             "members": [
                 {
                     "name": "Arn",
@@ -3503,13 +3590,16 @@
         },
         "OpenIDConnectProviderListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of IAM OpenID Connect providers.</p>",
             "of": "OpenIDConnectProviderListEntry"
         },
         "OpenIDConnectProviderUrlType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Contains a URL that specifies the endpoint for an OpenID Connect provider.</p>"
         },
         "PasswordPolicy": {
             "type": "structure",
+            "documentation": "<p>Contains information about the account password policy.</p> <p> This data type is used as a response element in the <a>GetAccountPasswordPolicy</a> action. </p>",
             "members": [
                 {
                     "name": "MinimumPasswordLength",
@@ -3565,6 +3655,7 @@
         },
         "PasswordPolicyViolationException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the provided password did not meet the requirements imposed by the account password policy. </p>",
             "members": [
                 {
                     "name": "message",
@@ -3574,6 +3665,7 @@
         },
         "Policy": {
             "type": "structure",
+            "documentation": "<p>Contains information about a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicy</a>, <a>GetPolicy</a>, and <a>ListPolicies</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -3628,6 +3720,7 @@
         },
         "PolicyDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM policy, including the policy document.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>",
             "members": [
                 {
                     "name": "PolicyName",
@@ -3643,6 +3736,7 @@
         },
         "PolicyGroup": {
             "type": "structure",
+            "documentation": "<p>Contains information about a group that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "GroupName",
@@ -3657,6 +3751,7 @@
         },
         "PolicyRole": {
             "type": "structure",
+            "documentation": "<p>Contains information about a role that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "RoleName",
@@ -3671,6 +3766,7 @@
         },
         "PolicyUser": {
             "type": "structure",
+            "documentation": "<p>Contains information about a user that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> action. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "UserName",
@@ -3685,6 +3781,7 @@
         },
         "PolicyVersion": {
             "type": "structure",
+            "documentation": "<p>Contains information about a version of a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicyVersion</a>, <a>GetPolicyVersion</a>, <a>ListPolicyVersions</a>, and <a>GetAccountAuthorizationDetails</a> actions. </p> <p>For more information about managed policies, refer to <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>",
             "members": [
                 {
                     "name": "Document",
@@ -3852,6 +3949,7 @@
         },
         "Role": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM role.</p> <p> This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateRole</a> </p> </li> <li> <p> <a>GetRole</a> </p> </li> <li> <p> <a>ListRoles</a> </p> </li> </ul>",
             "members": [
                 {
                     "name": "Path",
@@ -3887,6 +3985,7 @@
         },
         "RoleDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM role, including all of the role's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>",
             "members": [
                 {
                     "name": "Path",
@@ -3938,6 +4037,7 @@
         },
         "SAMLProviderListEntry": {
             "type": "structure",
+            "documentation": "<p>Contains the list of SAML providers for this account.</p>",
             "members": [
                 {
                     "name": "Arn",
@@ -3965,6 +4065,7 @@
         },
         "SSHPublicKey": {
             "type": "structure",
+            "documentation": "<p>Contains information about an SSH public key.</p> <p>This data type is used as a response element in the <a>GetSSHPublicKey</a> and <a>UploadSSHPublicKey</a> actions. </p>",
             "members": [
                 {
                     "name": "UserName",
@@ -4004,6 +4105,7 @@
         },
         "SSHPublicKeyMetadata": {
             "type": "structure",
+            "documentation": "<p>Contains information about an SSH public key, without the key's body or fingerprint.</p> <p>This data type is used as a response element in the <a>ListSSHPublicKeys</a> action.</p>",
             "members": [
                 {
                     "name": "UserName",
@@ -4029,6 +4131,7 @@
         },
         "ServerCertificate": {
             "type": "structure",
+            "documentation": "<p>Contains information about a server certificate.</p> <p> This data type is used as a response element in the <a>GetServerCertificate</a> action. </p>",
             "members": [
                 {
                     "name": "ServerCertificateMetadata",
@@ -4049,6 +4152,7 @@
         },
         "ServerCertificateMetadata": {
             "type": "structure",
+            "documentation": "<p>Contains information about a server certificate without its certificate body, certificate chain, and private key. </p> <p> This data type is used as a response element in the <a>UploadServerCertificate</a> and <a>ListServerCertificates</a> actions. </p>",
             "members": [
                 {
                     "name": "Path",
@@ -4084,6 +4188,7 @@
         },
         "ServiceFailureException": {
             "type": "structure",
+            "documentation": "<p>The request processing has failed because of an unknown error, exception or failure. </p>",
             "members": [
                 {
                     "name": "message",
@@ -4107,6 +4212,7 @@
         },
         "SigningCertificate": {
             "type": "structure",
+            "documentation": "<p>Contains information about an X.509 signing certificate.</p> <p>This data type is used as a response element in the <a>UploadSigningCertificate</a> and <a>ListSigningCertificates</a> actions. </p>",
             "members": [
                 {
                     "name": "UserName",
@@ -4137,6 +4243,7 @@
         },
         "UnrecognizedPublicKeyEncodingException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the public key encoding format is unsupported or unrecognized.</p>",
             "members": [
                 {
                     "name": "message",
@@ -4301,6 +4408,7 @@
         },
         "UpdateSAMLProviderResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>UpdateSAMLProvider</a> request. </p>",
             "members": [
                 {
                     "name": "SAMLProviderArn",
@@ -4406,6 +4514,7 @@
         },
         "UploadSSHPublicKeyResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>UploadSSHPublicKey</a> request.</p>",
             "members": [
                 {
                     "name": "SSHPublicKey",
@@ -4446,6 +4555,7 @@
         },
         "UploadServerCertificateResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>UploadServerCertificate</a> request. </p>",
             "members": [
                 {
                     "name": "ServerCertificateMetadata",
@@ -4471,6 +4581,7 @@
         },
         "UploadSigningCertificateResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>UploadSigningCertificate</a> request. </p>",
             "members": [
                 {
                     "name": "Certificate",
@@ -4481,6 +4592,7 @@
         },
         "User": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM user entity.</p> <p> This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateUser</a> </p> </li> <li> <p> <a>GetUser</a> </p> </li> <li> <p> <a>ListUsers</a> </p> </li> </ul>",
             "members": [
                 {
                     "name": "Path",
@@ -4516,6 +4628,7 @@
         },
         "UserDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about an IAM user, including all the user's policies and all the IAM groups the user is in.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> action.</p>",
             "members": [
                 {
                     "name": "Path",
@@ -4560,6 +4673,7 @@
         },
         "VirtualMFADevice": {
             "type": "structure",
+            "documentation": "<p>Contains information about a virtual MFA device.</p>",
             "members": [
                 {
                     "name": "SerialNumber",
@@ -4592,6 +4706,7 @@
         },
         "accessKeyMetadataListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of access key metadata.</p> <p>This data type is used as a response element in the <a>ListAccessKeys</a> action.</p>",
             "of": "AccessKeyMetadata"
         },
         "accessKeySecretType": {
@@ -4605,7 +4720,8 @@
             "type": "string"
         },
         "arnType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The Amazon Resource Name (ARN). ARNs are unique identifiers for AWS resources. </p> <p>For more information about ARNs, go to <a href=\"http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>. </p>"
         },
         "assignmentStatusType": {
             "type": "string"
@@ -4637,6 +4753,7 @@
         },
         "certificateListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of signing certificates.</p> <p>This data type is used as a response element in the <a>ListSigningCertificates</a> action.</p>",
             "of": "SigningCertificate"
         },
         "clientIDListType": {
@@ -4689,6 +4806,7 @@
         },
         "groupListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of IAM groups.</p> <p>This data type is used as a response element in the <a>ListGroups</a> action.</p>",
             "of": "Group"
         },
         "groupNameListType": {
@@ -4703,6 +4821,7 @@
         },
         "instanceProfileListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of instance profiles.</p>",
             "of": "InstanceProfile"
         },
         "instanceProfileNameType": {
@@ -4746,6 +4865,7 @@
         },
         "mfaDeviceListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of MFA devices.</p> <p>This data type is used as a response element in the <a>ListMFADevices</a> and <a>ListVirtualMFADevices</a> actions. </p>",
             "of": "MFADevice"
         },
         "minimumPasswordLengthType": {
@@ -4789,6 +4909,7 @@
         },
         "policyNameListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of policy names.</p> <p>This data type is used as a response element in the <a>ListPolicies</a> action.</p>",
             "of": "policyNameType"
         },
         "policyNameType": {
@@ -4821,6 +4942,7 @@
         },
         "roleListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of IAM roles.</p> <p>This data type is used as a response element in the <a>ListRoles</a> action.</p>",
             "of": "Role"
         },
         "roleNameType": {
@@ -4849,17 +4971,21 @@
             "type": "string"
         },
         "summaryMapType": {
-            "type": "map"
+            "type": "map",
+            "key": "summaryKeyType",
+            "value": "summaryValueType"
         },
         "summaryValueType": {
             "type": "integer"
         },
         "thumbprintListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of thumbprints of identity provider server certificates.</p>",
             "of": "thumbprintType"
         },
         "thumbprintType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Contains a thumbprint for an identity provider's server certificate.</p> <p>The identity provider's server certificate thumbprint is the hex-encoded SHA-1 hash value of the self-signed X.509 certificate used by the domain where the OpenID Connect provider makes its keys available. It is always a 40-character string. </p>"
         },
         "unrecognizedPublicKeyEncodingMessage": {
             "type": "string"
@@ -4870,6 +4996,7 @@
         },
         "userListType": {
             "type": "list",
+            "documentation": "<p>Contains a list of users.</p> <p>This data type is used as a response element in the <a>GetGroup</a> and <a>ListUsers</a> actions. </p>",
             "of": "User"
         },
         "userNameType": {

--- a/libcloudcore/data/aws/importexport/service.json
+++ b/libcloudcore/data/aws/importexport/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://importexport.amazonaws.com/doc/2010-06-01/"
         }
@@ -100,10 +103,12 @@
     },
     "shapes": {
         "APIVersion": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Specifies the version of the client tool."
         },
         "Artifact": {
             "type": "structure",
+            "documentation": "A discrete item that contains the description and URL of an artifact (such as a PDF).",
             "members": [
                 {
                     "name": "Description",
@@ -117,10 +122,12 @@
         },
         "ArtifactList": {
             "type": "list",
+            "documentation": "A collection of artifacts.",
             "of": "Artifact"
         },
         "BucketPermissionException": {
             "type": "structure",
+            "documentation": "The account specified does not have the appropriate bucket permissions.",
             "members": [
                 {
                     "name": "message",
@@ -130,6 +137,7 @@
         },
         "CancelJobInput": {
             "type": "structure",
+            "documentation": "Input structure for the CancelJob operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -143,6 +151,7 @@
         },
         "CancelJobOutput": {
             "type": "structure",
+            "documentation": "Output structure for the CancelJob operation.",
             "members": [
                 {
                     "name": "Success",
@@ -152,6 +161,7 @@
         },
         "CanceledJobIdException": {
             "type": "structure",
+            "documentation": "The specified job ID has been canceled and is no longer valid.",
             "members": [
                 {
                     "name": "message",
@@ -160,10 +170,12 @@
             ]
         },
         "Carrier": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Name of the shipping company. This value is included when the LocationCode is \"Returned\"."
         },
         "CreateJobInput": {
             "type": "structure",
+            "documentation": "Input structure for the CreateJob operation.",
             "members": [
                 {
                     "name": "JobType",
@@ -189,6 +201,7 @@
         },
         "CreateJobOutput": {
             "type": "structure",
+            "documentation": "Output structure for the CreateJob operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -218,6 +231,7 @@
         },
         "CreateJobQuotaExceededException": {
             "type": "structure",
+            "documentation": "Each account can create only a certain number of jobs per day. If you need to create more than this, please contact awsimportexport@amazon.com to explain your particular use case.",
             "members": [
                 {
                     "name": "message",
@@ -226,22 +240,28 @@
             ]
         },
         "CreationDate": {
-            "type": "timestamp"
+            "type": "timestamp",
+            "documentation": "Timestamp of the CreateJob request in ISO8601 date format. For example \"2010-03-28T20:27:35Z\"."
         },
         "CurrentManifest": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The last manifest submitted, which will be used to process the job."
         },
         "Description": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The associated description for this object."
         },
         "ErrorCount": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "Number of errors. We return this value when the ProgressCode is Success or SuccessWithErrors."
         },
         "ErrorMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The human-readable description of a particular error."
         },
         "ExpiredJobIdException": {
             "type": "structure",
+            "documentation": "Indicates that the specified job has expired out of the system.",
             "members": [
                 {
                     "name": "message",
@@ -320,6 +340,7 @@
         },
         "GetStatusInput": {
             "type": "structure",
+            "documentation": "Input structure for the GetStatus operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -333,6 +354,7 @@
         },
         "GetStatusOutput": {
             "type": "structure",
+            "documentation": "Output structure for the GetStatus operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -402,6 +424,7 @@
         },
         "InvalidAccessKeyIdException": {
             "type": "structure",
+            "documentation": "The AWS Access Key ID specified in the request did not match the manifest's accessKeyId value. The manifest and the request authentication must use the same AWS Access Key ID.",
             "members": [
                 {
                     "name": "message",
@@ -411,6 +434,7 @@
         },
         "InvalidAddressException": {
             "type": "structure",
+            "documentation": "The address specified in the manifest is invalid.",
             "members": [
                 {
                     "name": "message",
@@ -420,6 +444,7 @@
         },
         "InvalidCustomsException": {
             "type": "structure",
+            "documentation": "One or more customs parameters was invalid. Please correct and resubmit.",
             "members": [
                 {
                     "name": "message",
@@ -429,6 +454,7 @@
         },
         "InvalidFileSystemException": {
             "type": "structure",
+            "documentation": "File system specified in export manifest is invalid.",
             "members": [
                 {
                     "name": "message",
@@ -438,6 +464,7 @@
         },
         "InvalidJobIdException": {
             "type": "structure",
+            "documentation": "The JOBID was missing, not found, or not associated with the AWS account.",
             "members": [
                 {
                     "name": "message",
@@ -447,6 +474,7 @@
         },
         "InvalidManifestFieldException": {
             "type": "structure",
+            "documentation": "One or more manifest fields was invalid. Please correct and resubmit.",
             "members": [
                 {
                     "name": "message",
@@ -456,6 +484,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "One or more parameters had an invalid value.",
             "members": [
                 {
                     "name": "message",
@@ -465,6 +494,7 @@
         },
         "InvalidVersionException": {
             "type": "structure",
+            "documentation": "The client tool version is invalid.",
             "members": [
                 {
                     "name": "message",
@@ -473,13 +503,16 @@
             ]
         },
         "IsCanceled": {
-            "type": "boolean"
+            "type": "boolean",
+            "documentation": "Indicates whether the job was canceled."
         },
         "IsTruncated": {
-            "type": "boolean"
+            "type": "boolean",
+            "documentation": "Indicates whether the list of jobs was truncated. If true, then call ListJobs again using the last JobId element as the marker."
         },
         "Job": {
             "type": "structure",
+            "documentation": "Representation of a job returned by the ListJobs operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -500,21 +533,25 @@
             ]
         },
         "JobId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "A unique identifier which refers to a particular job."
         },
         "JobIdList": {
             "type": "list",
             "of": "GenericString"
         },
         "JobType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Specifies whether the job to initiate is an import or export job."
         },
         "JobsList": {
             "type": "list",
+            "documentation": "A list container for Jobs returned by the ListJobs operation.",
             "of": "Job"
         },
         "ListJobsInput": {
             "type": "structure",
+            "documentation": "Input structure for the ListJobs operation.",
             "members": [
                 {
                     "name": "MaxJobs",
@@ -532,6 +569,7 @@
         },
         "ListJobsOutput": {
             "type": "structure",
+            "documentation": "Output structure for the ListJobs operation.",
             "members": [
                 {
                     "name": "Jobs",
@@ -544,19 +582,24 @@
             ]
         },
         "LocationCode": {
-            "type": "string"
+            "type": "string",
+            "documentation": "A token representing the location of the storage device, such as \"AtAWS\"."
         },
         "LocationMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "A more human readable form of the physical location of the storage device."
         },
         "LogBucket": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Amazon S3 bucket for user logs."
         },
         "LogKey": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The key where the user logs were stored."
         },
         "MalformedManifestException": {
             "type": "structure",
+            "documentation": "Your manifest is not well-formed.",
             "members": [
                 {
                     "name": "message",
@@ -565,19 +608,24 @@
             ]
         },
         "Manifest": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The UTF-8 encoded text of the manifest file."
         },
         "ManifestAddendum": {
-            "type": "string"
+            "type": "string",
+            "documentation": "For internal use only."
         },
         "Marker": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Specifies the JOBID to start after when listing the jobs created with your account. AWS Import/Export lists your jobs in reverse chronological order. See MaxJobs."
         },
         "MaxJobs": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "Sets the maximum number of jobs returned in the response. If there are additional jobs that were not returned because MaxJobs was exceeded, the response contains &lt;IsTruncated&gt;true&lt;/IsTruncated&gt;. To return the additional jobs, see Marker."
         },
         "MissingCustomsException": {
             "type": "structure",
+            "documentation": "One or more required customs parameters was missing from the manifest.",
             "members": [
                 {
                     "name": "message",
@@ -587,6 +635,7 @@
         },
         "MissingManifestFieldException": {
             "type": "structure",
+            "documentation": "One or more required fields were missing from the manifest file. Please correct and resubmit.",
             "members": [
                 {
                     "name": "message",
@@ -596,6 +645,7 @@
         },
         "MissingParameterException": {
             "type": "structure",
+            "documentation": "One or more required parameters was missing from the request.",
             "members": [
                 {
                     "name": "message",
@@ -605,6 +655,7 @@
         },
         "MultipleRegionsException": {
             "type": "structure",
+            "documentation": "Your manifest file contained buckets from multiple regions. A job is restricted to buckets from one region. Please correct and resubmit.",
             "members": [
                 {
                     "name": "message",
@@ -614,6 +665,7 @@
         },
         "NoSuchBucketException": {
             "type": "structure",
+            "documentation": "The specified bucket does not exist. Create the specified bucket or change the manifest's bucket, exportBucket, or logBucket field to a bucket that the account, as specified by the manifest's Access Key ID, has write permissions to.",
             "members": [
                 {
                     "name": "message",
@@ -622,28 +674,36 @@
             ]
         },
         "ProgressCode": {
-            "type": "string"
+            "type": "string",
+            "documentation": "A token representing the state of the job, such as \"Started\"."
         },
         "ProgressMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "A more human readable form of the job status."
         },
         "Signature": {
-            "type": "string"
+            "type": "string",
+            "documentation": "An encrypted code used to authenticate the request and response, for example, \"DV+TpDfx1/TdSE9ktyK9k/bDTVI=\". Only use this value is you want to create the signature file yourself. Generally you should use the SignatureFileContents value."
         },
         "SignatureFileContents": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The actual text of the SIGNATURE file to be written to disk."
         },
         "Success": {
-            "type": "boolean"
+            "type": "boolean",
+            "documentation": "Specifies whether (true) or not (false) AWS Import/Export updated your job."
         },
         "TrackingNumber": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The shipping tracking number assigned by AWS Import/Export to the storage device when it's returned to you. We return this value when the LocationCode is \"Returned\"."
         },
         "URL": {
-            "type": "string"
+            "type": "string",
+            "documentation": "The URL for a given Artifact."
         },
         "UnableToCancelJobIdException": {
             "type": "structure",
+            "documentation": "AWS Import/Export cannot cancel the job",
             "members": [
                 {
                     "name": "message",
@@ -653,6 +713,7 @@
         },
         "UnableToUpdateJobIdException": {
             "type": "structure",
+            "documentation": "AWS Import/Export cannot update the job",
             "members": [
                 {
                     "name": "message",
@@ -662,6 +723,7 @@
         },
         "UpdateJobInput": {
             "type": "structure",
+            "documentation": "Input structure for the UpateJob operation.",
             "members": [
                 {
                     "name": "JobId",
@@ -687,6 +749,7 @@
         },
         "UpdateJobOutput": {
             "type": "structure",
+            "documentation": "Output structure for the UpateJob operation.",
             "members": [
                 {
                     "name": "Success",
@@ -703,10 +766,12 @@
             ]
         },
         "ValidateOnly": {
-            "type": "boolean"
+            "type": "boolean",
+            "documentation": "Validate the manifest and parameter values in the request but do not actually create a job."
         },
         "WarningMessage": {
-            "type": "string"
+            "type": "string",
+            "documentation": "An optional message notifying you of non-fatal issues with the job, such as use of an incompatible Amazon S3 bucket name."
         }
     }
 }

--- a/libcloudcore/data/aws/kinesis/service.json
+++ b/libcloudcore/data/aws/kinesis/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -130,6 +134,7 @@
     "shapes": {
         "AddTagsToStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>AddTagsToStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -148,6 +153,7 @@
         },
         "CreateStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>CreateStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -166,6 +172,7 @@
         },
         "DeleteStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>DeleteStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -176,6 +183,7 @@
         },
         "DescribeStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>DescribeStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -199,6 +207,7 @@
         },
         "DescribeStreamOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>DescribeStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamDescription",
@@ -215,6 +224,7 @@
         },
         "ExpiredIteratorException": {
             "type": "structure",
+            "documentation": "<p>The provided iterator exceeds the maximum age allowed.</p>",
             "members": [
                 {
                     "name": "message",
@@ -225,6 +235,7 @@
         },
         "GetRecordsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <a>GetRecords</a>.</p>",
             "members": [
                 {
                     "name": "ShardIterator",
@@ -243,6 +254,7 @@
         },
         "GetRecordsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <a>GetRecords</a>.</p>",
             "members": [
                 {
                     "name": "Records",
@@ -263,6 +275,7 @@
         },
         "GetShardIteratorInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>GetShardIterator</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -288,6 +301,7 @@
         },
         "GetShardIteratorOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>GetShardIterator</code>.</p>",
             "members": [
                 {
                     "name": "ShardIterator",
@@ -301,6 +315,7 @@
         },
         "HashKeyRange": {
             "type": "structure",
+            "documentation": "<p>The range of possible hash key values for the shard, which is a set of ordered contiguous positive integers.</p>",
             "members": [
                 {
                     "name": "StartingHashKey",
@@ -316,6 +331,7 @@
         },
         "InvalidArgumentException": {
             "type": "structure",
+            "documentation": "<p>A specified parameter exceeds its restrictions, is not supported, or can't be used. For more information, see the returned message.</p>",
             "members": [
                 {
                     "name": "message",
@@ -326,6 +342,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The requested resource exceeds the maximum number allowed, or the number of concurrent stream requests exceeds the maximum number allowed (5).</p>",
             "members": [
                 {
                     "name": "message",
@@ -336,6 +353,7 @@
         },
         "ListStreamsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>ListStreams</code>.</p>",
             "members": [
                 {
                     "name": "Limit",
@@ -354,6 +372,7 @@
         },
         "ListStreamsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>ListStreams</code>.</p>",
             "members": [
                 {
                     "name": "StreamNames",
@@ -369,6 +388,7 @@
         },
         "ListTagsForStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>ListTagsForStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -392,6 +412,7 @@
         },
         "ListTagsForStreamOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>ListTagsForStream</code>.</p>",
             "members": [
                 {
                     "name": "Tags",
@@ -407,6 +428,7 @@
         },
         "MergeShardsInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>MergeShards</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -436,6 +458,7 @@
         },
         "ProvisionedThroughputExceededException": {
             "type": "structure",
+            "documentation": "<p>The request rate is too high, or the requested data is too large for the available throughput. Reduce the frequency or size of your requests. For more information, see <a href=\"http://docs.aws.amazon.com/general/latest/gr/api-retries.html\" target=\"_blank\">Error Retries and Exponential Backoff in AWS</a> in the <i>AWS General Reference</i>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -446,6 +469,7 @@
         },
         "PutRecordInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>PutRecord</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -476,6 +500,7 @@
         },
         "PutRecordOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>PutRecord</code>.</p>",
             "members": [
                 {
                     "name": "ShardId",
@@ -491,6 +516,7 @@
         },
         "PutRecordsInput": {
             "type": "structure",
+            "documentation": "<p>A <code>PutRecords</code> request.</p>",
             "members": [
                 {
                     "name": "Records",
@@ -506,6 +532,7 @@
         },
         "PutRecordsOutput": {
             "type": "structure",
+            "documentation": "<p><code>PutRecords</code> results.</p>",
             "members": [
                 {
                     "name": "FailedRecordCount",
@@ -521,6 +548,7 @@
         },
         "PutRecordsRequestEntry": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>PutRecords</code>.</p>",
             "members": [
                 {
                     "name": "Data",
@@ -545,6 +573,7 @@
         },
         "PutRecordsResultEntry": {
             "type": "structure",
+            "documentation": "<p>Represents the result of an individual record from a <code>PutRecords</code> request. A record that is successfully added to your Amazon Kinesis stream includes SequenceNumber and ShardId in the result. A record that fails to be added to your Amazon Kinesis stream includes ErrorCode and ErrorMessage in the result.</p>",
             "members": [
                 {
                     "name": "SequenceNumber",
@@ -574,6 +603,7 @@
         },
         "Record": {
             "type": "structure",
+            "documentation": "<p>The unit of data of the Amazon Kinesis stream, which is composed of a sequence number, a partition key, and a data blob.</p>",
             "members": [
                 {
                     "name": "SequenceNumber",
@@ -598,6 +628,7 @@
         },
         "RemoveTagsFromStreamInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>RemoveTagsFromStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -613,6 +644,7 @@
         },
         "ResourceInUseException": {
             "type": "structure",
+            "documentation": "<p>The resource is not available for this operation. For example, you attempted to split a shard but the stream is not in the <code>ACTIVE</code> state.</p>",
             "members": [
                 {
                     "name": "message",
@@ -623,6 +655,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The requested resource could not be found. It might not be specified correctly, or it might not be in the <code>ACTIVE</code> state.</p>",
             "members": [
                 {
                     "name": "message",
@@ -636,6 +669,7 @@
         },
         "SequenceNumberRange": {
             "type": "structure",
+            "documentation": "<p>The range of possible sequence numbers for the shard.</p>",
             "members": [
                 {
                     "name": "StartingSequenceNumber",
@@ -651,6 +685,7 @@
         },
         "Shard": {
             "type": "structure",
+            "documentation": "<p>A uniquely identified group of data records in an Amazon Kinesis stream.</p>",
             "members": [
                 {
                     "name": "ShardId",
@@ -694,6 +729,7 @@
         },
         "SplitShardInput": {
             "type": "structure",
+            "documentation": "<p>Represents the input for <code>SplitShard</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -717,6 +753,7 @@
         },
         "StreamDescription": {
             "type": "structure",
+            "documentation": "<p>Represents the output for <code>DescribeStream</code>.</p>",
             "members": [
                 {
                     "name": "StreamName",
@@ -757,6 +794,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Metadata assigned to the stream, consisting of a key-value pair.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -782,7 +820,9 @@
             "of": "Tag"
         },
         "TagMap": {
-            "type": "map"
+            "type": "map",
+            "key": "TagKey",
+            "value": "TagValue"
         },
         "TagValue": {
             "type": "string"

--- a/libcloudcore/data/aws/kms/service.json
+++ b/libcloudcore/data/aws/kms/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -239,6 +243,7 @@
         },
         "AliasListEntry": {
             "type": "structure",
+            "documentation": "Contains information about an alias.",
             "members": [
                 {
                     "name": "AliasName",
@@ -262,6 +267,7 @@
         },
         "AlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because it attempted to create a resource that already exists.</p>",
             "members": [
                 {
                     "name": "message",
@@ -426,6 +432,7 @@
         },
         "DependencyTimeoutException": {
             "type": "structure",
+            "documentation": "<p>The system timed out while trying to fulfill the request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -478,6 +485,7 @@
         },
         "DisabledException": {
             "type": "structure",
+            "documentation": "<p>A request was rejected because the specified key was marked as disabled.</p>",
             "members": [
                 {
                     "name": "message",
@@ -549,7 +557,9 @@
             "type": "string"
         },
         "EncryptionContextType": {
-            "type": "map"
+            "type": "map",
+            "key": "EncryptionContextKey",
+            "value": "EncryptionContextValue"
         },
         "EncryptionContextValue": {
             "type": "string"
@@ -719,6 +729,7 @@
         },
         "GrantConstraints": {
             "type": "structure",
+            "documentation": "Contains constraints on the grant.",
             "members": [
                 {
                     "name": "EncryptionContextSubset",
@@ -741,6 +752,7 @@
         },
         "GrantListEntry": {
             "type": "structure",
+            "documentation": "<p>Contains information about each entry in the grant list.</p>",
             "members": [
                 {
                     "name": "GrantId",
@@ -790,6 +802,7 @@
         },
         "InvalidAliasNameException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the specified alias name is not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -799,6 +812,7 @@
         },
         "InvalidArnException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because a specified ARN was not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -808,6 +822,7 @@
         },
         "InvalidCiphertextException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the specified ciphertext has been corrupted or is otherwise invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -817,6 +832,7 @@
         },
         "InvalidGrantTokenException": {
             "type": "structure",
+            "documentation": "<p>A grant token provided as part of the request is invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -826,6 +842,7 @@
         },
         "InvalidKeyUsageException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the specified KeySpec parameter is not valid. The currently supported value is ENCRYPT/DECRYPT. </p>",
             "members": [
                 {
                     "name": "message",
@@ -835,6 +852,7 @@
         },
         "InvalidMarkerException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the marker that specifies where pagination should next begin is not valid. </p>",
             "members": [
                 {
                     "name": "message",
@@ -844,6 +862,7 @@
         },
         "KMSInternalException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because an internal exception occurred. This error can be retried.</p>",
             "members": [
                 {
                     "name": "message",
@@ -860,6 +879,7 @@
         },
         "KeyListEntry": {
             "type": "structure",
+            "documentation": "<p>Contains information about each entry in the key list.</p>",
             "members": [
                 {
                     "name": "KeyId",
@@ -875,6 +895,7 @@
         },
         "KeyMetadata": {
             "type": "structure",
+            "documentation": "Contains metadata associated with a specific key.",
             "members": [
                 {
                     "name": "AWSAccountId",
@@ -915,6 +936,7 @@
         },
         "KeyUnavailableException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the key was disabled, not found, or otherwise not available.</p>",
             "members": [
                 {
                     "name": "message",
@@ -927,6 +949,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because a quota was exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1089,6 +1112,7 @@
         },
         "MalformedPolicyDocumentException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the specified policy is not syntactically or semantically correct. </p>",
             "members": [
                 {
                     "name": "message",
@@ -1101,6 +1125,7 @@
         },
         "NotFoundException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the specified entity or resource could not be found. </p>",
             "members": [
                 {
                     "name": "message",
@@ -1234,6 +1259,7 @@
         },
         "UnsupportedOperationException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because a specified parameter is not supported.</p>",
             "members": [
                 {
                     "name": "message",

--- a/libcloudcore/data/aws/lambda/service.json
+++ b/libcloudcore/data/aws/lambda/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -361,6 +365,7 @@
         },
         "EventSourceMappingConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes mapping between an Amazon Kinesis stream and a Lambda function.</p>",
             "members": [
                 {
                     "name": "UUID",
@@ -416,6 +421,7 @@
         },
         "FunctionCode": {
             "type": "structure",
+            "documentation": "<p>The code for the Lambda function.</p>",
             "members": [
                 {
                     "name": "ZipFile",
@@ -441,6 +447,7 @@
         },
         "FunctionCodeLocation": {
             "type": "structure",
+            "documentation": "<p>The object for the Lambda function location.</p>",
             "members": [
                 {
                     "name": "RepositoryType",
@@ -456,6 +463,7 @@
         },
         "FunctionConfiguration": {
             "type": "structure",
+            "documentation": "<p>A complex type that describes function metadata.</p>",
             "members": [
                 {
                     "name": "FunctionName",
@@ -554,6 +562,7 @@
         },
         "GetFunctionResponse": {
             "type": "structure",
+            "documentation": "<p>This response contains the object for the Lambda function location (see <a>API_FunctionCodeLocation</a></p>",
             "members": [
                 {
                     "name": "Configuration",
@@ -598,6 +607,7 @@
         },
         "InvalidParameterValueException": {
             "type": "structure",
+            "documentation": "<p>One of the parameters in the request is invalid. For example, if you provided an IAM role for AWS Lambda to assume in the <code>CreateFunction</code> or the <code>UpdateFunctionConfiguration</code> API, that AWS Lambda is unable to assume you will get this exception. </p>",
             "members": [
                 {
                     "name": "Type",
@@ -611,6 +621,7 @@
         },
         "InvalidRequestContentException": {
             "type": "structure",
+            "documentation": "<p>The request body could not be parsed as JSON.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -662,6 +673,7 @@
         },
         "InvocationResponse": {
             "type": "structure",
+            "documentation": "<p>Upon success, returns an empty response. Otherwise, throws an exception.</p>",
             "members": [
                 {
                     "name": "StatusCode",
@@ -712,6 +724,7 @@
         },
         "InvokeAsyncResponse": {
             "type": "structure",
+            "documentation": "<p>Upon success, it returns empty response. Otherwise, throws an exception.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -756,6 +769,7 @@
         },
         "ListEventSourceMappingsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains a list of event sources (see <a>API_EventSourceMappingConfiguration</a>)</p>",
             "members": [
                 {
                     "name": "NextMarker",
@@ -790,6 +804,7 @@
         },
         "ListFunctionsResponse": {
             "type": "structure",
+            "documentation": "<p>Contains a list of AWS Lambda function configurations (see <a>FunctionConfiguration</a>.</p>",
             "members": [
                 {
                     "name": "NextMarker",
@@ -817,6 +832,7 @@
         },
         "PolicyLengthExceededException": {
             "type": "structure",
+            "documentation": "<p>Lambda function access policy is limited to 20 KB.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -865,6 +881,7 @@
         },
         "ResourceConflictException": {
             "type": "structure",
+            "documentation": "<p>The resource already exists.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -878,6 +895,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>The resource (for example, a Lambda function or access policy statement) specified in the request does not exist.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -906,6 +924,7 @@
         },
         "ServiceException": {
             "type": "structure",
+            "documentation": "<p>The AWS Lambda service encountered an internal error.</p>",
             "members": [
                 {
                     "name": "Type",

--- a/libcloudcore/data/aws/logs/service.json
+++ b/libcloudcore/data/aws/logs/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -232,7 +236,8 @@
             ]
         },
         "Days": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653.</p>"
         },
         "DeleteDestinationRequest": {
             "type": "structure",
@@ -344,7 +349,8 @@
             ]
         },
         "DescribeLimit": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>The maximum number of results to return.</p>"
         },
         "DescribeLogGroupsRequest": {
             "type": "structure",
@@ -550,13 +556,17 @@
             "type": "long"
         },
         "EventsLimit": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>The maximum number of events to return.</p>"
         },
         "ExtractedValues": {
-            "type": "map"
+            "type": "map",
+            "key": "Token",
+            "value": "Value"
         },
         "FilterCount": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>The number of metric filters associated with the log group.</p>"
         },
         "FilterLogEventsRequest": {
             "type": "structure",
@@ -624,13 +634,16 @@
             ]
         },
         "FilterName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A name for a metric or subscription filter.</p>"
         },
         "FilterPattern": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A symbolic description of how Amazon CloudWatch Logs should interpret the data in each log event. For example, a log event may contain timestamps, IP addresses, strings, and so on. You use the filter pattern to specify what to look for in the log event message.</p>"
         },
         "FilteredLogEvent": {
             "type": "structure",
+            "documentation": "<p>Represents a matched event from a <code class=\"code\">FilterLogEvents</code> request.</p>",
             "members": [
                 {
                     "name": "logStreamName",
@@ -659,6 +672,7 @@
         },
         "FilteredLogEvents": {
             "type": "list",
+            "documentation": "<p>A list of matched <code class=\"code\">FilteredLogEvent</code> objects returned from a <code class=\"code\">FilterLogEvents</code> request.</p>",
             "of": "FilteredLogEvent"
         },
         "GetLogEventsRequest": {
@@ -718,6 +732,7 @@
         },
         "InputLogEvent": {
             "type": "structure",
+            "documentation": "<p>A log event is a record of some activity that was recorded by the application or resource being monitored. The log event record that Amazon CloudWatch Logs understands contains two properties: the timestamp of when the event occurred, and the raw event message.</p>",
             "members": [
                 {
                     "name": "timestamp",
@@ -731,10 +746,12 @@
         },
         "InputLogEvents": {
             "type": "list",
+            "documentation": "<p>A list of log events belonging to a log stream.</p>",
             "of": "InputLogEvent"
         },
         "InputLogStreamNames": {
             "type": "list",
+            "documentation": "<p>A list of log stream names.</p>",
             "of": "LogStreamName"
         },
         "Interleaved": {
@@ -742,6 +759,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "<p>Returned if a parameter of the request is incorrectly specified.</p>",
             "members": []
         },
         "InvalidSequenceTokenException": {
@@ -755,6 +773,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Returned if you have reached the maximum number of resources that can be created.</p>",
             "members": []
         },
         "LogEventIndex": {
@@ -794,10 +813,12 @@
         },
         "LogGroups": {
             "type": "list",
+            "documentation": "<p>A list of log groups.</p>",
             "of": "LogGroup"
         },
         "LogStream": {
             "type": "structure",
+            "documentation": "<p>A log stream is sequence of log events from a single emitter of logs.</p>",
             "members": [
                 {
                     "name": "logStreamName",
@@ -841,10 +862,12 @@
         },
         "LogStreams": {
             "type": "list",
+            "documentation": "<p>A list of log streams.</p>",
             "of": "LogStream"
         },
         "MetricFilter": {
             "type": "structure",
+            "documentation": "<p>Metric filters can be used to express how Amazon CloudWatch Logs would extract metric observations from ingested log events and transform them to metric data in a CloudWatch metric.</p>",
             "members": [
                 {
                     "name": "filterName",
@@ -890,10 +913,12 @@
             "of": "MetricFilter"
         },
         "MetricName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of the CloudWatch metric to which the monitored log information should be published. For example, you may publish to a metric called ErrorCount.</p>"
         },
         "MetricNamespace": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The destination namespace of the new CloudWatch metric.</p>"
         },
         "MetricTransformation": {
             "type": "structure",
@@ -917,13 +942,16 @@
             "of": "MetricTransformation"
         },
         "MetricValue": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>What to publish to the metric. For example, if you're counting the occurrences of a particular term like \"Error\", the value will be \"1\" for each occurrence. If you're counting the bytes transferred the published value will be the value in the log event.</p>"
         },
         "NextToken": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A string token used for pagination that points to the next page of results. It must be a value obtained from the response of the previous request. The token expires after 24 hours.</p>"
         },
         "OperationAbortedException": {
             "type": "structure",
+            "documentation": "<p>Returned if multiple requests to update the same resource were in conflict.</p>",
             "members": []
         },
         "OrderBy": {
@@ -1119,10 +1147,12 @@
         },
         "ResourceAlreadyExistsException": {
             "type": "structure",
+            "documentation": "<p>Returned if the specified resource already exists.</p>",
             "members": []
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>Returned if the specified resource does not exist.</p>",
             "members": []
         },
         "RoleArn": {
@@ -1130,6 +1160,7 @@
         },
         "SearchedLogStream": {
             "type": "structure",
+            "documentation": "<p>An object indicating the search status of a log stream in a <code class=\"code\">FilterLogEvents</code> request.</p>",
             "members": [
                 {
                     "name": "logStreamName",
@@ -1145,13 +1176,16 @@
         },
         "SearchedLogStreams": {
             "type": "list",
+            "documentation": "<p>A list of <code class=\"code\">SearchedLogStream</code> objects indicating the search status for log streams in a <code class=\"code\">FilterLogEvents</code> request.</p>",
             "of": "SearchedLogStream"
         },
         "SequenceToken": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A string token used for making PutLogEvents requests. A <code class=\"code\">sequenceToken</code> can only be used once, and PutLogEvents requests must include the <code class=\"code\">sequenceToken</code> obtained from the response of the previous request.</p>"
         },
         "ServiceUnavailableException": {
             "type": "structure",
+            "documentation": "<p>Returned if the service cannot complete the request.</p>",
             "members": []
         },
         "StartFromHead": {
@@ -1224,7 +1258,8 @@
             ]
         },
         "Timestamp": {
-            "type": "long"
+            "type": "long",
+            "documentation": "<p>A point in time expressed as the number of milliseconds since Jan 1, 1970 00:00:00 UTC.</p>"
         },
         "Token": {
             "type": "string"

--- a/libcloudcore/data/aws/machinelearning/service.json
+++ b/libcloudcore/data/aws/machinelearning/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -255,13 +259,16 @@
     },
     "shapes": {
         "Algorithm": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The function used to train a <code>MLModel</code>. Training choices supported by Amazon ML include the following:</p> <ul> <li>SGD - Stochastic Gradient Descent.</li> <li>RandomForest - Random forest of decision trees.</li> </ul>"
         },
         "AwsUserArn": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>An Amazon Web Service (AWS) user account identifier. The account identifier can be an AWS root account or an AWS Identity and Access Management (IAM) user.</p>"
         },
         "BatchPrediction": {
             "type": "structure",
+            "documentation": "<p> Represents the output of <a>GetBatchPrediction</a> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <i>Batch Prediction</i>.</p>",
             "members": [
                 {
                     "name": "BatchPredictionId",
@@ -321,14 +328,16 @@
             ]
         },
         "BatchPredictionFilterVariable": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A list of the variables to use in searching or filtering <code>BatchPrediction</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>BatchPrediction</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>BatchPrediction</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>BatchPrediction</code><b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>BatchPrediction</code> creation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>MLModel</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in the <code>BatchPrediction</code>.</li> <li> <code>DataURI</code> - Sets the search criteria to the data file(s) used in the <code>BatchPrediction</code>. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"
         },
         "BatchPredictions": {
             "type": "list",
             "of": "BatchPrediction"
         },
         "ComparatorValue": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The value specified in a filtering condition. The <code>ComparatorValue</code> becomes the reference value when matching or evaluating data values in filtering and searching functions.</p>"
         },
         "ComputeStatistics": {
             "type": "boolean"
@@ -365,6 +374,7 @@
         },
         "CreateBatchPredictionOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateBatchPrediction</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <a>CreateBatchPrediction</a> operation is asynchronous. You can poll for status updates by using the <a>GetBatchPrediction</a> operation and checking the <code>Status</code> parameter of the result. </p>",
             "members": [
                 {
                     "name": "BatchPredictionId",
@@ -405,6 +415,7 @@
         },
         "CreateDataSourceFromRDSOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateDataSourceFromRDS</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <a>CreateDataSourceFromRDS</a> operation is asynchronous. You can poll for updates by using the <a>GetBatchPrediction</a> operation and checking the <code>Status</code> parameter. You can inspect the <code>Message</code> when <code>Status</code> shows up as <code>FAILED</code>. You can also check the progress of the copy operation by going to the <code>DataPipeline</code> console and looking up the pipeline using the pipelineId from the describe call.</p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -445,6 +456,7 @@
         },
         "CreateDataSourceFromRedshiftOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateDataSourceFromRedshift</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <a>CreateDataSourceFromRedshift</a> operation is asynchronous. You can poll for updates by using the <a>GetBatchPrediction</a> operation and checking the <code>Status</code> parameter. </p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -480,6 +492,7 @@
         },
         "CreateDataSourceFromS3Output": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateDataSourceFromS3</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <a>CreateDataSourceFromS3</a> operation is asynchronous. You can poll for updates by using the <a>GetBatchPrediction</a> operation and checking the <code>Status</code> parameter. </p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -515,6 +528,7 @@
         },
         "CreateEvaluationOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateEvaluation</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p><a>CreateEvaluation</a> operation is asynchronous. You can poll for status updates by using the <a>GetEvaluation</a> operation and checking the <code>Status</code> parameter. </p>",
             "members": [
                 {
                     "name": "EvaluationId",
@@ -565,6 +579,7 @@
         },
         "CreateMLModelOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>CreateMLModel</a> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <a>CreateMLModel</a> operation is asynchronous. You can poll for status updates by using the <a>GetMLModel</a> operation and checking the <code>Status</code> parameter. </p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -585,6 +600,7 @@
         },
         "CreateRealtimeEndpointOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>CreateRealtimeEndpoint</a> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>.</p> <note> <p>The endpoint information includes the URI of the <code>MLModel</code>; that is, the location to send online prediction requests for the specified <code>MLModel</code>.</p> </note>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -602,10 +618,12 @@
             "type": "string"
         },
         "DataSchema": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The schema of a <code>DataSource</code>. The <code>DataSchema</code> defines the structure of the observation data in the data file(s) referenced in the <code>DataSource</code>. The DataSource schema is expressed in JSON format.</p> { \"version\": \"1.0\", \"recordAnnotationFieldName\": \"F1\", \"recordWeightFieldName\": \"F2\", \"targetFieldName\": \"F3\", \"dataFormat\": \"CSV\", \"dataFileContainsHeader\": true, \"variables\": [ { \"fieldName\": \"F1\", \"fieldType\": \"TEXT\" }, { \"fieldName\": \"F2\", \"fieldType\": \"NUMERIC\" }, { \"fieldName\": \"F3\", \"fieldType\": \"CATEGORICAL\" }, { \"fieldName\": \"F4\", \"fieldType\": \"NUMERIC\" }, { \"fieldName\": \"F5\", \"fieldType\": \"CATEGORICAL\" }, { \"fieldName\": \"F6\", \"fieldType\": \"TEXT\" }, { \"fieldName\": \"F7\", \"fieldType\": \"WEIGHTED_INT_SEQUENCE\" }, { \"fieldName\": \"F8\", \"fieldType\": \"WEIGHTED_STRING_SEQUENCE\" } ], \"excludedVariableNames\": [ \"F6\" ] }"
         },
         "DataSource": {
             "type": "structure",
+            "documentation": "<p> Represents the output of the <a>GetDataSource</a> operation. </p> <p> The content consists of the detailed metadata and data file information and the current status of the <code>DataSource</code>. </p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -682,7 +700,8 @@
             ]
         },
         "DataSourceFilterVariable": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A list of the variables to use in searching or filtering <code>DataSource</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>DataSource</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>DataSource</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>DataSource</code> <b> </b> <code>Name</code>.</li> <li> <code>DataUri</code> - Sets the search criteria to the URI of data files used to create the <code>DataSource</code>. The URI can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked the <code>DataSource</code> creation.</li> </ul> <note><title>Note</title> <p>The variable names should match the variable names in the <code>DataSource</code>.</p> </note>"
         },
         "DataSources": {
             "type": "list",
@@ -700,6 +719,7 @@
         },
         "DeleteBatchPredictionOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>DeleteBatchPrediction</a> operation.</p> <p>You can use the <a>GetBatchPrediction</a> operation and check the value of the <code>Status</code> parameter to see whether a <code>BatchPrediction</code> is marked as <code>DELETED</code>.</p>",
             "members": [
                 {
                     "name": "BatchPredictionId",
@@ -720,6 +740,7 @@
         },
         "DeleteDataSourceOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>DeleteDataSource</a> operation.</p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -740,6 +761,7 @@
         },
         "DeleteEvaluationOutput": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>DeleteEvaluation</a> operation. The output indicates that Amazon Machine Learning (Amazon ML) received the request.</p> <p>You can use the <a>GetEvaluation</a> operation and check the value of the <code>Status</code> parameter to see whether an <code>Evaluation</code> is marked as <code>DELETED</code>.</p>",
             "members": [
                 {
                     "name": "EvaluationId",
@@ -760,6 +782,7 @@
         },
         "DeleteMLModelOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>DeleteMLModel</a> operation.</p> <p>You can use the <a>GetMLModel</a> operation and check the value of the <code>Status</code> parameter to see whether an <code>MLModel</code> is marked as <code>DELETED</code>.</p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -780,6 +803,7 @@
         },
         "DeleteRealtimeEndpointOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>DeleteRealtimeEndpoint</a> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>. </p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -855,6 +879,7 @@
         },
         "DescribeBatchPredictionsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>DescribeBatchPredictions</a> operation. The content is essentially a list of <code>BatchPrediction</code>s.</p>",
             "members": [
                 {
                     "name": "Results",
@@ -930,6 +955,7 @@
         },
         "DescribeDataSourcesOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the query results from a <a>DescribeDataSources</a> operation. The content is essentially a list of <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "Results",
@@ -1005,6 +1031,7 @@
         },
         "DescribeEvaluationsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the query results from a <a>DescribeEvaluations</a> operation. The content is essentially a list of <code>Evaluation</code>.</p>",
             "members": [
                 {
                     "name": "Results",
@@ -1080,6 +1107,7 @@
         },
         "DescribeMLModelsOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>DescribeMLModels</a> operation. The content is essentially a list of <code>MLModel</code>.</p>",
             "members": [
                 {
                     "name": "Results",
@@ -1094,10 +1122,14 @@
             ]
         },
         "DetailsAttributes": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Contains the key values of <code>DetailsMap</code>: PredictiveModelType - Indicates the type of the <code>MLModel</code>. Algorithm - Indicates the algorithm was used for the <code>MLModel</code>."
         },
         "DetailsMap": {
-            "type": "map"
+            "type": "map",
+            "documentation": "Provides any additional details regarding the prediction.",
+            "key": "DetailsAttributes",
+            "value": "DetailsValue"
         },
         "DetailsValue": {
             "type": "string"
@@ -1125,13 +1157,16 @@
             "type": "string"
         },
         "EntityName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A user-supplied name or description of the Amazon ML resource.</p>"
         },
         "EntityStatus": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>Entity status with the following possible values:</p> <ul> <li>PENDING</li> <li>INPROGRESS</li> <li>FAILED</li> <li>COMPLETED</li> <li>DELETED</li> </ul>"
         },
         "EpochTime": {
-            "type": "timestamp"
+            "type": "timestamp",
+            "documentation": "<p>A timestamp represented in epoch time.</p>"
         },
         "ErrorCode": {
             "type": "integer"
@@ -1141,6 +1176,7 @@
         },
         "Evaluation": {
             "type": "structure",
+            "documentation": "<p> Represents the output of <a>GetEvaluation</a> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>",
             "members": [
                 {
                     "name": "EvaluationId",
@@ -1200,7 +1236,8 @@
             ]
         },
         "EvaluationFilterVariable": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A list of the variables to use in searching or filtering <code>Evaluation</code>.</p> <ul> <li> <code>CreatedAt</code> - Sets the search criteria to <code>Evaluation</code> creation date.</li> <li> <code>Status</code> - Sets the search criteria to <code>Evaluation</code> status.</li> <li> <code>Name</code> - Sets the search criteria to the contents of <code>Evaluation</code> <b> </b> <code>Name</code>.</li> <li> <code>IAMUser</code> - Sets the search criteria to the user account that invoked an evaluation.</li> <li> <code>MLModelId</code> - Sets the search criteria to the <code>Predictor</code> that was evaluated.</li> <li> <code>DataSourceId</code> - Sets the search criteria to the <code>DataSource</code> used in evaluation.</li> <li> <code>DataUri</code> - Sets the search criteria to the data file(s) used in evaluation. The URL can identify either a file or an Amazon Simple Storage Service (Amazon S3) bucket or directory.</li> </ul>"
         },
         "Evaluations": {
             "type": "list",
@@ -1218,6 +1255,7 @@
         },
         "GetBatchPredictionOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>GetBatchPrediction</a> operation and describes a <code>BatchPrediction</code>.</p>",
             "members": [
                 {
                     "name": "BatchPredictionId",
@@ -1298,6 +1336,7 @@
         },
         "GetDataSourceOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>GetDataSource</a> operation and describes a <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -1395,6 +1434,7 @@
         },
         "GetEvaluationOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>GetEvaluation</a> operation and describes an <code>Evaluation</code>.</p>",
             "members": [
                 {
                     "name": "EvaluationId",
@@ -1475,6 +1515,7 @@
         },
         "GetMLModelOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of a <a>GetMLModel</a> operation, and provides detailed information about a <code>MLModel</code>.</p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -1569,6 +1610,7 @@
         },
         "IdempotentParameterMismatchException": {
             "type": "structure",
+            "documentation": "<p>A second request to use or change an object was not allowed. This can result from retrying a request using a parameter that was not present in the original request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1581,10 +1623,12 @@
             ]
         },
         "IntegerType": {
-            "type": "integer"
+            "type": "integer",
+            "documentation": "<p>Integer type that is a 32-bit signed number.</p>"
         },
         "InternalServerException": {
             "type": "structure",
+            "documentation": "<p>An error on the server occurred when trying to process a request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1598,6 +1642,7 @@
         },
         "InvalidInputException": {
             "type": "structure",
+            "documentation": "<p>An error on the client occurred. Typically, the cause is an invalid input value.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1614,6 +1659,7 @@
         },
         "LimitExceededException": {
             "type": "structure",
+            "documentation": "<p>The subscriber exceeded the maximum number of operations. This exception can occur when listing objects such as <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1626,10 +1672,12 @@
             ]
         },
         "LongType": {
-            "type": "long"
+            "type": "long",
+            "documentation": "<p>Long integer type that is a 64-bit signed number.</p>"
         },
         "MLModel": {
             "type": "structure",
+            "documentation": "<p> Represents the output of a <a>GetMLModel</a> operation. </p> <p>The content consists of the detailed metadata and the current status of the <code>MLModel</code>.</p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -1725,13 +1773,15 @@
             "of": "MLModel"
         },
         "Message": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p> Description of the most recent details about an entity.</p>"
         },
         "PageLimit": {
             "type": "integer"
         },
         "PerformanceMetrics": {
             "type": "structure",
+            "documentation": "<p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href=\"http://docs.aws.amazon.com/machine-learning/latest/dg\">Amazon Machine Learning Developer Guide</a>. </p>",
             "members": [
                 {
                     "name": "Properties",
@@ -1740,7 +1790,9 @@
             ]
         },
         "PerformanceMetricsProperties": {
-            "type": "map"
+            "type": "map",
+            "key": "PerformanceMetricsPropertyKey",
+            "value": "PerformanceMetricsPropertyValue"
         },
         "PerformanceMetricsPropertyKey": {
             "type": "string"
@@ -1777,6 +1829,7 @@
         },
         "Prediction": {
             "type": "structure",
+            "documentation": "<p>The output from a <code>Predict</code> operation: </p> <ul> <li> <p> <code>Details</code> - Contains the following attributes: DetailsAttributes.PREDICTIVE_MODEL_TYPE - REGRESSION | BINARY | MULTICLASS DetailsAttributes.ALGORITHM - SGD </p> </li> <li> <p> <code>PredictedLabel</code> - Present for either a BINARY or MULTICLASS <code>MLModel</code> request. </p> </li> <li> <p> <code>PredictedScores</code> - Contains the raw classification score corresponding to each label. </p> </li> <li> <p> <code>PredictedValue</code> - Present for a REGRESSION <code>MLModel</code> request. </p> </li> </ul>",
             "members": [
                 {
                     "name": "predictedLabel",
@@ -1800,6 +1853,7 @@
         },
         "PredictorNotMountedException": {
             "type": "structure",
+            "documentation": "<p>The exception is thrown when a predict request is made to an unmounted <code>MLModel</code>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1812,6 +1866,7 @@
         },
         "RDSDataSpec": {
             "type": "structure",
+            "documentation": "<p>The data specification of an Amazon Relational Database Service (Amazon RDS) <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "DatabaseInformation",
@@ -1872,6 +1927,7 @@
         },
         "RDSDatabase": {
             "type": "structure",
+            "documentation": "<p>The database details of an Amazon RDS database.</p>",
             "members": [
                 {
                     "name": "InstanceIdentifier",
@@ -1886,6 +1942,7 @@
         },
         "RDSDatabaseCredentials": {
             "type": "structure",
+            "documentation": "<p>The database credentials to connect to a database on an RDS DB instance.</p>",
             "members": [
                 {
                     "name": "Username",
@@ -1898,19 +1955,24 @@
             ]
         },
         "RDSDatabaseName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of a database hosted on an RDS DB instance.</p>"
         },
         "RDSDatabasePassword": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The password to be used by Amazon ML to connect to a database on an RDS DB instance. The password should have sufficient permissions to execute the <code>RDSSelectQuery</code> query.</p>"
         },
         "RDSDatabaseUsername": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The username to be used by Amazon ML to connect to database on an Amazon RDS instance. The username should have sufficient permissions to execute an <code>RDSSelectSqlQuery</code> query.</p>"
         },
         "RDSInstanceIdentifier": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Identifier of RDS DB Instances."
         },
         "RDSMetadata": {
             "type": "structure",
+            "documentation": "<p>The datasource details that are specific to Amazon RDS.</p>",
             "members": [
                 {
                     "name": "Database",
@@ -1944,10 +2006,12 @@
             ]
         },
         "RDSSelectSqlQuery": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The SQL query to be executed against the Amazon RDS database. The SQL query should be valid for the Amazon RDS type being used. </p>"
         },
         "RealtimeEndpointInfo": {
             "type": "structure",
+            "documentation": "<p> Describes the real-time endpoint information for an <code>MLModel</code>.</p>",
             "members": [
                 {
                     "name": "PeakRequestsPerSecond",
@@ -1978,13 +2042,18 @@
             "type": "string"
         },
         "Record": {
-            "type": "map"
+            "type": "map",
+            "documentation": "<p>A map of variable name-value pairs that represent an observation.</p>",
+            "key": "VariableName",
+            "value": "VariableValue"
         },
         "RedshiftClusterIdentifier": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The ID of an Amazon Redshift cluster.</p>"
         },
         "RedshiftDataSpec": {
             "type": "structure",
+            "documentation": "<p>Describes the data specification of an Amazon Redshift <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "DatabaseInformation",
@@ -2025,6 +2094,7 @@
         },
         "RedshiftDatabase": {
             "type": "structure",
+            "documentation": "<p>Describes the database details required to connect to an Amazon Redshift database.</p>",
             "members": [
                 {
                     "name": "DatabaseName",
@@ -2038,6 +2108,7 @@
         },
         "RedshiftDatabaseCredentials": {
             "type": "structure",
+            "documentation": "<p> Describes the database credentials for connecting to a database on an Amazon Redshift cluster.</p>",
             "members": [
                 {
                     "name": "Username",
@@ -2050,16 +2121,20 @@
             ]
         },
         "RedshiftDatabaseName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of a database hosted on an Amazon Redshift cluster.</p>"
         },
         "RedshiftDatabasePassword": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A password to be used by Amazon ML to connect to a database on an Amazon Redshift cluster. The password should have sufficient permissions to execute a <code>RedshiftSelectSqlQuery</code> query. The password should be valid for an Amazon Redshift <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html\">USER</a>.</p>"
         },
         "RedshiftDatabaseUsername": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A username to be used by Amazon Machine Learning (Amazon ML)to connect to a database on an Amazon Redshift cluster. The username should have sufficient permissions to execute the <code>RedshiftSelectSqlQuery</code> query. The username should be valid for an Amazon Redshift <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html\">USER</a>.</p>"
         },
         "RedshiftMetadata": {
             "type": "structure",
+            "documentation": "<p>Describes the <Code>DataSource</Code> details specific to Amazon Redshift.</p>",
             "members": [
                 {
                     "name": "RedshiftDatabase",
@@ -2077,10 +2152,12 @@
             ]
         },
         "RedshiftSelectSqlQuery": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p> Describes the SQL query to execute on the Amazon Redshift database. The SQL query should be valid for an Amazon Redshift <a href=\"http://docs.aws.amazon.com/redshift/latest/dg/r_SELECT_synopsis.html\">SELECT</a>. </p>"
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>A specified resource cannot be located.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2093,10 +2170,12 @@
             ]
         },
         "RoleARN": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The Amazon Resource Name (ARN) of an <a href=\"http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html#roles-about-termsandconcepts\">AWS IAM Role</a> such as the following: arn:aws:iam::account:role/rolename. </p>"
         },
         "S3DataSpec": {
             "type": "structure",
+            "documentation": "<p> Describes the data specification of a <code>DataSource</code>.</p>",
             "members": [
                 {
                     "name": "DataLocationS3",
@@ -2121,7 +2200,8 @@
             ]
         },
         "S3Url": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A reference to a file or bucket on Amazon Simple Storage Service (Amazon S3).</p>"
         },
         "ScoreThreshold": {
             "type": "float"
@@ -2130,16 +2210,23 @@
             "type": "float"
         },
         "ScoreValuePerLabelMap": {
-            "type": "map"
+            "type": "map",
+            "documentation": "Provides the raw classification score corresponding to each label.",
+            "key": "Label",
+            "value": "ScoreValue"
         },
         "SortOrder": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The sort order specified in a listing condition. Possible values include the following:</p> <ul> <li> <code>asc</code> - Present the information in ascending order (from A-Z).</li> <li> <code>dsc</code> - Present the information in descending order (from Z-A).</li> </ul>"
         },
         "StringType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>String type.</p>"
         },
         "TrainingParameters": {
-            "type": "map"
+            "type": "map",
+            "key": "StringType",
+            "value": "StringType"
         },
         "UpdateBatchPredictionInput": {
             "type": "structure",
@@ -2158,6 +2245,7 @@
         },
         "UpdateBatchPredictionOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>UpdateBatchPrediction</a> operation.</p> <p>You can see the updated content by using the <a>GetBatchPrediction</a> operation.</p>",
             "members": [
                 {
                     "name": "BatchPredictionId",
@@ -2183,6 +2271,7 @@
         },
         "UpdateDataSourceOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>UpdateDataSource</a> operation.</p> <p>You can see the updated content by using the <a>GetBatchPrediction</a> operation.</p>",
             "members": [
                 {
                     "name": "DataSourceId",
@@ -2208,6 +2297,7 @@
         },
         "UpdateEvaluationOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>UpdateEvaluation</a> operation.</p> <p>You can see the updated content by using the <a>GetEvaluation</a> operation.</p>",
             "members": [
                 {
                     "name": "EvaluationId",
@@ -2238,6 +2328,7 @@
         },
         "UpdateMLModelOutput": {
             "type": "structure",
+            "documentation": "<p>Represents the output of an <a>UpdateMLModel</a> operation.</p> <p>You can see the updated content by using the <a>GetMLModel</a> operation.</p>",
             "members": [
                 {
                     "name": "MLModelId",
@@ -2247,13 +2338,16 @@
             ]
         },
         "VariableName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The name of a variable. Currently it's used to specify the name of the target value, label, weight, and tags.</p>"
         },
         "VariableValue": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The value of a variable. Currently it's used to specify values of the target value, weights, and tag variables and for filtering variable values.</p>"
         },
         "Verbose": {
-            "type": "boolean"
+            "type": "boolean",
+            "documentation": "<p>Specifies whether a describe operation should return exhaustive or abbreviated information.</p>"
         },
         "VipURL": {
             "type": "string"

--- a/libcloudcore/data/aws/opsworks/service.json
+++ b/libcloudcore/data/aws/opsworks/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -550,6 +554,7 @@
     "shapes": {
         "AgentVersion": {
             "type": "structure",
+            "documentation": "<p>Describes an agent version.</p>",
             "members": [
                 {
                     "name": "Version",
@@ -569,6 +574,7 @@
         },
         "App": {
             "type": "structure",
+            "documentation": "<p>A description of the app.</p>",
             "members": [
                 {
                     "name": "AppId",
@@ -643,7 +649,9 @@
             ]
         },
         "AppAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "AppAttributesKeys",
+            "value": "String"
         },
         "AppAttributesKeys": {
             "type": "string"
@@ -720,6 +728,7 @@
         },
         "AutoScalingThresholds": {
             "type": "structure",
+            "documentation": "<p>Describes a load-based auto scaling upscaling or downscaling threshold configuration, which specifies when AWS OpsWorks starts or stops load-based instances.</p>",
             "members": [
                 {
                     "name": "InstanceCount",
@@ -763,6 +772,7 @@
         },
         "BlockDeviceMapping": {
             "type": "structure",
+            "documentation": "<p>Describes a block device mapping. This data type maps directly to the Amazon EC2 <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html\">BlockDeviceMapping</a> data type. </p>",
             "members": [
                 {
                     "name": "DeviceName",
@@ -795,6 +805,7 @@
         },
         "ChefConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes the Chef configuration.</p>",
             "members": [
                 {
                     "name": "ManageBerkshelf",
@@ -924,6 +935,7 @@
         },
         "CloneStackResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CloneStack</code> request.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -934,6 +946,7 @@
         },
         "Command": {
             "type": "structure",
+            "documentation": "<p>Describes a command.</p>",
             "members": [
                 {
                     "name": "CommandId",
@@ -1058,6 +1071,7 @@
         },
         "CreateAppResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateApp</code> request.</p>",
             "members": [
                 {
                     "name": "AppId",
@@ -1103,6 +1117,7 @@
         },
         "CreateDeploymentResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateDeployment</code> request.</p>",
             "members": [
                 {
                     "name": "DeploymentId",
@@ -1203,6 +1218,7 @@
         },
         "CreateInstanceResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateInstance</code> request.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -1303,6 +1319,7 @@
         },
         "CreateLayerResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateLayer</code> request.</p>",
             "members": [
                 {
                     "name": "LayerId",
@@ -1412,6 +1429,7 @@
         },
         "CreateStackResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateStack</code> request.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -1447,6 +1465,7 @@
         },
         "CreateUserProfileResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>CreateUserProfile</code> request.</p>",
             "members": [
                 {
                     "name": "IamUserArn",
@@ -1456,10 +1475,13 @@
             ]
         },
         "DailyAutoScalingSchedule": {
-            "type": "map"
+            "type": "map",
+            "key": "Hour",
+            "value": "Switch"
         },
         "DataSource": {
             "type": "structure",
+            "documentation": "<p>Describes an app's data source.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -1547,6 +1569,7 @@
         },
         "Deployment": {
             "type": "structure",
+            "documentation": "<p>Describes a deployment of a stack or app.</p>",
             "members": [
                 {
                     "name": "DeploymentId",
@@ -1611,6 +1634,7 @@
         },
         "DeploymentCommand": {
             "type": "structure",
+            "documentation": "<p>Used to specify a stack or deployment command.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -1625,7 +1649,9 @@
             ]
         },
         "DeploymentCommandArgs": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "Strings"
         },
         "DeploymentCommandName": {
             "type": "string"
@@ -1701,6 +1727,7 @@
         },
         "DescribeAgentVersionsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeAgentVersions</code> request.</p>",
             "members": [
                 {
                     "name": "AgentVersions",
@@ -1726,6 +1753,7 @@
         },
         "DescribeAppsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeApps</code> request.</p>",
             "members": [
                 {
                     "name": "Apps",
@@ -1756,6 +1784,7 @@
         },
         "DescribeCommandsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeCommands</code> request.</p>",
             "members": [
                 {
                     "name": "Commands",
@@ -1786,6 +1815,7 @@
         },
         "DescribeDeploymentsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeDeployments</code> request.</p>",
             "members": [
                 {
                     "name": "Deployments",
@@ -1821,6 +1851,7 @@
         },
         "DescribeEcsClustersResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeEcsClusters</code> request.</p>",
             "members": [
                 {
                     "name": "EcsClusters",
@@ -1856,6 +1887,7 @@
         },
         "DescribeElasticIpsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeElasticIps</code> request.</p>",
             "members": [
                 {
                     "name": "ElasticIps",
@@ -1881,6 +1913,7 @@
         },
         "DescribeElasticLoadBalancersResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeElasticLoadBalancers</code> request.</p>",
             "members": [
                 {
                     "name": "ElasticLoadBalancers",
@@ -1911,6 +1944,7 @@
         },
         "DescribeInstancesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeInstances</code> request.</p>",
             "members": [
                 {
                     "name": "Instances",
@@ -1936,6 +1970,7 @@
         },
         "DescribeLayersResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeLayers</code> request.</p>",
             "members": [
                 {
                     "name": "Layers",
@@ -1956,6 +1991,7 @@
         },
         "DescribeLoadBasedAutoScalingResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeLoadBasedAutoScaling</code> request.</p>",
             "members": [
                 {
                     "name": "LoadBasedAutoScalingConfigurations",
@@ -1966,6 +2002,7 @@
         },
         "DescribeMyUserProfileResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeMyUserProfile</code> request.</p>",
             "members": [
                 {
                     "name": "UserProfile",
@@ -1991,6 +2028,7 @@
         },
         "DescribePermissionsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribePermissions</code> request.</p>",
             "members": [
                 {
                     "name": "Permissions",
@@ -2021,6 +2059,7 @@
         },
         "DescribeRaidArraysResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeRaidArrays</code> request.</p>",
             "members": [
                 {
                     "name": "RaidArrays",
@@ -2046,6 +2085,7 @@
         },
         "DescribeRdsDbInstancesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeRdsDbInstances</code> request.</p>",
             "members": [
                 {
                     "name": "RdsDbInstances",
@@ -2076,6 +2116,7 @@
         },
         "DescribeServiceErrorsResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeServiceErrors</code> request.</p>",
             "members": [
                 {
                     "name": "ServiceErrors",
@@ -2096,6 +2137,7 @@
         },
         "DescribeStackProvisioningParametersResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeStackProvisioningParameters</code> request.</p>",
             "members": [
                 {
                     "name": "AgentInstallerUrl",
@@ -2121,6 +2163,7 @@
         },
         "DescribeStackSummaryResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeStackSummary</code> request.</p>",
             "members": [
                 {
                     "name": "StackSummary",
@@ -2141,6 +2184,7 @@
         },
         "DescribeStacksResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeStacks</code> request.</p>",
             "members": [
                 {
                     "name": "Stacks",
@@ -2161,6 +2205,7 @@
         },
         "DescribeTimeBasedAutoScalingResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeTimeBasedAutoScaling</code> request.</p>",
             "members": [
                 {
                     "name": "TimeBasedAutoScalingConfigurations",
@@ -2181,6 +2226,7 @@
         },
         "DescribeUserProfilesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeUserProfiles</code> request.</p>",
             "members": [
                 {
                     "name": "UserProfiles",
@@ -2216,6 +2262,7 @@
         },
         "DescribeVolumesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>DescribeVolumes</code> request.</p>",
             "members": [
                 {
                     "name": "Volumes",
@@ -2254,6 +2301,7 @@
         },
         "EbsBlockDevice": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon EBS volume. This data type maps directly to the Amazon EC2 <a href=\"http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html\">EbsBlockDevice</a> data type.</p>",
             "members": [
                 {
                     "name": "SnapshotId",
@@ -2284,6 +2332,7 @@
         },
         "EcsCluster": {
             "type": "structure",
+            "documentation": "<p>Describes a registered Amazon ECS cluster.</p>",
             "members": [
                 {
                     "name": "EcsClusterArn",
@@ -2313,6 +2362,7 @@
         },
         "ElasticIp": {
             "type": "structure",
+            "documentation": "<p>Describes an Elastic IP address.</p>",
             "members": [
                 {
                     "name": "Ip",
@@ -2347,6 +2397,7 @@
         },
         "ElasticLoadBalancer": {
             "type": "structure",
+            "documentation": "<p>Describes an Elastic Load Balancing instance.</p>",
             "members": [
                 {
                     "name": "ElasticLoadBalancerName",
@@ -2401,6 +2452,7 @@
         },
         "EnvironmentVariable": {
             "type": "structure",
+            "documentation": "<p>Represents an app's environment variable.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -2435,6 +2487,7 @@
         },
         "GetHostnameSuggestionResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>GetHostnameSuggestion</code> request.</p>",
             "members": [
                 {
                     "name": "LayerId",
@@ -2465,6 +2518,7 @@
         },
         "GrantAccessResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>GrantAccess</code> request.</p>",
             "members": [
                 {
                     "name": "TemporaryCredential",
@@ -2478,6 +2532,7 @@
         },
         "Instance": {
             "type": "structure",
+            "documentation": "<p>Describes an instance.</p>",
             "members": [
                 {
                     "name": "AgentVersion",
@@ -2678,6 +2733,7 @@
         },
         "InstanceIdentity": {
             "type": "structure",
+            "documentation": "<p>Contains a description of an Amazon EC2 instance from the Amazon EC2 metadata service. For more information, see <a href=\"http://docs.aws.amazon.com/sdkfornet/latest/apidocs/Index.html\">Instance Metadata and User Data</a>.</p>",
             "members": [
                 {
                     "name": "Document",
@@ -2697,6 +2753,7 @@
         },
         "InstancesCount": {
             "type": "structure",
+            "documentation": "<p>Describes how many instances a stack has for each status.</p>",
             "members": [
                 {
                     "name": "Assigning",
@@ -2800,6 +2857,7 @@
         },
         "Layer": {
             "type": "structure",
+            "documentation": "<p>Describes a layer.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -2908,7 +2966,9 @@
             ]
         },
         "LayerAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "LayerAttributesKeys",
+            "value": "String"
         },
         "LayerAttributesKeys": {
             "type": "string"
@@ -2922,6 +2982,7 @@
         },
         "LifecycleEventConfiguration": {
             "type": "structure",
+            "documentation": "<p>Specifies the lifecycle event configuration</p>",
             "members": [
                 {
                     "name": "Shutdown",
@@ -2932,6 +2993,7 @@
         },
         "LoadBasedAutoScalingConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes a layer's load-based auto scaling configuration.</p>",
             "members": [
                 {
                     "name": "LayerId",
@@ -2963,10 +3025,13 @@
             "type": "integer"
         },
         "Parameters": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "Permission": {
             "type": "structure",
+            "documentation": "<p>Describes stack or user permissions.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -3001,6 +3066,7 @@
         },
         "RaidArray": {
             "type": "structure",
+            "documentation": "<p>Describes an instance's RAID array.</p>",
             "members": [
                 {
                     "name": "RaidArrayId",
@@ -3075,6 +3141,7 @@
         },
         "RdsDbInstance": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon RDS instance.</p>",
             "members": [
                 {
                     "name": "RdsDbInstanceArn",
@@ -3139,6 +3206,7 @@
         },
         "Recipes": {
             "type": "structure",
+            "documentation": "<p>AWS OpsWorks supports five lifecycle events: <b>setup</b>, <b>configuration</b>, <b>deploy</b>, <b>undeploy</b>, and <b>shutdown</b>. For each layer, AWS OpsWorks runs a set of standard recipes for each event. In addition, you can provide custom recipes for any or all layers and events. AWS OpsWorks runs custom event recipes after the standard recipes. <code>LayerCustomRecipes</code> specifies the custom recipes for a particular layer to be run in response to each of the five events. </p> <p>To specify a recipe, use the cookbook's directory name in the repository followed by two colons and the recipe name, which is the recipe's file name without the .rb extension. For example: phpapp2::dbsetup specifies the dbsetup.rb recipe in the repository's phpapp2 folder. </p>",
             "members": [
                 {
                     "name": "Setup",
@@ -3184,6 +3252,7 @@
         },
         "RegisterEcsClusterResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>RegisterEcsCluster</code> request.</p>",
             "members": [
                 {
                     "name": "EcsClusterArn",
@@ -3209,6 +3278,7 @@
         },
         "RegisterElasticIpResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>RegisterElasticIp</code> request.</p>",
             "members": [
                 {
                     "name": "ElasticIp",
@@ -3259,6 +3329,7 @@
         },
         "RegisterInstanceResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>RegisterInstanceResult</code> request.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -3309,6 +3380,7 @@
         },
         "RegisterVolumeResult": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a <code>RegisterVolume</code> request.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -3319,6 +3391,7 @@
         },
         "ReportedOs": {
             "type": "structure",
+            "documentation": "<p>A registered instance's reported operating system.</p>",
             "members": [
                 {
                     "name": "Family",
@@ -3339,6 +3412,7 @@
         },
         "ResourceNotFoundException": {
             "type": "structure",
+            "documentation": "<p>Indicates that a resource was not found.</p>",
             "members": [
                 {
                     "name": "message",
@@ -3352,6 +3426,7 @@
         },
         "SelfUserProfile": {
             "type": "structure",
+            "documentation": "<p>Describes a user's SSH information.</p>",
             "members": [
                 {
                     "name": "IamUserArn",
@@ -3377,6 +3452,7 @@
         },
         "ServiceError": {
             "type": "structure",
+            "documentation": "<p>Describes an AWS OpsWorks service error.</p>",
             "members": [
                 {
                     "name": "ServiceErrorId",
@@ -3486,6 +3562,7 @@
         },
         "ShutdownEventConfiguration": {
             "type": "structure",
+            "documentation": "<p>The Shutdown event configuration.</p>",
             "members": [
                 {
                     "name": "ExecutionTimeout",
@@ -3501,6 +3578,7 @@
         },
         "Source": {
             "type": "structure",
+            "documentation": "<p>Contains the information required to retrieve an app or cookbook from a repository. For more information, see <a href=\"http://docs.aws.amazon.com/opsworks/latest/userguide/workingapps-creating.html\">Creating Apps</a> or <a href=\"http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook.html\">Custom Recipes and Cookbooks</a>.</p>",
             "members": [
                 {
                     "name": "Type",
@@ -3539,6 +3617,7 @@
         },
         "SslConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes an app's SSL configuration.</p>",
             "members": [
                 {
                     "name": "Certificate",
@@ -3559,6 +3638,7 @@
         },
         "Stack": {
             "type": "structure",
+            "documentation": "<p>Describes a stack.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -3672,13 +3752,16 @@
             ]
         },
         "StackAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "StackAttributesKeys",
+            "value": "String"
         },
         "StackAttributesKeys": {
             "type": "string"
         },
         "StackConfigurationManager": {
             "type": "structure",
+            "documentation": "<p>Describes the configuration manager.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -3694,6 +3777,7 @@
         },
         "StackSummary": {
             "type": "structure",
+            "documentation": "<p>Summarizes the number of layers, instances, and apps in a stack.</p>",
             "members": [
                 {
                     "name": "StackId",
@@ -3783,6 +3867,7 @@
         },
         "TemporaryCredential": {
             "type": "structure",
+            "documentation": "<p>Contains the data needed by RDP clients such as the Microsoft Remote Desktop Connection to log in to the instance.</p>",
             "members": [
                 {
                     "name": "Username",
@@ -3808,6 +3893,7 @@
         },
         "TimeBasedAutoScalingConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes an instance's time-based auto scaling configuration.</p>",
             "members": [
                 {
                     "name": "InstanceId",
@@ -4241,6 +4327,7 @@
         },
         "UserProfile": {
             "type": "structure",
+            "documentation": "<p>Describes a user's SSH information.</p>",
             "members": [
                 {
                     "name": "IamUserArn",
@@ -4278,6 +4365,7 @@
         },
         "ValidationException": {
             "type": "structure",
+            "documentation": "<p>Indicates that a request was invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -4291,6 +4379,7 @@
         },
         "Volume": {
             "type": "structure",
+            "documentation": "<p>Describes an instance's Amazon EBS volume.</p>",
             "members": [
                 {
                     "name": "VolumeId",
@@ -4361,6 +4450,7 @@
         },
         "VolumeConfiguration": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon EBS volume configuration.</p>",
             "members": [
                 {
                     "name": "MountPoint",
@@ -4407,6 +4497,7 @@
         },
         "WeeklyAutoScalingSchedule": {
             "type": "structure",
+            "documentation": "<p>Describes a time-based instance's auto scaling schedule. The schedule consists of a set of key-value pairs.</p> <ul> <li>The key is the time period (a UTC hour) and must be an integer from 0 - 23.</li> <li>The value indicates whether the instance should be online or offline for the specified period, and must be set to \"on\" or \"off\"</li> </ul> <p>The default setting for all time periods is off, so you use the following parameters primarily to specify the online periods. You don't have to explicitly specify offline periods unless you want to change an online period to an offline period. </p> <p>The following example specifies that the instance should be online for four hours, from UTC 1200 - 1600. It will be off for the remainder of the day.</p> <p> <code> { \"12\":\"on\", \"13\":\"on\", \"14\":\"on\", \"15\":\"on\" } </code> </p>",
             "members": [
                 {
                     "name": "Monday",

--- a/libcloudcore/data/aws/rds/service.json
+++ b/libcloudcore/data/aws/rds/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://rds.amazonaws.com/doc/2014-10-31/"
         }
@@ -710,6 +713,7 @@
     "shapes": {
         "AccountAttributesMessage": {
             "type": "structure",
+            "documentation": "<p>Data returned by the <b>DescribeAccountAttributes</b> action.</p>",
             "members": [
                 {
                     "name": "AccountQuotas",
@@ -720,6 +724,7 @@
         },
         "AccountQuota": {
             "type": "structure",
+            "documentation": "<p>Describes a quota for an AWS account, for example, the number of DB instances allowed.</p>",
             "members": [
                 {
                     "name": "AccountQuotaName",
@@ -744,6 +749,7 @@
         },
         "AddSourceIdentifierToSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -759,6 +765,7 @@
         },
         "AddTagsToResourceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -777,6 +784,7 @@
         },
         "ApplyPendingMaintenanceActionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ResourceIdentifier",
@@ -797,18 +805,22 @@
         },
         "AuthorizationAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The specified CIDRIP or EC2 security group is already authorized for the specified DB security group. </p>",
             "members": []
         },
         "AuthorizationNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> Specified CIDRIP or EC2 security group is not authorized for the specified DB security group. </p> <p>RDS may not also be authorized via IAM to perform necessary actions on your behalf.</p>",
             "members": []
         },
         "AuthorizationQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> DB security group authorization quota has been reached. </p>",
             "members": []
         },
         "AuthorizeDBSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -839,6 +851,7 @@
         },
         "AvailabilityZone": {
             "type": "structure",
+            "documentation": "<p> Contains Availability Zone information. </p> <p> This data type is used as an element in the following data type: <ul><li><a>OrderableDBInstanceOption</a></li></ul></p>",
             "members": [
                 {
                     "name": "Name",
@@ -863,6 +876,7 @@
         },
         "Certificate": {
             "type": "structure",
+            "documentation": "<p>A CA certificate for an AWS account. </p>",
             "members": [
                 {
                     "name": "CertificateIdentifier",
@@ -897,6 +911,7 @@
         },
         "CertificateMessage": {
             "type": "structure",
+            "documentation": "<p>Data returned by the <b>DescribeCertificates</b> action.</p>",
             "members": [
                 {
                     "name": "Certificates",
@@ -912,10 +927,12 @@
         },
         "CertificateNotFoundFault": {
             "type": "structure",
+            "documentation": "<p><i>CertificateIdentifier</i> does not refer to an existing certificate. </p>",
             "members": []
         },
         "CharacterSet": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
             "members": [
                 {
                     "name": "CharacterSetName",
@@ -931,6 +948,7 @@
         },
         "CopyDBClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceDBClusterSnapshotIdentifier",
@@ -950,6 +968,7 @@
         },
         "CopyDBParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceDBParameterGroupIdentifier",
@@ -974,6 +993,7 @@
         },
         "CopyDBSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceDBSnapshotIdentifier",
@@ -998,6 +1018,7 @@
         },
         "CopyOptionGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceOptionGroupIdentifier",
@@ -1022,6 +1043,7 @@
         },
         "CreateDBClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "AvailabilityZones",
@@ -1111,6 +1133,7 @@
         },
         "CreateDBClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -1135,6 +1158,7 @@
         },
         "CreateDBClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterSnapshotIdentifier",
@@ -1155,6 +1179,7 @@
         },
         "CreateDBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBName",
@@ -1393,6 +1418,7 @@
         },
         "CreateDBParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -1417,6 +1443,7 @@
         },
         "CreateDBSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -1436,6 +1463,7 @@
         },
         "CreateDBSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSnapshotIdentifier",
@@ -1455,6 +1483,7 @@
         },
         "CreateDBSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSubnetGroupName",
@@ -1479,6 +1508,7 @@
         },
         "CreateEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -1518,6 +1548,7 @@
         },
         "CreateOptionGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -1547,6 +1578,7 @@
         },
         "DBCluster": {
             "type": "structure",
+            "documentation": "<p>Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>CreateDBCluster</a> </li> <li> <a>DeleteDBCluster</a> </li> <li> <a>FailoverDBCluster</a> </li> <li> <a>ModifyDBCluster</a> </li> <li> <a>RestoreDBClusterFromSnapshot</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action.</p>",
             "members": [
                 {
                     "name": "AllocatedStorage",
@@ -1662,6 +1694,7 @@
         },
         "DBClusterAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>User already has a DB cluster with the given identifier. </p>",
             "members": []
         },
         "DBClusterList": {
@@ -1670,6 +1703,7 @@
         },
         "DBClusterMember": {
             "type": "structure",
+            "documentation": "<p>Contains information about an instance that is part of a DB cluster.</p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -1694,6 +1728,7 @@
         },
         "DBClusterMessage": {
             "type": "structure",
+            "documentation": "<p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1709,6 +1744,7 @@
         },
         "DBClusterNotFoundFault": {
             "type": "structure",
+            "documentation": "<p><i>DBClusterIdentifier</i> does not refer to an existing DB cluster. </p>",
             "members": []
         },
         "DBClusterOptionGroupMemberships": {
@@ -1717,6 +1753,7 @@
         },
         "DBClusterOptionGroupStatus": {
             "type": "structure",
+            "documentation": "<p>Contains status information for a DB cluster option group.</p>",
             "members": [
                 {
                     "name": "DBClusterOptionGroupName",
@@ -1732,6 +1769,7 @@
         },
         "DBClusterParameterGroup": {
             "type": "structure",
+            "documentation": "<p>Contains the result of a successful invocation of the <a>CreateDBClusterParameterGroup</a> action. </p> <p>This data type is used as a request parameter in the <a>DeleteDBClusterParameterGroup</a> action, and as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -1752,6 +1790,7 @@
         },
         "DBClusterParameterGroupDetails": {
             "type": "structure",
+            "documentation": "<p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>",
             "members": [
                 {
                     "name": "Parameters",
@@ -1771,6 +1810,7 @@
         },
         "DBClusterParameterGroupNameMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -1781,10 +1821,12 @@
         },
         "DBClusterParameterGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBClusterParameterGroupName</i> does not refer to an existing DB Cluster parameter group. </p>",
             "members": []
         },
         "DBClusterParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1800,10 +1842,12 @@
         },
         "DBClusterQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>User attempted to create a new DB cluster and the user has already reached the maximum allowed DB cluster quota. </p>",
             "members": []
         },
         "DBClusterSnapshot": {
             "type": "structure",
+            "documentation": "<p>Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>CreateDBClusterSnapshot</a> </li> <li> <a>DeleteDBClusterSnapshot</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action.</p>",
             "members": [
                 {
                     "name": "AvailabilityZones",
@@ -1884,6 +1928,7 @@
         },
         "DBClusterSnapshotAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>User already has a DB cluster snapshot with the given identifier. </p>",
             "members": []
         },
         "DBClusterSnapshotList": {
@@ -1892,6 +1937,7 @@
         },
         "DBClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1907,10 +1953,12 @@
         },
         "DBClusterSnapshotNotFoundFault": {
             "type": "structure",
+            "documentation": "<p><i>DBClusterSnapshotIdentifier</i> does not refer to an existing DB cluster snapshot. </p>",
             "members": []
         },
         "DBEngineVersion": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>",
             "members": [
                 {
                     "name": "Engine",
@@ -1955,6 +2003,7 @@
         },
         "DBEngineVersionMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1970,6 +2019,7 @@
         },
         "DBInstance": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>CreateDBInstance</a> </li> <li> <a>DeleteDBInstance</a> </li> <li> <a>ModifyDBInstance</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action.</p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -2180,6 +2230,7 @@
         },
         "DBInstanceAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> User already has a DB instance with the given identifier. </p>",
             "members": []
         },
         "DBInstanceList": {
@@ -2188,6 +2239,7 @@
         },
         "DBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2203,10 +2255,12 @@
         },
         "DBInstanceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBInstanceIdentifier</i> does not refer to an existing DB instance. </p>",
             "members": []
         },
         "DBInstanceStatusInfo": {
             "type": "structure",
+            "documentation": "<p>Provides a list of status information for a DB instance.</p>",
             "members": [
                 {
                     "name": "StatusType",
@@ -2236,10 +2290,12 @@
         },
         "DBLogFileNotFoundFault": {
             "type": "structure",
+            "documentation": "<p><i>LogFileName</i> does not refer to an existing DB log file.</p>",
             "members": []
         },
         "DBParameterGroup": {
             "type": "structure",
+            "documentation": "<p>Contains the result of a successful invocation of the <a>CreateDBParameterGroup</a> action. </p> <p>This data type is used as a request parameter in the <a>DeleteDBParameterGroup</a> action, and as a response element in the <a>DescribeDBParameterGroups</a> action. </p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -2260,10 +2316,12 @@
         },
         "DBParameterGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> A DB parameter group with the same name exists. </p>",
             "members": []
         },
         "DBParameterGroupDetails": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>",
             "members": [
                 {
                     "name": "Parameters",
@@ -2283,6 +2341,7 @@
         },
         "DBParameterGroupNameMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -2293,14 +2352,17 @@
         },
         "DBParameterGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBParameterGroupName</i> does not refer to an existing DB parameter group. </p>",
             "members": []
         },
         "DBParameterGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of DB parameter groups. </p>",
             "members": []
         },
         "DBParameterGroupStatus": {
             "type": "structure",
+            "documentation": "<p> The status of the DB parameter group. </p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <a>CreateDBInstance</a> </li> <li> <a>CreateDBInstanceReadReplica</a> </li> <li> <a>DeleteDBInstance</a> </li> <li> <a>ModifyDBInstance</a> </li> <li> <a>RebootDBInstance</a> </li> <li> <a>RestoreDBInstanceFromDBSnapshot</a> </li> </ul>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -2320,6 +2382,7 @@
         },
         "DBParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2335,6 +2398,7 @@
         },
         "DBSecurityGroup": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>DescribeDBSecurityGroups</a> </li> <li> <a>AuthorizeDBSecurityGroupIngress</a> </li> <li> <a>CreateDBSecurityGroup</a> </li> <li> <a>RevokeDBSecurityGroupIngress</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action.</p>",
             "members": [
                 {
                     "name": "OwnerId",
@@ -2370,10 +2434,12 @@
         },
         "DBSecurityGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> A DB security group with the name specified in <i>DBSecurityGroupName</i> already exists. </p>",
             "members": []
         },
         "DBSecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the following actions: </p> <ul> <li> <a>ModifyDBInstance</a> </li> <li> <a>RebootDBInstance</a> </li> <li> <a>RestoreDBInstanceFromDBSnapshot</a> </li> <li> <a>RestoreDBInstanceToPointInTime</a> </li> </ul>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -2393,6 +2459,7 @@
         },
         "DBSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBSecurityGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2412,14 +2479,17 @@
         },
         "DBSecurityGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBSecurityGroupName</i> does not refer to an existing DB security group. </p>",
             "members": []
         },
         "DBSecurityGroupNotSupportedFault": {
             "type": "structure",
+            "documentation": "<p> A DB security group is not allowed for this action. </p>",
             "members": []
         },
         "DBSecurityGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of DB security groups. </p>",
             "members": []
         },
         "DBSecurityGroups": {
@@ -2428,6 +2498,7 @@
         },
         "DBSnapshot": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>CreateDBSnapshot</a> </li> <li> <a>DeleteDBSnapshot</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSnapshots</a> action.</p>",
             "members": [
                 {
                     "name": "DBSnapshotIdentifier",
@@ -2548,6 +2619,7 @@
         },
         "DBSnapshotAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBSnapshotIdentifier</i> is already used by an existing snapshot. </p>",
             "members": []
         },
         "DBSnapshotList": {
@@ -2556,6 +2628,7 @@
         },
         "DBSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBSnapshots</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2571,10 +2644,12 @@
         },
         "DBSnapshotNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBSnapshotIdentifier</i> does not refer to an existing DB snapshot. </p>",
             "members": []
         },
         "DBSubnetGroup": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the following actions: </p> <ul> <li> <a>CreateDBSubnetGroup</a> </li> <li> <a>ModifyDBSubnetGroup</a> </li> <li> <a>DescribeDBSubnetGroups</a> </li> <li> <a>DeleteDBSubnetGroup</a> </li> </ul> <p>This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action.</p>",
             "members": [
                 {
                     "name": "DBSubnetGroupName",
@@ -2605,14 +2680,17 @@
         },
         "DBSubnetGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBSubnetGroupName</i> is already used by an existing DB subnet group. </p>",
             "members": []
         },
         "DBSubnetGroupDoesNotCoverEnoughAZs": {
             "type": "structure",
+            "documentation": "<p> Subnets in the DB subnet group should cover at least two Availability Zones unless there is only one Availability Zone. </p>",
             "members": []
         },
         "DBSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2628,14 +2706,17 @@
         },
         "DBSubnetGroupNotAllowedFault": {
             "type": "structure",
+            "documentation": "<p> Indicates that the DBSubnetGroup should not be specified while creating read replicas that lie in the same region as the source instance. </p>",
             "members": []
         },
         "DBSubnetGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>DBSubnetGroupName</i> does not refer to an existing DB subnet group. </p>",
             "members": []
         },
         "DBSubnetGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of DB subnet groups. </p>",
             "members": []
         },
         "DBSubnetGroups": {
@@ -2644,14 +2725,17 @@
         },
         "DBSubnetQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of subnets in a DB subnet groups. </p>",
             "members": []
         },
         "DBUpgradeDependencyFailureFault": {
             "type": "structure",
+            "documentation": "<p> The DB upgrade failed because a resource the DB depends on could not be modified. </p>",
             "members": []
         },
         "DeleteDBClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -2672,6 +2756,7 @@
         },
         "DeleteDBClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -2682,6 +2767,7 @@
         },
         "DeleteDBClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterSnapshotIdentifier",
@@ -2692,6 +2778,7 @@
         },
         "DeleteDBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -2712,6 +2799,7 @@
         },
         "DeleteDBParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -2722,6 +2810,7 @@
         },
         "DeleteDBSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -2732,6 +2821,7 @@
         },
         "DeleteDBSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSnapshotIdentifier",
@@ -2742,6 +2832,7 @@
         },
         "DeleteDBSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSubnetGroupName",
@@ -2752,6 +2843,7 @@
         },
         "DeleteEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -2762,6 +2854,7 @@
         },
         "DeleteOptionGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -2772,10 +2865,12 @@
         },
         "DescribeAccountAttributesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": []
         },
         "DescribeCertificatesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "CertificateIdentifier",
@@ -2801,6 +2896,7 @@
         },
         "DescribeDBClusterParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -2826,6 +2922,7 @@
         },
         "DescribeDBClusterParametersMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -2856,6 +2953,7 @@
         },
         "DescribeDBClusterSnapshotsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -2891,6 +2989,7 @@
         },
         "DescribeDBClustersMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -2961,6 +3060,7 @@
         },
         "DescribeDBInstancesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -2986,6 +3086,7 @@
         },
         "DescribeDBLogFilesDetails": {
             "type": "structure",
+            "documentation": "<p>This data type is used as a response element to <a>DescribeDBLogFiles</a>.</p>",
             "members": [
                 {
                     "name": "LogFileName",
@@ -3010,6 +3111,7 @@
         },
         "DescribeDBLogFilesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -3050,6 +3152,7 @@
         },
         "DescribeDBLogFilesResponse": {
             "type": "structure",
+            "documentation": "<p> The response from a call to <a>DescribeDBLogFiles</a>. </p>",
             "members": [
                 {
                     "name": "DescribeDBLogFiles",
@@ -3065,6 +3168,7 @@
         },
         "DescribeDBParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -3120,6 +3224,7 @@
         },
         "DescribeDBSecurityGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -3145,6 +3250,7 @@
         },
         "DescribeDBSnapshotsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -3180,6 +3286,7 @@
         },
         "DescribeDBSubnetGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSubnetGroupName",
@@ -3205,6 +3312,7 @@
         },
         "DescribeEngineDefaultClusterParametersMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupFamily",
@@ -3230,6 +3338,7 @@
         },
         "DescribeEngineDefaultParametersMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupFamily",
@@ -3255,6 +3364,7 @@
         },
         "DescribeEventCategoriesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceType",
@@ -3270,6 +3380,7 @@
         },
         "DescribeEventSubscriptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -3295,6 +3406,7 @@
         },
         "DescribeEventsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -3345,6 +3457,7 @@
         },
         "DescribeOptionGroupOptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "EngineName",
@@ -3375,6 +3488,7 @@
         },
         "DescribeOptionGroupsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -3410,6 +3524,7 @@
         },
         "DescribeOrderableDBInstanceOptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Engine",
@@ -3455,6 +3570,7 @@
         },
         "DescribePendingMaintenanceActionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ResourceIdentifier",
@@ -3480,6 +3596,7 @@
         },
         "DescribeReservedDBInstancesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ReservedDBInstanceId",
@@ -3535,6 +3652,7 @@
         },
         "DescribeReservedDBInstancesOfferingsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ReservedDBInstancesOfferingId",
@@ -3585,6 +3703,7 @@
         },
         "DomainMembership": {
             "type": "structure",
+            "documentation": "<p> An Active Directory Domain membership record associated with the DB instance. </p>",
             "members": [
                 {
                     "name": "Domain",
@@ -3605,10 +3724,12 @@
         },
         "DomainMembershipList": {
             "type": "list",
+            "documentation": "<p> List of Active Directory Domain membership records associated with a DB instance. </p>",
             "of": "DomainMembership"
         },
         "DomainNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> <i>Domain</i> does not refer to an existing Active Directory Domain. </p>",
             "members": []
         },
         "Double": {
@@ -3616,6 +3737,7 @@
         },
         "DownloadDBLogFilePortionDetails": {
             "type": "structure",
+            "documentation": "<p>This data type is used as a response element to <a>DownloadDBLogFilePortion</a>.</p>",
             "members": [
                 {
                     "name": "LogFileData",
@@ -3636,6 +3758,7 @@
         },
         "DownloadDBLogFilePortionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -3661,6 +3784,7 @@
         },
         "EC2SecurityGroup": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the following actions: </p> <ul> <li> <a>AuthorizeDBSecurityGroupIngress</a> </li> <li> <a>DescribeDBSecurityGroups</a> </li> <li> <a>RevokeDBSecurityGroupIngress</a> </li> </ul>",
             "members": [
                 {
                     "name": "Status",
@@ -3690,6 +3814,7 @@
         },
         "Endpoint": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the following actions: </p> <ul> <li> <a>CreateDBInstance</a> </li> <li> <a>DescribeDBInstances</a> </li> <li> <a>DeleteDBInstance</a> </li> </ul>",
             "members": [
                 {
                     "name": "Address",
@@ -3705,6 +3830,7 @@
         },
         "EngineDefaults": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>",
             "members": [
                 {
                     "name": "DBParameterGroupFamily",
@@ -3725,6 +3851,7 @@
         },
         "Event": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -3759,6 +3886,7 @@
         },
         "EventCategoriesMap": {
             "type": "structure",
+            "documentation": "<p>Contains the results of a successful invocation of the <a>DescribeEventCategories</a> action.</p>",
             "members": [
                 {
                     "name": "SourceType",
@@ -3778,6 +3906,7 @@
         },
         "EventCategoriesMessage": {
             "type": "structure",
+            "documentation": "<p>Data returned from the <b>DescribeEventCategories</b> action.</p>",
             "members": [
                 {
                     "name": "EventCategoriesMapList",
@@ -3792,6 +3921,7 @@
         },
         "EventSubscription": {
             "type": "structure",
+            "documentation": "<p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>",
             "members": [
                 {
                     "name": "CustomerAwsId",
@@ -3842,6 +3972,7 @@
         },
         "EventSubscriptionQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>You have reached the maximum number of event subscriptions.</p>",
             "members": []
         },
         "EventSubscriptionsList": {
@@ -3850,6 +3981,7 @@
         },
         "EventSubscriptionsMessage": {
             "type": "structure",
+            "documentation": "<p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3865,6 +3997,7 @@
         },
         "EventsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3880,6 +4013,7 @@
         },
         "FailoverDBClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -3913,6 +4047,7 @@
         },
         "IPRange": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeDBSecurityGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Status",
@@ -3932,22 +4067,27 @@
         },
         "InstanceQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of DB instances. </p>",
             "members": []
         },
         "InsufficientDBClusterCapacityFault": {
             "type": "structure",
+            "documentation": "<p>The DB cluster does not have enough capacity for the current operation. </p>",
             "members": []
         },
         "InsufficientDBInstanceCapacityFault": {
             "type": "structure",
+            "documentation": "<p> Specified DB instance class is not available in the specified Availability Zone. </p>",
             "members": []
         },
         "InsufficientDomainCapacityFault": {
             "type": "structure",
+            "documentation": "<p> Requested Active Directory Domain has reached maximum number of instances. </p>",
             "members": []
         },
         "InsufficientStorageClusterCapacityFault": {
             "type": "structure",
+            "documentation": "<p>There is insufficient storage available for the current action. You may be able to resolve this error by updating your subnet group to use different Availability Zones that have more storage available.</p>",
             "members": []
         },
         "Integer": {
@@ -3958,62 +4098,77 @@
         },
         "InvalidDBClusterSnapshotStateFault": {
             "type": "structure",
+            "documentation": "<p>The supplied value is not a valid DB cluster snapshot state. </p>",
             "members": []
         },
         "InvalidDBClusterStateFault": {
             "type": "structure",
+            "documentation": "<p>The supplied value is not a valid DB cluster state. </p>",
             "members": []
         },
         "InvalidDBInstanceStateFault": {
             "type": "structure",
+            "documentation": "<p> The specified DB instance is not in the <i>available</i> state. </p>",
             "members": []
         },
         "InvalidDBParameterGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The DB parameter group cannot be deleted because it is in use. </p>",
             "members": []
         },
         "InvalidDBSecurityGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The state of the DB security group does not allow deletion. </p>",
             "members": []
         },
         "InvalidDBSnapshotStateFault": {
             "type": "structure",
+            "documentation": "<p> The state of the DB snapshot does not allow deletion. </p>",
             "members": []
         },
         "InvalidDBSubnetGroupFault": {
             "type": "structure",
+            "documentation": "<p> Indicates the DBSubnetGroup does not belong to the same VPC as that of an existing cross region read replica of the same source instance. </p>",
             "members": []
         },
         "InvalidDBSubnetGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The DB subnet group cannot be deleted because it is in use. </p>",
             "members": []
         },
         "InvalidDBSubnetStateFault": {
             "type": "structure",
+            "documentation": "<p> The DB subnet is not in the <i>available</i> state. </p>",
             "members": []
         },
         "InvalidEventSubscriptionStateFault": {
             "type": "structure",
+            "documentation": "<p>This error can occur if someone else is modifying a subscription. You should retry the action.</p>",
             "members": []
         },
         "InvalidOptionGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The option group is not in the <i>available</i> state. </p>",
             "members": []
         },
         "InvalidRestoreFault": {
             "type": "structure",
+            "documentation": "<p> Cannot restore from vpc backup to non-vpc DB instance. </p>",
             "members": []
         },
         "InvalidSubnet": {
             "type": "structure",
+            "documentation": "<p> The requested subnet is invalid, or multiple subnets were requested that are not all in a common VPC. </p>",
             "members": []
         },
         "InvalidVPCNetworkStateFault": {
             "type": "structure",
+            "documentation": "<p> DB subnet group does not cover all Availability Zones after it is created because users' change. </p>",
             "members": []
         },
         "KMSKeyNotAccessibleFault": {
             "type": "structure",
+            "documentation": "<p> Error accessing KMS key. </p>",
             "members": []
         },
         "KeyList": {
@@ -4022,6 +4177,7 @@
         },
         "ListTagsForResourceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -4040,6 +4196,7 @@
         },
         "ModifyDBClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -4100,6 +4257,7 @@
         },
         "ModifyDBClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -4115,6 +4273,7 @@
         },
         "ModifyDBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -4240,6 +4399,7 @@
         },
         "ModifyDBParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -4255,6 +4415,7 @@
         },
         "ModifyDBSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSubnetGroupName",
@@ -4275,6 +4436,7 @@
         },
         "ModifyEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -4305,6 +4467,7 @@
         },
         "ModifyOptionGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -4330,6 +4493,7 @@
         },
         "Option": {
             "type": "structure",
+            "documentation": "<p> Option details. </p>",
             "members": [
                 {
                     "name": "OptionName",
@@ -4375,6 +4539,7 @@
         },
         "OptionConfiguration": {
             "type": "structure",
+            "documentation": "<p> A list of all available options </p>",
             "members": [
                 {
                     "name": "OptionName",
@@ -4409,6 +4574,7 @@
         },
         "OptionGroup": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -4449,10 +4615,12 @@
         },
         "OptionGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The option group you are trying to create already exists. </p>",
             "members": []
         },
         "OptionGroupMembership": {
             "type": "structure",
+            "documentation": "<p> Provides information on the option groups the DB instance is a member of. </p>",
             "members": [
                 {
                     "name": "OptionGroupName",
@@ -4472,10 +4640,12 @@
         },
         "OptionGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The specified option group could not be found. </p>",
             "members": []
         },
         "OptionGroupOption": {
             "type": "structure",
+            "documentation": "<p> Available option. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -4536,6 +4706,7 @@
         },
         "OptionGroupOptionSetting": {
             "type": "structure",
+            "documentation": "<p>Option group option settings are used to display settings available for each option with their default values and other information. These values are used with the DescribeOptionGroupOptions action. </p>",
             "members": [
                 {
                     "name": "SettingName",
@@ -4575,10 +4746,12 @@
         },
         "OptionGroupOptionsList": {
             "type": "list",
+            "documentation": "<p> List of available option group options. </p>",
             "of": "OptionGroupOption"
         },
         "OptionGroupOptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "OptionGroupOptions",
@@ -4593,10 +4766,12 @@
         },
         "OptionGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The quota of 20 option groups was exceeded for this AWS account. </p>",
             "members": []
         },
         "OptionGroups": {
             "type": "structure",
+            "documentation": "<p> List of option groups. </p>",
             "members": [
                 {
                     "name": "OptionGroupsList",
@@ -4620,6 +4795,7 @@
         },
         "OptionSetting": {
             "type": "structure",
+            "documentation": "<p> Option settings are the actual settings being applied or configured for that option. It is used when you modify an option group or describe option groups. For example, the NATIVE_NETWORK_ENCRYPTION option has a setting called SQLNET.ENCRYPTION_SERVER that can have several different values. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -4686,6 +4862,7 @@
         },
         "OrderableDBInstanceOption": {
             "type": "structure",
+            "documentation": "<p> Contains a list of available options for a DB instance </p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
             "members": [
                 {
                     "name": "Engine",
@@ -4750,6 +4927,7 @@
         },
         "OrderableDBInstanceOptionsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>",
             "members": [
                 {
                     "name": "OrderableDBInstanceOptions",
@@ -4765,6 +4943,7 @@
         },
         "Parameter": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -4824,6 +5003,7 @@
         },
         "PendingMaintenanceAction": {
             "type": "structure",
+            "documentation": "<p>Provides information about a pending maintenance action for a resource.</p>",
             "members": [
                 {
                     "name": "Action",
@@ -4867,6 +5047,7 @@
         },
         "PendingMaintenanceActionsMessage": {
             "type": "structure",
+            "documentation": "<p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>",
             "members": [
                 {
                     "name": "PendingMaintenanceActions",
@@ -4882,6 +5063,7 @@
         },
         "PendingModifiedValues": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>",
             "members": [
                 {
                     "name": "DBInstanceClass",
@@ -4942,10 +5124,12 @@
         },
         "PointInTimeRestoreNotEnabledFault": {
             "type": "structure",
+            "documentation": "<p> <i>SourceDBInstanceIdentifier</i> refers to a DB instance with <i>BackupRetentionPeriod</i> equal to 0. </p>",
             "members": []
         },
         "PromoteReadReplicaMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -4966,10 +5150,12 @@
         },
         "ProvisionedIopsNotAvailableInAZFault": {
             "type": "structure",
+            "documentation": "<p> Provisioned IOPS not available in the specified Availability Zone. </p>",
             "members": []
         },
         "PurchaseReservedDBInstancesOfferingMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ReservedDBInstancesOfferingId",
@@ -4998,6 +5184,7 @@
         },
         "RebootDBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -5013,6 +5200,7 @@
         },
         "RecurringCharge": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>DescribeReservedDBInstancesOfferings</a> actions. </p>",
             "members": [
                 {
                     "name": "RecurringChargeAmount",
@@ -5032,6 +5220,7 @@
         },
         "RemoveSourceIdentifierFromSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -5047,6 +5236,7 @@
         },
         "RemoveTagsFromResourceMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -5062,6 +5252,7 @@
         },
         "ReservedDBInstance": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstances</a> and <a>PurchaseReservedDBInstancesOffering</a> actions. </p>",
             "members": [
                 {
                     "name": "ReservedDBInstanceId",
@@ -5137,6 +5328,7 @@
         },
         "ReservedDBInstanceAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> User already has a reservation with the given identifier. </p>",
             "members": []
         },
         "ReservedDBInstanceList": {
@@ -5145,6 +5337,7 @@
         },
         "ReservedDBInstanceMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstances</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -5160,14 +5353,17 @@
         },
         "ReservedDBInstanceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The specified reserved DB Instance not found. </p>",
             "members": []
         },
         "ReservedDBInstanceQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would exceed the user's DB Instance quota. </p>",
             "members": []
         },
         "ReservedDBInstancesOffering": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
             "members": [
                 {
                     "name": "ReservedDBInstancesOfferingId",
@@ -5227,6 +5423,7 @@
         },
         "ReservedDBInstancesOfferingMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the result of a successful invocation of the <a>DescribeReservedDBInstancesOfferings</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -5242,10 +5439,12 @@
         },
         "ReservedDBInstancesOfferingNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> Specified offering does not exist. </p>",
             "members": []
         },
         "ResetDBClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterParameterGroupName",
@@ -5266,6 +5465,7 @@
         },
         "ResetDBParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBParameterGroupName",
@@ -5286,10 +5486,12 @@
         },
         "ResourceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The specified resource ID was not found. </p>",
             "members": []
         },
         "ResourcePendingMaintenanceActions": {
             "type": "structure",
+            "documentation": "<p>Describes the pending maintenance actions for a resource.</p>",
             "members": [
                 {
                     "name": "ResourceIdentifier",
@@ -5305,6 +5507,7 @@
         },
         "RestoreDBClusterFromSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "AvailabilityZones",
@@ -5365,6 +5568,7 @@
         },
         "RestoreDBClusterToPointInTimeMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBClusterIdentifier",
@@ -5414,6 +5618,7 @@
         },
         "RestoreDBInstanceFromDBSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBInstanceIdentifier",
@@ -5528,6 +5733,7 @@
         },
         "RestoreDBInstanceToPointInTimeMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SourceDBInstanceIdentifier",
@@ -5652,6 +5858,7 @@
         },
         "RevokeDBSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBSecurityGroupName",
@@ -5682,18 +5889,22 @@
         },
         "SNSInvalidTopicFault": {
             "type": "structure",
+            "documentation": "<p>SNS has responded that there is a problem with the SND topic specified.</p>",
             "members": []
         },
         "SNSNoAuthorizationFault": {
             "type": "structure",
+            "documentation": "<p>You do not have permission to publish to the SNS topic ARN.</p>",
             "members": []
         },
         "SNSTopicArnNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The SNS topic ARN does not exist.</p>",
             "members": []
         },
         "SnapshotQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed number of DB snapshots. </p>",
             "members": []
         },
         "SourceIdsList": {
@@ -5702,6 +5913,7 @@
         },
         "SourceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The requested source could not be found.</p>",
             "members": []
         },
         "SourceType": {
@@ -5709,10 +5921,12 @@
         },
         "StorageQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would result in user exceeding the allowed amount of storage available across all DB instances. </p>",
             "members": []
         },
         "StorageTypeNotSupportedFault": {
             "type": "structure",
+            "documentation": "<p> <i>StorageType</i> specified cannot be associated with the DB Instance. </p>",
             "members": []
         },
         "String": {
@@ -5720,6 +5934,7 @@
         },
         "Subnet": {
             "type": "structure",
+            "documentation": "<p> This data type is used as a response element in the <a>DescribeDBSubnetGroups</a> action. </p>",
             "members": [
                 {
                     "name": "SubnetIdentifier",
@@ -5739,6 +5954,7 @@
         },
         "SubnetAlreadyInUse": {
             "type": "structure",
+            "documentation": "<p> The DB subnet is already in use in the Availability Zone. </p>",
             "members": []
         },
         "SubnetIdentifierList": {
@@ -5751,14 +5967,17 @@
         },
         "SubscriptionAlreadyExistFault": {
             "type": "structure",
+            "documentation": "<p>The supplied subscription name already exists.</p>",
             "members": []
         },
         "SubscriptionCategoryNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The supplied category does not exist.</p>",
             "members": []
         },
         "SubscriptionNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The subscription name does not exist.</p>",
             "members": []
         },
         "SupportedCharacterSetsList": {
@@ -5770,6 +5989,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Metadata assigned to an Amazon RDS resource consisting of a key-value pair.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -5785,10 +6005,12 @@
         },
         "TagList": {
             "type": "list",
+            "documentation": "<p>A list of tags.</p>",
             "of": "Tag"
         },
         "TagListMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "TagList",
@@ -5803,6 +6025,7 @@
         },
         "VpcSecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p>This data type is used as a response element for queries on VPC security group membership.</p>",
             "members": [
                 {
                     "name": "VpcSecurityGroupId",

--- a/libcloudcore/data/aws/redshift/service.json
+++ b/libcloudcore/data/aws/redshift/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://redshift.amazonaws.com/doc/2012-12-01/"
         }
@@ -539,10 +542,12 @@
     "shapes": {
         "AccessToSnapshotDeniedFault": {
             "type": "structure",
+            "documentation": "<p> The owner of the specified snapshot has not authorized your account to access the snapshot. </p>",
             "members": []
         },
         "AccountWithRestoreAccess": {
             "type": "structure",
+            "documentation": "<p> Describes an AWS customer account authorized to restore a snapshot. </p>",
             "members": [
                 {
                     "name": "AccountId",
@@ -557,18 +562,22 @@
         },
         "AuthorizationAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The specified CIDR block or EC2 security group is already authorized for the specified cluster security group. </p>",
             "members": []
         },
         "AuthorizationNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The specified CIDR IP range or EC2 security group is not authorized for the specified cluster security group. </p>",
             "members": []
         },
         "AuthorizationQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The authorization quota for the cluster security group has been reached. </p>",
             "members": []
         },
         "AuthorizeClusterSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p> ??? </p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -594,6 +603,7 @@
         },
         "AuthorizeSnapshotAccessMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SnapshotIdentifier",
@@ -614,6 +624,7 @@
         },
         "AvailabilityZone": {
             "type": "structure",
+            "documentation": "<p> Describes an availability zone. </p>",
             "members": [
                 {
                     "name": "Name",
@@ -634,10 +645,12 @@
         },
         "BucketNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> Could not find the specified S3 bucket. </p>",
             "members": []
         },
         "Cluster": {
             "type": "structure",
+            "documentation": "<p>Describes a cluster.</p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -798,6 +811,7 @@
         },
         "ClusterAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The account already has a cluster with the given identifier. </p>",
             "members": []
         },
         "ClusterList": {
@@ -806,6 +820,7 @@
         },
         "ClusterNode": {
             "type": "structure",
+            "documentation": "<p>The identifier of a node in a cluster.</p>",
             "members": [
                 {
                     "name": "NodeRole",
@@ -830,10 +845,12 @@
         },
         "ClusterNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The <i>ClusterIdentifier</i> parameter does not refer to an existing cluster. </p>",
             "members": []
         },
         "ClusterParameterGroup": {
             "type": "structure",
+            "documentation": "<p>Describes a parameter group.</p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -859,10 +876,12 @@
         },
         "ClusterParameterGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> A cluster parameter group with the same name already exists. </p>",
             "members": []
         },
         "ClusterParameterGroupDetails": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterParameters</a> action. </p>",
             "members": [
                 {
                     "name": "Parameters",
@@ -878,6 +897,7 @@
         },
         "ClusterParameterGroupNameMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>ModifyClusterParameterGroup</a> and <a>ResetClusterParameterGroup</a> actions and indicate the parameter group involved and the status of the operation on the parameter group. </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -893,14 +913,17 @@
         },
         "ClusterParameterGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The parameter group name does not refer to an existing parameter group. </p>",
             "members": []
         },
         "ClusterParameterGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would result in the user exceeding the allowed number of cluster parameter groups. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ClusterParameterGroupStatus": {
             "type": "structure",
+            "documentation": "<p> Describes the status of a parameter group. </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -925,6 +948,7 @@
         },
         "ClusterParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterParameterGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -940,6 +964,7 @@
         },
         "ClusterParameterStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a parameter group.</p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -964,10 +989,12 @@
         },
         "ClusterQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would exceed the allowed number of cluster instances for this account. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ClusterSecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Describes a security group.</p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -998,10 +1025,12 @@
         },
         "ClusterSecurityGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> A cluster security group with the same name already exists. </p>",
             "members": []
         },
         "ClusterSecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p>Describes a security group.</p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -1021,6 +1050,7 @@
         },
         "ClusterSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterSecurityGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1040,10 +1070,12 @@
         },
         "ClusterSecurityGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The cluster security group name does not refer to an existing cluster security group. </p>",
             "members": []
         },
         "ClusterSecurityGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would result in the user exceeding the allowed number of cluster security groups. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ClusterSecurityGroups": {
@@ -1052,10 +1084,12 @@
         },
         "ClusterSnapshotAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> The value specified as a snapshot identifier is already used by an existing snapshot. </p>",
             "members": []
         },
         "ClusterSnapshotCopyStatus": {
             "type": "structure",
+            "documentation": "<p> Returns the destination region and retention period that are configured for cross-region snapshot copy. </p>",
             "members": [
                 {
                     "name": "DestinationRegion",
@@ -1076,14 +1110,17 @@
         },
         "ClusterSnapshotNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The snapshot identifier does not refer to an existing cluster snapshot. </p>",
             "members": []
         },
         "ClusterSnapshotQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would result in the user exceeding the allowed number of cluster snapshots. </p>",
             "members": []
         },
         "ClusterSubnetGroup": {
             "type": "structure",
+            "documentation": "<p>Describes a subnet group.</p>",
             "members": [
                 {
                     "name": "ClusterSubnetGroupName",
@@ -1119,10 +1156,12 @@
         },
         "ClusterSubnetGroupAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> A <i>ClusterSubnetGroupName</i> is already used by an existing cluster subnet group. </p>",
             "members": []
         },
         "ClusterSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterSubnetGroups</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1138,10 +1177,12 @@
         },
         "ClusterSubnetGroupNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The cluster subnet group name does not refer to an existing cluster subnet group. </p>",
             "members": []
         },
         "ClusterSubnetGroupQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would result in user exceeding the allowed number of cluster subnet groups. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ClusterSubnetGroups": {
@@ -1150,10 +1191,12 @@
         },
         "ClusterSubnetQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would result in user exceeding the allowed number of subnets in a cluster subnet groups. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ClusterVersion": {
             "type": "structure",
+            "documentation": "<p>Describes a cluster version, including the parameter group family and description of the version.</p>",
             "members": [
                 {
                     "name": "ClusterVersion",
@@ -1178,6 +1221,7 @@
         },
         "ClusterVersionsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterVersions</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1193,6 +1237,7 @@
         },
         "ClustersMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusters</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -1208,6 +1253,7 @@
         },
         "CopyClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SourceSnapshotIdentifier",
@@ -1228,10 +1274,12 @@
         },
         "CopyToRegionDisabledFault": {
             "type": "structure",
+            "documentation": "<p> Cross-region snapshot copy was temporarily disabled. Try your request again. </p>",
             "members": []
         },
         "CreateClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "DBName",
@@ -1357,6 +1405,7 @@
         },
         "CreateClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -1382,6 +1431,7 @@
         },
         "CreateClusterSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p>???</p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -1402,6 +1452,7 @@
         },
         "CreateClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SnapshotIdentifier",
@@ -1422,6 +1473,7 @@
         },
         "CreateClusterSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterSubnetGroupName",
@@ -1447,6 +1499,7 @@
         },
         "CreateEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -1492,6 +1545,7 @@
         },
         "CreateHsmClientCertificateMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmClientCertificateIdentifier",
@@ -1507,6 +1561,7 @@
         },
         "CreateHsmConfigurationMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmConfigurationIdentifier",
@@ -1547,6 +1602,7 @@
         },
         "CreateSnapshotCopyGrantMessage": {
             "type": "structure",
+            "documentation": "<p>The result of the <code>CreateSnapshotCopyGrant</code> action.</p>",
             "members": [
                 {
                     "name": "SnapshotCopyGrantName",
@@ -1567,6 +1623,7 @@
         },
         "CreateTagsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <code>CreateTags</code> action. </p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -1582,6 +1639,7 @@
         },
         "DefaultClusterParameters": {
             "type": "structure",
+            "documentation": "<p>Describes the default cluster parameters for a parameter group family. </p>",
             "members": [
                 {
                     "name": "ParameterGroupFamily",
@@ -1602,6 +1660,7 @@
         },
         "DeleteClusterMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -1622,6 +1681,7 @@
         },
         "DeleteClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -1632,6 +1692,7 @@
         },
         "DeleteClusterSecurityGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -1642,6 +1703,7 @@
         },
         "DeleteClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SnapshotIdentifier",
@@ -1667,6 +1729,7 @@
         },
         "DeleteEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -1677,6 +1740,7 @@
         },
         "DeleteHsmClientCertificateMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmClientCertificateIdentifier",
@@ -1687,6 +1751,7 @@
         },
         "DeleteHsmConfigurationMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmConfigurationIdentifier",
@@ -1697,6 +1762,7 @@
         },
         "DeleteSnapshotCopyGrantMessage": {
             "type": "structure",
+            "documentation": "<p>The result of the <code>DeleteSnapshotCopyGrant</code> action.</p>",
             "members": [
                 {
                     "name": "SnapshotCopyGrantName",
@@ -1707,6 +1773,7 @@
         },
         "DeleteTagsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <code>DeleteTags</code> action. </p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -1722,6 +1789,7 @@
         },
         "DescribeClusterParameterGroupsMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -1777,6 +1845,7 @@
         },
         "DescribeClusterSecurityGroupsMessage": {
             "type": "structure",
+            "documentation": "<p>???</p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -1807,6 +1876,7 @@
         },
         "DescribeClusterSnapshotsMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -1862,6 +1932,7 @@
         },
         "DescribeClusterSubnetGroupsMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterSubnetGroupName",
@@ -1917,6 +1988,7 @@
         },
         "DescribeClustersMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -1947,6 +2019,7 @@
         },
         "DescribeDefaultClusterParametersMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupFamily",
@@ -1967,6 +2040,7 @@
         },
         "DescribeEventCategoriesMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SourceType",
@@ -1977,6 +2051,7 @@
         },
         "DescribeEventSubscriptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -1997,6 +2072,7 @@
         },
         "DescribeEventsMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -2037,6 +2113,7 @@
         },
         "DescribeHsmClientCertificatesMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmClientCertificateIdentifier",
@@ -2067,6 +2144,7 @@
         },
         "DescribeHsmConfigurationsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmConfigurationIdentifier",
@@ -2097,6 +2175,7 @@
         },
         "DescribeLoggingStatusMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2107,6 +2186,7 @@
         },
         "DescribeOrderableClusterOptionsMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterVersion",
@@ -2132,6 +2212,7 @@
         },
         "DescribeReservedNodeOfferingsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ReservedNodeOfferingId",
@@ -2152,6 +2233,7 @@
         },
         "DescribeReservedNodesMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ReservedNodeId",
@@ -2172,6 +2254,7 @@
         },
         "DescribeResizeMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2182,6 +2265,7 @@
         },
         "DescribeSnapshotCopyGrantsMessage": {
             "type": "structure",
+            "documentation": "<p>The result of the <code>DescribeSnapshotCopyGrants</code> action.</p>",
             "members": [
                 {
                     "name": "SnapshotCopyGrantName",
@@ -2212,6 +2296,7 @@
         },
         "DescribeTagsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <code>DescribeTags</code> action. </p>",
             "members": [
                 {
                     "name": "ResourceName",
@@ -2247,6 +2332,7 @@
         },
         "DisableLoggingMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2257,6 +2343,7 @@
         },
         "DisableSnapshotCopyMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2273,6 +2360,7 @@
         },
         "EC2SecurityGroup": {
             "type": "structure",
+            "documentation": "<p>Describes an Amazon EC2 security group.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -2302,6 +2390,7 @@
         },
         "ElasticIpStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of the elastic IP (EIP) address.</p>",
             "members": [
                 {
                     "name": "ElasticIp",
@@ -2317,6 +2406,7 @@
         },
         "EnableLoggingMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2337,6 +2427,7 @@
         },
         "EnableSnapshotCopyMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2362,6 +2453,7 @@
         },
         "Endpoint": {
             "type": "structure",
+            "documentation": "<p>Describes a connection endpoint.</p>",
             "members": [
                 {
                     "name": "Address",
@@ -2377,6 +2469,7 @@
         },
         "Event": {
             "type": "structure",
+            "documentation": "<p> Describes an event. </p>",
             "members": [
                 {
                     "name": "SourceIdentifier",
@@ -2440,6 +2533,7 @@
         },
         "EventCategoriesMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "EventCategoriesMapList",
@@ -2543,6 +2637,7 @@
         },
         "EventSubscriptionQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request would exceed the allowed number of event subscriptions for this account. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "EventSubscriptionsList": {
@@ -2551,6 +2646,7 @@
         },
         "EventSubscriptionsMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2566,6 +2662,7 @@
         },
         "EventsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeEvents</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2581,6 +2678,7 @@
         },
         "HsmClientCertificate": {
             "type": "structure",
+            "documentation": "<p>Returns information about an HSM client certificate. The certificate is stored in a secure Hardware Storage Module (HSM), and used by the Amazon Redshift cluster to encrypt data files.</p>",
             "members": [
                 {
                     "name": "HsmClientCertificateIdentifier",
@@ -2601,6 +2699,7 @@
         },
         "HsmClientCertificateAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>There is already an existing Amazon Redshift HSM client certificate with the specified identifier.</p>",
             "members": []
         },
         "HsmClientCertificateList": {
@@ -2609,6 +2708,7 @@
         },
         "HsmClientCertificateMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2624,14 +2724,17 @@
         },
         "HsmClientCertificateNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>There is no Amazon Redshift HSM client certificate with the specified identifier.</p>",
             "members": []
         },
         "HsmClientCertificateQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The quota for HSM client certificates has been reached. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "HsmConfiguration": {
             "type": "structure",
+            "documentation": "<p>Returns information about an HSM configuration, which is an object that describes to Amazon Redshift clusters the information they require to connect to an HSM where they can store database encryption keys.</p>",
             "members": [
                 {
                     "name": "HsmConfigurationIdentifier",
@@ -2662,6 +2765,7 @@
         },
         "HsmConfigurationAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>There is already an existing Amazon Redshift HSM configuration with the specified identifier.</p>",
             "members": []
         },
         "HsmConfigurationList": {
@@ -2670,6 +2774,7 @@
         },
         "HsmConfigurationMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Marker",
@@ -2685,14 +2790,17 @@
         },
         "HsmConfigurationNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>There is no Amazon Redshift HSM configuration with the specified identifier.</p>",
             "members": []
         },
         "HsmConfigurationQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> The quota for HSM configurations has been reached. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "HsmStatus": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "HsmClientCertificateIdentifier",
@@ -2713,6 +2821,7 @@
         },
         "IPRange": {
             "type": "structure",
+            "documentation": "<p> Describes an IP range used in a security group. </p>",
             "members": [
                 {
                     "name": "Status",
@@ -2749,14 +2858,17 @@
         },
         "IncompatibleOrderableOptions": {
             "type": "structure",
+            "documentation": "<p> The specified options are incompatible. </p>",
             "members": []
         },
         "InsufficientClusterCapacityFault": {
             "type": "structure",
+            "documentation": "<p> The number of nodes specified exceeds the allotted capacity of the cluster. </p>",
             "members": []
         },
         "InsufficientS3BucketPolicyFault": {
             "type": "structure",
+            "documentation": "<p> The cluster does not have read bucket or put object permissions on the S3 bucket specified when enabling logging. </p>",
             "members": []
         },
         "Integer": {
@@ -2767,78 +2879,97 @@
         },
         "InvalidClusterParameterGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The cluster parameter group action can not be completed because another task is in progress that involves the parameter group. Wait a few moments and try the operation again. </p>",
             "members": []
         },
         "InvalidClusterSecurityGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The state of the cluster security group is not <code>available</code>. </p>",
             "members": []
         },
         "InvalidClusterSnapshotStateFault": {
             "type": "structure",
+            "documentation": "<p> The state of the cluster snapshot is not <code>available</code>, or other accounts are authorized to access the snapshot. </p>",
             "members": []
         },
         "InvalidClusterStateFault": {
             "type": "structure",
+            "documentation": "<p> The specified cluster is not in the <code>available</code> state. </p>",
             "members": []
         },
         "InvalidClusterSubnetGroupStateFault": {
             "type": "structure",
+            "documentation": "<p> The cluster subnet group cannot be deleted because it is in use. </p>",
             "members": []
         },
         "InvalidClusterSubnetStateFault": {
             "type": "structure",
+            "documentation": "<p>The state of the subnet is invalid.</p>",
             "members": []
         },
         "InvalidElasticIpFault": {
             "type": "structure",
+            "documentation": "<p>The Elastic IP (EIP) is invalid or cannot be found.</p>",
             "members": []
         },
         "InvalidHsmClientCertificateStateFault": {
             "type": "structure",
+            "documentation": "<p>The specified HSM client certificate is not in the <code>available</code> state, or it is still in use by one or more Amazon Redshift clusters.</p>",
             "members": []
         },
         "InvalidHsmConfigurationStateFault": {
             "type": "structure",
+            "documentation": "<p>The specified HSM configuration is not in the <code>available</code> state, or it is still in use by one or more Amazon Redshift clusters.</p>",
             "members": []
         },
         "InvalidRestoreFault": {
             "type": "structure",
+            "documentation": "<p>The restore is invalid.</p>",
             "members": []
         },
         "InvalidS3BucketNameFault": {
             "type": "structure",
+            "documentation": "<p>The S3 bucket name is invalid. For more information about naming rules, go to <a href=\"http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html\">Bucket Restrictions and Limitations</a> in the Amazon Simple Storage Service (S3) Developer Guide.</p>",
             "members": []
         },
         "InvalidS3KeyPrefixFault": {
             "type": "structure",
+            "documentation": "<p> The string specified for the logging S3 key prefix does not comply with the documented constraints. </p>",
             "members": []
         },
         "InvalidSnapshotCopyGrantStateFault": {
             "type": "structure",
+            "documentation": "<p>The snapshot copy grant can't be deleted because it is used by one or more clusters.</p>",
             "members": []
         },
         "InvalidSubnet": {
             "type": "structure",
+            "documentation": "<p> The requested subnet is not valid, or not all of the subnets are in the same VPC. </p>",
             "members": []
         },
         "InvalidSubscriptionStateFault": {
             "type": "structure",
+            "documentation": "<p> The subscription request is invalid because it is a duplicate request. This subscription request is already in progress. </p>",
             "members": []
         },
         "InvalidTagFault": {
             "type": "structure",
+            "documentation": "<p> The tag is invalid. </p>",
             "members": []
         },
         "InvalidVPCNetworkStateFault": {
             "type": "structure",
+            "documentation": "<p> The cluster subnet group does not cover all Availability Zones. </p>",
             "members": []
         },
         "LimitExceededFault": {
             "type": "structure",
+            "documentation": "<p>The encryption key has exceeded its grant limit in AWS KMS. </p>",
             "members": []
         },
         "LoggingStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of logging for a cluster.</p>",
             "members": [
                 {
                     "name": "LoggingEnabled",
@@ -2880,6 +3011,7 @@
         },
         "ModifyClusterMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -2960,6 +3092,7 @@
         },
         "ModifyClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -2975,6 +3108,7 @@
         },
         "ModifyClusterSubnetGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterSubnetGroupName",
@@ -2995,6 +3129,7 @@
         },
         "ModifyEventSubscriptionMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "SubscriptionName",
@@ -3035,6 +3170,7 @@
         },
         "ModifySnapshotCopyRetentionPeriodMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -3050,14 +3186,17 @@
         },
         "NumberOfNodesPerClusterLimitExceededFault": {
             "type": "structure",
+            "documentation": "<p>The operation would exceed the number of nodes allowed for a cluster.</p>",
             "members": []
         },
         "NumberOfNodesQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The operation would exceed the number of nodes allotted to the account. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "OrderableClusterOption": {
             "type": "structure",
+            "documentation": "<p> Describes an orderable cluster option. </p>",
             "members": [
                 {
                     "name": "ClusterVersion",
@@ -3087,6 +3226,7 @@
         },
         "OrderableClusterOptionsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeOrderableClusterOptions</a> action. </p>",
             "members": [
                 {
                     "name": "OrderableClusterOptions",
@@ -3102,6 +3242,7 @@
         },
         "Parameter": {
             "type": "structure",
+            "documentation": "<p> Describes a parameter in a cluster parameter group. </p>",
             "members": [
                 {
                     "name": "ParameterName",
@@ -3163,6 +3304,7 @@
         },
         "PendingModifiedValues": {
             "type": "structure",
+            "documentation": "<p> Describes cluster attributes that are in a pending state. A change to one or more the attributes was requested and is in progress or will be applied. </p>",
             "members": [
                 {
                     "name": "MasterUserPassword",
@@ -3203,6 +3345,7 @@
         },
         "PurchaseReservedNodeOfferingMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ReservedNodeOfferingId",
@@ -3218,6 +3361,7 @@
         },
         "RebootClusterMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -3228,6 +3372,7 @@
         },
         "RecurringCharge": {
             "type": "structure",
+            "documentation": "<p>Describes a recurring charge.</p>",
             "members": [
                 {
                     "name": "RecurringChargeAmount",
@@ -3247,6 +3392,7 @@
         },
         "ReservedNode": {
             "type": "structure",
+            "documentation": "<p> Describes a reserved node. You can call the <a>DescribeReservedNodeOfferings</a> API to obtain the available reserved node offerings. </p>",
             "members": [
                 {
                     "name": "ReservedNodeId",
@@ -3312,6 +3458,7 @@
         },
         "ReservedNodeAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p> User already has a reservation with the given identifier. </p>",
             "members": []
         },
         "ReservedNodeList": {
@@ -3320,10 +3467,12 @@
         },
         "ReservedNodeNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The specified reserved compute node not found. </p>",
             "members": []
         },
         "ReservedNodeOffering": {
             "type": "structure",
+            "documentation": "<p>Describes a reserved node offering.</p>",
             "members": [
                 {
                     "name": "ReservedNodeOfferingId",
@@ -3373,10 +3522,12 @@
         },
         "ReservedNodeOfferingNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> Specified offering does not exist. </p>",
             "members": []
         },
         "ReservedNodeOfferingsMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeReservedNodeOfferings</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3392,10 +3543,12 @@
         },
         "ReservedNodeQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p> Request would exceed the user's compute node quota. For information about increasing your quota, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/amazon-redshift-limits.html\">Limits in Amazon Redshift</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": []
         },
         "ReservedNodesMessage": {
             "type": "structure",
+            "documentation": "<p>Contains the output from the <a>DescribeReservedNodes</a> action.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3411,6 +3564,7 @@
         },
         "ResetClusterParameterGroupMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ParameterGroupName",
@@ -3431,10 +3585,12 @@
         },
         "ResizeNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>A resize operation for the specified cluster is not found.</p>",
             "members": []
         },
         "ResizeProgressMessage": {
             "type": "structure",
+            "documentation": "<p>Describes the result of a cluster resize operation.</p>",
             "members": [
                 {
                     "name": "TargetNodeType",
@@ -3500,6 +3656,7 @@
         },
         "ResourceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p> The resource could not be found. </p>",
             "members": []
         },
         "RestorableNodeTypeList": {
@@ -3508,6 +3665,7 @@
         },
         "RestoreFromClusterSnapshotMessage": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -3608,6 +3766,7 @@
         },
         "RestoreStatus": {
             "type": "structure",
+            "documentation": "<p>Describes the status of a cluster restore action. Returns null if the cluster was not created by restoring a snapshot.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -3643,6 +3802,7 @@
         },
         "RevokeClusterSecurityGroupIngressMessage": {
             "type": "structure",
+            "documentation": "<p> ??? </p>",
             "members": [
                 {
                     "name": "ClusterSecurityGroupName",
@@ -3668,6 +3828,7 @@
         },
         "RevokeSnapshotAccessMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "SnapshotIdentifier",
@@ -3688,6 +3849,7 @@
         },
         "RotateEncryptionKeyMessage": {
             "type": "structure",
+            "documentation": "<p> </p>",
             "members": [
                 {
                     "name": "ClusterIdentifier",
@@ -3698,18 +3860,22 @@
         },
         "SNSInvalidTopicFault": {
             "type": "structure",
+            "documentation": "<p>Amazon SNS has responded that there is a problem with the specified Amazon SNS topic.</p>",
             "members": []
         },
         "SNSNoAuthorizationFault": {
             "type": "structure",
+            "documentation": "<p>You do not have permission to publish to the specified Amazon SNS topic.</p>",
             "members": []
         },
         "SNSTopicArnNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>An Amazon SNS topic with the specified Amazon Resource Name (ARN) does not exist.</p>",
             "members": []
         },
         "Snapshot": {
             "type": "structure",
+            "documentation": "<p>Describes a snapshot.</p>",
             "members": [
                 {
                     "name": "SnapshotIdentifier",
@@ -3855,18 +4021,22 @@
         },
         "SnapshotCopyAlreadyDisabledFault": {
             "type": "structure",
+            "documentation": "<p> The cluster already has cross-region snapshot copy disabled. </p>",
             "members": []
         },
         "SnapshotCopyAlreadyEnabledFault": {
             "type": "structure",
+            "documentation": "<p> The cluster already has cross-region snapshot copy enabled. </p>",
             "members": []
         },
         "SnapshotCopyDisabledFault": {
             "type": "structure",
+            "documentation": "<p> Cross-region snapshot copy was temporarily disabled. Try your request again. </p>",
             "members": []
         },
         "SnapshotCopyGrant": {
             "type": "structure",
+            "documentation": "<p>The snapshot copy grant that grants Amazon Redshift permission to encrypt copied snapshots with the specified customer master key (CMK) from AWS KMS in the destination region.</p> <p> For more information about managing snapshot copy grants, go to <a href=\"http://docs.aws.amazon.com/redshift/latest/mgmt/working-with-db-encryption.html\">Amazon Redshift Database Encryption</a> in the <i>Amazon Redshift Cluster Management Guide</i>. </p>",
             "members": [
                 {
                     "name": "SnapshotCopyGrantName",
@@ -3887,6 +4057,7 @@
         },
         "SnapshotCopyGrantAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>The snapshot copy grant can't be created because a grant with the same name already exists.</p>",
             "members": []
         },
         "SnapshotCopyGrantList": {
@@ -3895,6 +4066,7 @@
         },
         "SnapshotCopyGrantMessage": {
             "type": "structure",
+            "documentation": "<p>The result of the snapshot copy grant.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3910,10 +4082,12 @@
         },
         "SnapshotCopyGrantNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The specified snapshot copy grant can't be found. Make sure that the name is typed correctly and that the grant exists in the destination region.</p>",
             "members": []
         },
         "SnapshotCopyGrantQuotaExceededFault": {
             "type": "structure",
+            "documentation": "<p>The AWS account has exceeded the maximum number of snapshot copy grants in this region.</p>",
             "members": []
         },
         "SnapshotList": {
@@ -3922,6 +4096,7 @@
         },
         "SnapshotMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <a>DescribeClusterSnapshots</a> action. </p>",
             "members": [
                 {
                     "name": "Marker",
@@ -3941,6 +4116,7 @@
         },
         "SourceNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The specified Amazon Redshift event source could not be found.</p>",
             "members": []
         },
         "SourceType": {
@@ -3951,6 +4127,7 @@
         },
         "Subnet": {
             "type": "structure",
+            "documentation": "<p> Describes a subnet. </p>",
             "members": [
                 {
                     "name": "SubnetIdentifier",
@@ -3970,6 +4147,7 @@
         },
         "SubnetAlreadyInUse": {
             "type": "structure",
+            "documentation": "<p> A specified subnet is already in use by another cluster. </p>",
             "members": []
         },
         "SubnetIdentifierList": {
@@ -3982,22 +4160,27 @@
         },
         "SubscriptionAlreadyExistFault": {
             "type": "structure",
+            "documentation": "<p>There is already an existing event notification subscription with the specified name.</p>",
             "members": []
         },
         "SubscriptionCategoryNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The value specified for the event category was not one of the allowed values, or it specified a category that does not apply to the specified source type. The allowed values are Configuration, Management, Monitoring, and Security.</p>",
             "members": []
         },
         "SubscriptionEventIdNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>An Amazon Redshift event with the specified event ID does not exist.</p>",
             "members": []
         },
         "SubscriptionNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>An Amazon Redshift event notification subscription with the specified name does not exist.</p>",
             "members": []
         },
         "SubscriptionSeverityNotFoundFault": {
             "type": "structure",
+            "documentation": "<p>The value specified for the event severity was not one of the allowed values, or it specified a severity that does not apply to the specified source type. The allowed values are ERROR and INFO.</p>",
             "members": []
         },
         "TStamp": {
@@ -4005,6 +4188,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>A tag consisting of a name/value pair for a resource.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -4024,6 +4208,7 @@
         },
         "TagLimitExceededFault": {
             "type": "structure",
+            "documentation": "<p> The request exceeds the limit of 10 tags for the resource. </p>",
             "members": []
         },
         "TagList": {
@@ -4036,6 +4221,7 @@
         },
         "TaggedResource": {
             "type": "structure",
+            "documentation": "<p>A tag and its associated resource. </p>",
             "members": [
                 {
                     "name": "Tag",
@@ -4060,6 +4246,7 @@
         },
         "TaggedResourceListMessage": {
             "type": "structure",
+            "documentation": "<p> Contains the output from the <code>DescribeTags</code> action. </p>",
             "members": [
                 {
                     "name": "TaggedResources",
@@ -4075,18 +4262,22 @@
         },
         "UnauthorizedOperation": {
             "type": "structure",
+            "documentation": "<p> Your account is not authorized to perform the requested operation. </p>",
             "members": []
         },
         "UnknownSnapshotCopyRegionFault": {
             "type": "structure",
+            "documentation": "<p> The specified region is incorrect or does not exist. </p>",
             "members": []
         },
         "UnsupportedOperationFault": {
             "type": "structure",
+            "documentation": "<p> The requested operation isn't supported. </p>",
             "members": []
         },
         "UnsupportedOptionFault": {
             "type": "structure",
+            "documentation": "<p> A request option was specified that is not supported. </p>",
             "members": []
         },
         "VpcSecurityGroupIdList": {
@@ -4095,6 +4286,7 @@
         },
         "VpcSecurityGroupMembership": {
             "type": "structure",
+            "documentation": "<p>Describes the members of a VPC security group.</p>",
             "members": [
                 {
                     "name": "VpcSecurityGroupId",

--- a/libcloudcore/data/aws/route53/service.json
+++ b/libcloudcore/data/aws/route53/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "https://route53.amazonaws.com/doc/2013-04-01/"
         }
@@ -320,6 +323,7 @@
         },
         "AliasTarget": {
             "type": "structure",
+            "documentation": "<p><i>Alias resource record sets only:</i> Information about the domain to which you are redirecting traffic.</p> <p>For more information and an example, see <a href=\"http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingAliasRRSets.html\">Creating Alias Resource Record Sets</a> in the <i>Amazon Route 53 Developer Guide</i></p>.",
             "members": [
                 {
                     "name": "HostedZoneId",
@@ -343,6 +347,7 @@
         },
         "AssociateVPCWithHostedZoneRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to associate a VPC with an hosted zone.</p>",
             "members": [
                 {
                     "name": "HostedZoneId",
@@ -365,6 +370,7 @@
         },
         "AssociateVPCWithHostedZoneResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response information for the request.</p>",
             "members": [
                 {
                     "name": "ChangeInfo",
@@ -375,6 +381,7 @@
         },
         "Change": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the information for each change in a change batch request.</p>",
             "members": [
                 {
                     "name": "Action",
@@ -393,6 +400,7 @@
         },
         "ChangeBatch": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains an optional comment and the changes that you want to make with a change batch request.</p>",
             "members": [
                 {
                     "name": "Comment",
@@ -408,6 +416,7 @@
         },
         "ChangeInfo": {
             "type": "structure",
+            "documentation": "<p>A complex type that describes change information about changes made to your hosted zone.</p> <p>This element contains an ID that you use when performing a <a>GetChange</a> action to get detailed information about the change.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -433,6 +442,7 @@
         },
         "ChangeResourceRecordSetsRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains a change batch.</p>",
             "members": [
                 {
                     "name": "HostedZoneId",
@@ -450,6 +460,7 @@
         },
         "ChangeResourceRecordSetsResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response for the request.</p>",
             "members": [
                 {
                     "name": "ChangeInfo",
@@ -463,6 +474,7 @@
         },
         "ChangeTagsForResourceRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about a request to add, change, or delete the tags that are associated with a resource.</p>",
             "members": [
                 {
                     "name": "ResourceType",
@@ -492,6 +504,7 @@
         },
         "ChangeTagsForResourceResponse": {
             "type": "structure",
+            "documentation": "<p>Empty response for the request.</p>",
             "members": []
         },
         "Changes": {
@@ -513,6 +526,7 @@
         },
         "CreateHealthCheckRequest": {
             "type": "structure",
+            "documentation": "<p>&gt;A complex type that contains information about the request to create a health check.</p>",
             "members": [
                 {
                     "name": "CallerReference",
@@ -528,6 +542,7 @@
         },
         "CreateHealthCheckResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response information for the new health check.</p>",
             "members": [
                 {
                     "name": "HealthCheck",
@@ -545,6 +560,7 @@
         },
         "CreateHostedZoneRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to create a hosted zone.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -575,6 +591,7 @@
         },
         "CreateHostedZoneResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response information for the new hosted zone.</p>",
             "members": [
                 {
                     "name": "HostedZone",
@@ -641,6 +658,7 @@
         },
         "DelegationSet": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains name server information.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -659,6 +677,7 @@
         },
         "DelegationSetAlreadyCreated": {
             "type": "structure",
+            "documentation": "<p>A delegation set with the same owner and caller reference combination has already been created.</p>",
             "members": [
                 {
                     "name": "message",
@@ -669,6 +688,7 @@
         },
         "DelegationSetAlreadyReusable": {
             "type": "structure",
+            "documentation": "<p>The specified delegation set has already been marked as reusable.</p>",
             "members": [
                 {
                     "name": "message",
@@ -679,6 +699,7 @@
         },
         "DelegationSetInUse": {
             "type": "structure",
+            "documentation": "<p>The specified delegation contains associated hosted zones which must be deleted before the reusable delegation set can be deleted.</p>",
             "members": [
                 {
                     "name": "message",
@@ -693,6 +714,7 @@
         },
         "DelegationSetNotAvailable": {
             "type": "structure",
+            "documentation": "<p>Route 53 allows some duplicate domain names, but there is a maximum number of duplicate names. This error indicates that you have reached that maximum. If you want to create another hosted zone with the same name and Route 53 generates this error, you can request an increase to the limit on the <a href=\"http://aws.amazon.com/route53-request/\">Contact Us</a> page.</p>",
             "members": [
                 {
                     "name": "message",
@@ -703,6 +725,7 @@
         },
         "DelegationSetNotReusable": {
             "type": "structure",
+            "documentation": "<p>The specified delegation set has not been marked as reusable.</p>",
             "members": [
                 {
                     "name": "message",
@@ -717,6 +740,7 @@
         },
         "DeleteHealthCheckRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the request information for delete health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckId",
@@ -729,10 +753,12 @@
         },
         "DeleteHealthCheckResponse": {
             "type": "structure",
+            "documentation": "<p>Empty response for the request.</p>",
             "members": []
         },
         "DeleteHostedZoneRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the hosted zone that you want to delete.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -745,6 +771,7 @@
         },
         "DeleteHostedZoneResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response information for the request.</p>",
             "members": [
                 {
                     "name": "ChangeInfo",
@@ -755,6 +782,7 @@
         },
         "DeleteReusableDelegationSetRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the information for the delete request.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -767,6 +795,7 @@
         },
         "DeleteReusableDelegationSetResponse": {
             "type": "structure",
+            "documentation": "<p>Empty response for the request.</p>",
             "members": []
         },
         "DisassociateVPCComment": {
@@ -774,6 +803,7 @@
         },
         "DisassociateVPCFromHostedZoneRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to disassociate a VPC from an hosted zone.</p>",
             "members": [
                 {
                     "name": "HostedZoneId",
@@ -796,6 +826,7 @@
         },
         "DisassociateVPCFromHostedZoneResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing the response information for the request.</p>",
             "members": [
                 {
                     "name": "ChangeInfo",
@@ -819,6 +850,7 @@
         },
         "GeoLocation": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about a geo location.</p>",
             "members": [
                 {
                     "name": "ContinentCode",
@@ -851,6 +883,7 @@
         },
         "GeoLocationDetails": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about a <code>GeoLocation</code>.</p>",
             "members": [
                 {
                     "name": "ContinentCode",
@@ -896,6 +929,7 @@
         },
         "GetChangeRequest": {
             "type": "structure",
+            "documentation": "<p>The input for a GetChange request.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -908,6 +942,7 @@
         },
         "GetChangeResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the <code>ChangeInfo</code> element.</p>",
             "members": [
                 {
                     "name": "ChangeInfo",
@@ -918,10 +953,12 @@
         },
         "GetCheckerIpRangesRequest": {
             "type": "structure",
+            "documentation": "<p>Empty request.</p>",
             "members": []
         },
         "GetCheckerIpRangesResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the <code>CheckerIpRanges</code> element.</p>",
             "members": [
                 {
                     "name": "CheckerIpRanges",
@@ -932,6 +969,7 @@
         },
         "GetGeoLocationRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to get a geo location.</p>",
             "members": [
                 {
                     "name": "ContinentCode",
@@ -958,6 +996,7 @@
         },
         "GetGeoLocationResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about the specified geo location.</p>",
             "members": [
                 {
                     "name": "GeoLocationDetails",
@@ -968,10 +1007,12 @@
         },
         "GetHealthCheckCountRequest": {
             "type": "structure",
+            "documentation": "<p> To retrieve a count of all your health checks, send a <code>GET</code> request to the <code>2013-04-01/healthcheckcount</code> resource.</p>",
             "members": []
         },
         "GetHealthCheckCountResponse": {
             "type": "structure",
+            "documentation": "<p> A complex type that contains the count of health checks associated with the current AWS account.</p>",
             "members": [
                 {
                     "name": "HealthCheckCount",
@@ -982,6 +1023,7 @@
         },
         "GetHealthCheckLastFailureReasonRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to get the most recent failure reason for a health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckId",
@@ -994,6 +1036,7 @@
         },
         "GetHealthCheckLastFailureReasonResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the most recent failure for the specified health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckObservations",
@@ -1004,6 +1047,7 @@
         },
         "GetHealthCheckRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to get a health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckId",
@@ -1016,6 +1060,7 @@
         },
         "GetHealthCheckResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about the specified health check.</p>",
             "members": [
                 {
                     "name": "HealthCheck",
@@ -1026,6 +1071,7 @@
         },
         "GetHealthCheckStatusRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to get health check status for a health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckId",
@@ -1038,6 +1084,7 @@
         },
         "GetHealthCheckStatusResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the status of the specified health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckObservations",
@@ -1048,10 +1095,12 @@
         },
         "GetHostedZoneCountRequest": {
             "type": "structure",
+            "documentation": "<p> To retrieve a count of all your hosted zones, send a <code>GET</code> request to the <code>2013-04-01/hostedzonecount</code> resource.</p>",
             "members": []
         },
         "GetHostedZoneCountResponse": {
             "type": "structure",
+            "documentation": "<p> A complex type that contains the count of hosted zones associated with the current AWS account.</p>",
             "members": [
                 {
                     "name": "HostedZoneCount",
@@ -1062,6 +1111,7 @@
         },
         "GetHostedZoneRequest": {
             "type": "structure",
+            "documentation": "<p> The input for a GetHostedZone request.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1074,6 +1124,7 @@
         },
         "GetHostedZoneResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about the specified hosted zone.</p>",
             "members": [
                 {
                     "name": "HostedZone",
@@ -1094,6 +1145,7 @@
         },
         "GetReusableDelegationSetRequest": {
             "type": "structure",
+            "documentation": "<p> The input for a GetReusableDelegationSet request.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1106,6 +1158,7 @@
         },
         "GetReusableDelegationSetResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about the specified reusable delegation set.</p>",
             "members": [
                 {
                     "name": "DelegationSet",
@@ -1116,6 +1169,7 @@
         },
         "HealthCheck": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains identifying information about the health check.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1141,6 +1195,7 @@
         },
         "HealthCheckAlreadyExists": {
             "type": "structure",
+            "documentation": "<p>The health check you are trying to create already exists. Route 53 returns this error when a health check has already been created with the specified <code>CallerReference</code>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1151,6 +1206,7 @@
         },
         "HealthCheckConfig": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the health check configuration.</p>",
             "members": [
                 {
                     "name": "IPAddress",
@@ -1202,6 +1258,7 @@
         },
         "HealthCheckInUse": {
             "type": "structure",
+            "documentation": "<p>There are resource records associated with this health check. Before you can delete the health check, you must disassociate it from the resource record sets.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1215,6 +1272,7 @@
         },
         "HealthCheckObservation": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the IP address of a Route 53 health checker and the reason for the health check status.</p>",
             "members": [
                 {
                     "name": "IPAddress",
@@ -1253,6 +1311,7 @@
         },
         "HostedZone": {
             "type": "structure",
+            "documentation": "<p>A complex type that contain information about the specified hosted zone.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -1283,6 +1342,7 @@
         },
         "HostedZoneAlreadyExists": {
             "type": "structure",
+            "documentation": "<p>The hosted zone you are trying to create already exists. Route 53 returns this error when a hosted zone has already been created with the specified <code>CallerReference</code>.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1293,6 +1353,7 @@
         },
         "HostedZoneConfig": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains an optional comment about your hosted zone. If you don't want to specify a comment, you can omit the <code>HostedZoneConfig</code> and <code>Comment</code> elements from the XML document.</p>",
             "members": [
                 {
                     "name": "Comment",
@@ -1311,6 +1372,7 @@
         },
         "HostedZoneNotEmpty": {
             "type": "structure",
+            "documentation": "<p>The hosted zone contains resource record sets in addition to the default NS and SOA resource record sets. Before you can delete the hosted zone, you must delete the additional resource record sets.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1321,6 +1383,7 @@
         },
         "HostedZoneNotFound": {
             "type": "structure",
+            "documentation": "<p>The specified HostedZone cannot be found.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1344,6 +1407,7 @@
         },
         "IncompatibleVersion": {
             "type": "structure",
+            "documentation": "<p>The resource you are trying to access is unsupported on this Route 53 endpoint. Please consider using a newer endpoint or a tool that does so.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1353,6 +1417,7 @@
         },
         "InvalidArgument": {
             "type": "structure",
+            "documentation": "<p>At least one of the specified arguments is invalid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1363,6 +1428,7 @@
         },
         "InvalidChangeBatch": {
             "type": "structure",
+            "documentation": "<p>This error contains a list of one or more error messages. Each error message indicates one error in the change batch. For more information, see <a href=\"http://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html#example_Errors\">Example InvalidChangeBatch Errors</a>. </p>",
             "members": [
                 {
                     "name": "messages",
@@ -1373,6 +1439,7 @@
         },
         "InvalidDomainName": {
             "type": "structure",
+            "documentation": "<p>This error indicates that the specified domain name is not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1383,6 +1450,7 @@
         },
         "InvalidInput": {
             "type": "structure",
+            "documentation": "<p>Some value specified in the request is invalid or the XML document is malformed.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1393,6 +1461,7 @@
         },
         "InvalidVPCId": {
             "type": "structure",
+            "documentation": "<p>The hosted zone you are trying to create for your VPC_ID does not belong to you. Route 53 returns this error when the VPC specified by <code>VPCId</code> does not belong to you.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1406,6 +1475,7 @@
         },
         "LastVPCAssociation": {
             "type": "structure",
+            "documentation": "<p>The VPC you are trying to disassociate from the hosted zone is the last the VPC that is associated with the hosted zone. Route 53 currently doesn't support disassociate the last VPC from the hosted zone.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1416,6 +1486,7 @@
         },
         "LimitsExceeded": {
             "type": "structure",
+            "documentation": "<p>The limits specified for a resource have been exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1426,6 +1497,7 @@
         },
         "ListGeoLocationsRequest": {
             "type": "structure",
+            "documentation": "<p> The input for a ListGeoLocations request.</p>",
             "members": [
                 {
                     "name": "StartContinentCode",
@@ -1459,6 +1531,7 @@
         },
         "ListGeoLocationsResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the geo locations that are returned by the request and information about the response.</p>",
             "members": [
                 {
                     "name": "GeoLocationDetailsList",
@@ -1494,6 +1567,7 @@
         },
         "ListHealthChecksRequest": {
             "type": "structure",
+            "documentation": "<p> To retrieve a list of your health checks, send a <code>GET</code> request to the <code>2013-04-01/healthcheck</code> resource. The response to this request includes a <code>HealthChecks</code> element with zero or more <code>HealthCheck</code> child elements. By default, the list of health checks is displayed on a single page. You can control the length of the page that is displayed by using the <code>MaxItems</code> parameter. You can use the <code>Marker</code> parameter to control the health check that the list begins with.</p> <note> Route 53 returns a maximum of 100 items. If you set <code>MaxItems</code> to a value greater than 100, Route 53 returns only the first 100.</note>",
             "members": [
                 {
                     "name": "Marker",
@@ -1513,6 +1587,7 @@
         },
         "ListHealthChecksResponse": {
             "type": "structure",
+            "documentation": "<p> A complex type that contains the response for the request.</p>",
             "members": [
                 {
                     "name": "HealthChecks",
@@ -1543,6 +1618,7 @@
         },
         "ListHostedZonesByNameRequest": {
             "type": "structure",
+            "documentation": "<p>To retrieve a list of your hosted zones in lexicographic order, send a <code>GET</code> request to the <code>2013-04-01/hostedzonesbyname</code> resource. The response to this request includes a <code>HostedZones</code> element with zero or more <code>HostedZone</code> child elements lexicographically ordered by DNS name. By default, the list of hosted zones is displayed on a single page. You can control the length of the page that is displayed by using the <code>MaxItems</code> parameter. You can use the <code>DNSName</code> and <code>HostedZoneId</code> parameters to control the hosted zone that the list begins with.</p> <p>For more information about listing hosted zones, see <a href=\"http://docs.amazonwebservices.com/Route53/latest/DeveloperGuide/ListInfoOnHostedZone.html\">Listing the Hosted Zones for an AWS Account</a> in the <i>Amazon Route 53 Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "DNSName",
@@ -1569,6 +1645,7 @@
         },
         "ListHostedZonesByNameResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the response for the request.</p>",
             "members": [
                 {
                     "name": "HostedZones",
@@ -1609,6 +1686,7 @@
         },
         "ListHostedZonesRequest": {
             "type": "structure",
+            "documentation": "<p> To retrieve a list of your hosted zones, send a <code>GET</code> request to the <code>2013-04-01/hostedzone</code> resource. The response to this request includes a <code>HostedZones</code> element with zero or more <code>HostedZone</code> child elements. By default, the list of hosted zones is displayed on a single page. You can control the length of the page that is displayed by using the <code>MaxItems</code> parameter. You can use the <code>Marker</code> parameter to control the hosted zone that the list begins with. For more information about listing hosted zones, see <a href=\"http://docs.amazonwebservices.com/Route53/latest/DeveloperGuide/ListInfoOnHostedZone.html\">Listing the Hosted Zones for an AWS Account</a> in the <i>Amazon Route 53 Developer Guide</i>.</p> <note> Route 53 returns a maximum of 100 items. If you set <code>MaxItems</code> to a value greater than 100, Route 53 returns only the first 100.</note>",
             "members": [
                 {
                     "name": "Marker",
@@ -1634,6 +1712,7 @@
         },
         "ListHostedZonesResponse": {
             "type": "structure",
+            "documentation": "<p> A complex type that contains the response for the request.</p>",
             "members": [
                 {
                     "name": "HostedZones",
@@ -1664,6 +1743,7 @@
         },
         "ListResourceRecordSetsRequest": {
             "type": "structure",
+            "documentation": "<p> The input for a ListResourceRecordSets request.</p>",
             "members": [
                 {
                     "name": "HostedZoneId",
@@ -1704,6 +1784,7 @@
         },
         "ListResourceRecordSetsResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the resource record sets that are returned by the request and information about the response.</p>",
             "members": [
                 {
                     "name": "ResourceRecordSets",
@@ -1739,6 +1820,7 @@
         },
         "ListReusableDelegationSetsRequest": {
             "type": "structure",
+            "documentation": "<p> To retrieve a list of your reusable delegation sets, send a <code>GET</code> request to the <code>2013-04-01/delegationset</code> resource. The response to this request includes a <code>DelegationSets</code> element with zero or more <code>DelegationSet</code> child elements. By default, the list of reusable delegation sets is displayed on a single page. You can control the length of the page that is displayed by using the <code>MaxItems</code> parameter. You can use the <code>Marker</code> parameter to control the delegation set that the list begins with.</p> <note> Route 53 returns a maximum of 100 items. If you set <code>MaxItems</code> to a value greater than 100, Route 53 returns only the first 100.</note>",
             "members": [
                 {
                     "name": "Marker",
@@ -1758,6 +1840,7 @@
         },
         "ListReusableDelegationSetsResponse": {
             "type": "structure",
+            "documentation": "<p> A complex type that contains the response for the request.</p>",
             "members": [
                 {
                     "name": "DelegationSets",
@@ -1788,6 +1871,7 @@
         },
         "ListTagsForResourceRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about a request for a list of the tags that are associated with an individual resource.</p>",
             "members": [
                 {
                     "name": "ResourceType",
@@ -1807,6 +1891,7 @@
         },
         "ListTagsForResourceResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing tags for the specified resource.</p>",
             "members": [
                 {
                     "name": "ResourceTagSet",
@@ -1817,6 +1902,7 @@
         },
         "ListTagsForResourcesRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about a request for a list of the tags that are associated with up to 10 specified resources.</p>",
             "members": [
                 {
                     "name": "ResourceType",
@@ -1834,6 +1920,7 @@
         },
         "ListTagsForResourcesResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing tags for the specified resources.</p>",
             "members": [
                 {
                     "name": "ResourceTagSets",
@@ -1853,6 +1940,7 @@
         },
         "NoSuchDelegationSet": {
             "type": "structure",
+            "documentation": "<p>The specified delegation set does not exist.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1863,6 +1951,7 @@
         },
         "NoSuchGeoLocation": {
             "type": "structure",
+            "documentation": "<p>The geo location you are trying to get does not exist.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1873,6 +1962,7 @@
         },
         "NoSuchHealthCheck": {
             "type": "structure",
+            "documentation": "<p>The health check you are trying to get or delete does not exist.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1907,6 +1997,7 @@
         },
         "PriorRequestNotComplete": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because Route 53 was still processing a prior request.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1916,6 +2007,7 @@
         },
         "PublicZoneVPCAssociation": {
             "type": "structure",
+            "documentation": "<p>The hosted zone you are trying to associate VPC with doesn't have any VPC association. Route 53 currently doesn't support associate a VPC with a public hosted zone.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1944,6 +2036,7 @@
         },
         "ResourceRecord": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains the value of the <code>Value</code> element for the current resource record set.</p>",
             "members": [
                 {
                     "name": "Value",
@@ -1954,6 +2047,7 @@
         },
         "ResourceRecordSet": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the current resource record set.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -2034,6 +2128,7 @@
         },
         "ResourceTagSet": {
             "type": "structure",
+            "documentation": "<p>A complex type containing a resource and its associated tags.</p>",
             "members": [
                 {
                     "name": "ResourceType",
@@ -2067,6 +2162,7 @@
         },
         "StatusReport": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the health check status for the current observation.</p>",
             "members": [
                 {
                     "name": "Status",
@@ -2085,6 +2181,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>A single tag containing a key and value.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -2145,6 +2242,7 @@
         },
         "TooManyHostedZones": {
             "type": "structure",
+            "documentation": "<p>This error indicates that you've reached the maximum number of hosted zones that can be created for the current AWS account. You can request an increase to the limit on the <a href=\"http://aws.amazon.com/route53-request/\">Contact Us</a> page.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2155,6 +2253,7 @@
         },
         "UpdateHealthCheckRequest": {
             "type": "structure",
+            "documentation": "<p>&gt;A complex type that contains information about the request to update a health check.</p>",
             "members": [
                 {
                     "name": "HealthCheckId",
@@ -2211,6 +2310,7 @@
         },
         "UpdateHostedZoneCommentRequest": {
             "type": "structure",
+            "documentation": "<p>A complex type that contains information about the request to update a hosted zone comment.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -2228,6 +2328,7 @@
         },
         "UpdateHostedZoneCommentResponse": {
             "type": "structure",
+            "documentation": "<p>A complex type containing information about the specified hosted zone after the update.</p>",
             "members": [
                 {
                     "name": "HostedZone",
@@ -2250,6 +2351,7 @@
         },
         "VPCAssociationNotFound": {
             "type": "structure",
+            "documentation": "<p>The VPC you specified is not currently associated with the hosted zone.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2259,13 +2361,15 @@
             ]
         },
         "VPCId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A VPC ID</p>"
         },
         "VPCRegion": {
             "type": "string"
         },
         "VPCs": {
             "type": "list",
+            "documentation": "<p>A list of VPCs</p>",
             "of": "VPC"
         }
     }

--- a/libcloudcore/data/aws/route53domains/service.json
+++ b/libcloudcore/data/aws/route53domains/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -199,6 +203,7 @@
         },
         "CheckDomainAvailabilityRequest": {
             "type": "structure",
+            "documentation": "<p>The CheckDomainAvailability request contains the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -214,6 +219,7 @@
         },
         "CheckDomainAvailabilityResponse": {
             "type": "structure",
+            "documentation": "<p>The CheckDomainAvailability response includes the following elements.</p>",
             "members": [
                 {
                     "name": "Availability",
@@ -227,6 +233,7 @@
         },
         "ContactDetail": {
             "type": "structure",
+            "documentation": "<p>ContactDetail includes the following elements.</p>",
             "members": [
                 {
                     "name": "FirstName",
@@ -317,6 +324,7 @@
         },
         "DeleteTagsForDomainRequest": {
             "type": "structure",
+            "documentation": "<p>The DeleteTagsForDomainRequest includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -349,6 +357,7 @@
         },
         "DisableDomainTransferLockRequest": {
             "type": "structure",
+            "documentation": "<p>The DisableDomainTransferLock request includes the following element.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -359,6 +368,7 @@
         },
         "DisableDomainTransferLockResponse": {
             "type": "structure",
+            "documentation": "<p>The DisableDomainTransferLock response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -375,6 +385,7 @@
         },
         "DomainLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>The number of domains has exceeded the allowed threshold for the account.</p>",
             "members": [
                 {
                     "name": "message",
@@ -423,6 +434,7 @@
         },
         "DuplicateRequest": {
             "type": "structure",
+            "documentation": "<p>The request is already in progress for the domain.</p>",
             "members": [
                 {
                     "name": "message",
@@ -451,6 +463,7 @@
         },
         "EnableDomainTransferLockRequest": {
             "type": "structure",
+            "documentation": "<p>The EnableDomainTransferLock request includes the following element.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -461,6 +474,7 @@
         },
         "EnableDomainTransferLockResponse": {
             "type": "structure",
+            "documentation": "<p>The EnableDomainTransferLock response includes the following elements.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -474,6 +488,7 @@
         },
         "ExtraParam": {
             "type": "structure",
+            "documentation": "<p>ExtraParam includes the following elements.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -502,6 +517,7 @@
         },
         "GetDomainDetailRequest": {
             "type": "structure",
+            "documentation": "<p>The GetDomainDetail request includes the following element.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -512,6 +528,7 @@
         },
         "GetDomainDetailResponse": {
             "type": "structure",
+            "documentation": "<p>The GetDomainDetail response includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -622,6 +639,7 @@
         },
         "GetOperationDetailRequest": {
             "type": "structure",
+            "documentation": "<p>The GetOperationDetail request includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -632,6 +650,7 @@
         },
         "GetOperationDetailResponse": {
             "type": "structure",
+            "documentation": "<p>The GetOperationDetail response includes the following elements.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -677,6 +696,7 @@
         },
         "InvalidInput": {
             "type": "structure",
+            "documentation": "<p>The requested item is not acceptable. For example, for an OperationId it may refer to the ID of an operation that is already completed. For a domain name, it may not be a valid domain name or belong to the requester account.</p>",
             "members": [
                 {
                     "name": "message",
@@ -689,6 +709,7 @@
         },
         "ListDomainsRequest": {
             "type": "structure",
+            "documentation": "<p>The ListDomains request includes the following elements.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -704,6 +725,7 @@
         },
         "ListDomainsResponse": {
             "type": "structure",
+            "documentation": "<p>The ListDomains response includes the following elements.</p>",
             "members": [
                 {
                     "name": "Domains",
@@ -719,6 +741,7 @@
         },
         "ListOperationsRequest": {
             "type": "structure",
+            "documentation": "<p>The ListOperations request includes the following elements.</p>",
             "members": [
                 {
                     "name": "Marker",
@@ -734,6 +757,7 @@
         },
         "ListOperationsResponse": {
             "type": "structure",
+            "documentation": "<p>The ListOperations response includes the following elements.</p>",
             "members": [
                 {
                     "name": "Operations",
@@ -749,6 +773,7 @@
         },
         "ListTagsForDomainRequest": {
             "type": "structure",
+            "documentation": "<p>The ListTagsForDomainRequest includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -759,6 +784,7 @@
         },
         "ListTagsForDomainResponse": {
             "type": "structure",
+            "documentation": "<p>The ListTagsForDomain response includes the following elements.</p>",
             "members": [
                 {
                     "name": "TagList",
@@ -769,6 +795,7 @@
         },
         "Nameserver": {
             "type": "structure",
+            "documentation": "<p>Nameserver includes the following elements.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -791,6 +818,7 @@
         },
         "OperationLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>The number of operations or jobs running exceeded the allowed threshold for the account.</p>",
             "members": [
                 {
                     "name": "message",
@@ -803,6 +831,7 @@
         },
         "OperationSummary": {
             "type": "structure",
+            "documentation": "<p>OperationSummary includes the following elements.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -841,6 +870,7 @@
         },
         "RegisterDomainRequest": {
             "type": "structure",
+            "documentation": "<p>The RegisterDomain request includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -896,6 +926,7 @@
         },
         "RegisterDomainResponse": {
             "type": "structure",
+            "documentation": "<p>The RegisterDomain response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -921,6 +952,7 @@
         },
         "RetrieveDomainAuthCodeRequest": {
             "type": "structure",
+            "documentation": "<p>The RetrieveDomainAuthCode request includes the following element.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -931,6 +963,7 @@
         },
         "RetrieveDomainAuthCodeResponse": {
             "type": "structure",
+            "documentation": "<p>The RetrieveDomainAuthCode response includes the following element.</p>",
             "members": [
                 {
                     "name": "AuthCode",
@@ -944,6 +977,7 @@
         },
         "TLDRulesViolation": {
             "type": "structure",
+            "documentation": "<p>The top-level domain does not support this operation.</p>",
             "members": [
                 {
                     "name": "message",
@@ -953,6 +987,7 @@
         },
         "Tag": {
             "type": "structure",
+            "documentation": "<p>Each tag includes the following elements.</p>",
             "members": [
                 {
                     "name": "Key",
@@ -985,6 +1020,7 @@
         },
         "TransferDomainRequest": {
             "type": "structure",
+            "documentation": "<p>The TransferDomain request includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1050,6 +1086,7 @@
         },
         "TransferDomainResponse": {
             "type": "structure",
+            "documentation": "<p>The TranserDomain response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -1060,6 +1097,7 @@
         },
         "UnsupportedTLD": {
             "type": "structure",
+            "documentation": "<p>Amazon Route 53 does not support this top-level domain.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1069,6 +1107,7 @@
         },
         "UpdateDomainContactPrivacyRequest": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainContactPrivacy request includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1094,6 +1133,7 @@
         },
         "UpdateDomainContactPrivacyResponse": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainContactPrivacy response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -1104,6 +1144,7 @@
         },
         "UpdateDomainContactRequest": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainContact request includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1129,6 +1170,7 @@
         },
         "UpdateDomainContactResponse": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainContact response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -1139,6 +1181,7 @@
         },
         "UpdateDomainNameserversRequest": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainNameserver request includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",
@@ -1159,6 +1202,7 @@
         },
         "UpdateDomainNameserversResponse": {
             "type": "structure",
+            "documentation": "<p>The UpdateDomainNameservers response includes the following element.</p>",
             "members": [
                 {
                     "name": "OperationId",
@@ -1169,6 +1213,7 @@
         },
         "UpdateTagsForDomainRequest": {
             "type": "structure",
+            "documentation": "<p>The UpdateTagsForDomainRequest includes the following elements.</p>",
             "members": [
                 {
                     "name": "DomainName",

--- a/libcloudcore/data/aws/s3/service.json
+++ b/libcloudcore/data/aws/s3/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -613,6 +617,7 @@
         },
         "BucketAlreadyExists": {
             "type": "structure",
+            "documentation": "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.",
             "members": []
         },
         "BucketCannedACL": {
@@ -1829,7 +1834,8 @@
             "type": "string"
         },
         "EncodingType": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Requests Amazon S3 to encode the object keys in the response and specifies the encoding method to use. An object key may contain any Unicode character; however, XML 1.0 parser cannot parse some characters, such as characters with an ASCII value from 0 to 10. For characters that are not supported in XML 1.0, you can add this parameter to request that Amazon S3 encode the keys in the response."
         },
         "Error": {
             "type": "structure",
@@ -1867,7 +1873,8 @@
             "of": "Error"
         },
         "Event": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Bucket event for which to send notifications."
         },
         "EventList": {
             "type": "list",
@@ -2950,6 +2957,7 @@
         },
         "LambdaFunctionConfiguration": {
             "type": "structure",
+            "documentation": "Container for specifying the AWS Lambda notification configuration.",
             "members": [
                 {
                     "name": "Id",
@@ -3496,7 +3504,9 @@
             "type": "string"
         },
         "Metadata": {
-            "type": "map"
+            "type": "map",
+            "key": "MetadataKey",
+            "value": "MetadataValue"
         },
         "MetadataDirective": {
             "type": "string"
@@ -3568,18 +3578,22 @@
         },
         "NoSuchBucket": {
             "type": "structure",
+            "documentation": "The specified bucket does not exist.",
             "members": []
         },
         "NoSuchKey": {
             "type": "structure",
+            "documentation": "The specified key does not exist.",
             "members": []
         },
         "NoSuchUpload": {
             "type": "structure",
+            "documentation": "The specified multipart upload does not exist.",
             "members": []
         },
         "NoncurrentVersionExpiration": {
             "type": "structure",
+            "documentation": "Specifies when noncurrent object versions expire. Upon expiration, Amazon S3 permanently deletes the noncurrent object versions. You set this lifecycle configuration action on a bucket that has versioning enabled (or suspended) to request that Amazon S3 delete noncurrent object versions at a specific period in the object's lifetime.",
             "members": [
                 {
                     "name": "NoncurrentDays",
@@ -3590,6 +3604,7 @@
         },
         "NoncurrentVersionTransition": {
             "type": "structure",
+            "documentation": "Container for the transition rule that describes when noncurrent objects transition to the GLACIER storage class. If your bucket is versioning-enabled (or versioning is suspended), you can set this action to request that Amazon S3 transition noncurrent object versions to the GLACIER storage class at a specific period in the object's lifetime.",
             "members": [
                 {
                     "name": "NoncurrentDays",
@@ -3605,6 +3620,7 @@
         },
         "NotificationConfiguration": {
             "type": "structure",
+            "documentation": "Container for specifying the notification configuration of the bucket. If this element is empty, notifications are turned off on the bucket.",
             "members": [
                 {
                     "name": "TopicConfigurations",
@@ -3641,7 +3657,8 @@
             ]
         },
         "NotificationId": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Optional unique identifier for configurations in a notification configuration. If you don't provide one, Amazon S3 will assign an ID."
         },
         "Object": {
             "type": "structure",
@@ -3675,6 +3692,7 @@
         },
         "ObjectAlreadyInActiveTierError": {
             "type": "structure",
+            "documentation": "This operation is not allowed against this storage tier",
             "members": []
         },
         "ObjectCannedACL": {
@@ -3708,6 +3726,7 @@
         },
         "ObjectNotInActiveTierError": {
             "type": "structure",
+            "documentation": "The source object of the COPY operation is not in the active tier and is only stored in Amazon Glacier.",
             "members": []
         },
         "ObjectStorageClass": {
@@ -4499,6 +4518,7 @@
         },
         "QueueConfiguration": {
             "type": "structure",
+            "documentation": "Container for specifying an configuration when you want Amazon S3 to publish events to an Amazon Simple Queue Service (Amazon SQS) queue.",
             "members": [
                 {
                     "name": "Id",
@@ -4603,6 +4623,7 @@
         },
         "ReplicationConfiguration": {
             "type": "structure",
+            "documentation": "Container for replication rules. You can add as many as 1,000 rules. Total replication configuration size can be up to 2 MB.",
             "members": [
                 {
                     "name": "Role",
@@ -4652,10 +4673,12 @@
             "type": "string"
         },
         "RequestCharged": {
-            "type": "string"
+            "type": "string",
+            "documentation": "If present, indicates that the requester was successfully charged for the request."
         },
         "RequestPayer": {
-            "type": "string"
+            "type": "string",
+            "documentation": "Confirms that the requester knows that she or he will be charged for the request. Bucket owners need not specify this parameter in their requests. Documentation on downloading objects from requester pays buckets can be found at http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectsinRequesterPaysBuckets.html"
         },
         "RequestPaymentConfiguration": {
             "type": "structure",
@@ -4889,6 +4912,7 @@
         },
         "TopicConfiguration": {
             "type": "structure",
+            "documentation": "Container for specifying the configuration when you want Amazon S3 to publish events to an Amazon Simple Notification Service (Amazon SNS) topic.",
             "members": [
                 {
                     "name": "Id",

--- a/libcloudcore/data/aws/sdb/service.json
+++ b/libcloudcore/data/aws/sdb/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://sdb.amazonaws.com/doc/2009-04-15/"
         }
@@ -119,6 +122,7 @@
     "shapes": {
         "Attribute": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Name",
@@ -144,6 +148,7 @@
         },
         "AttributeDoesNotExist": {
             "type": "structure",
+            "documentation": "<p>The specified attribute does not exist.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -311,6 +316,7 @@
         },
         "DuplicateItemName": {
             "type": "structure",
+            "documentation": "<p>The item name was specified more than once. </p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -361,6 +367,7 @@
         },
         "InvalidNextToken": {
             "type": "structure",
+            "documentation": "<p>The specified NextToken is not valid. </p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -370,6 +377,7 @@
         },
         "InvalidNumberPredicates": {
             "type": "structure",
+            "documentation": "<p>Too many predicates exist in the query expression.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -379,6 +387,7 @@
         },
         "InvalidNumberValueTests": {
             "type": "structure",
+            "documentation": "<p>Too many predicates exist in the query expression.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -388,6 +397,7 @@
         },
         "InvalidParameterValue": {
             "type": "structure",
+            "documentation": "<p>The value for a parameter is invalid.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -397,6 +407,7 @@
         },
         "InvalidQueryExpression": {
             "type": "structure",
+            "documentation": "<p>The specified query expression syntax is not valid.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -406,6 +417,7 @@
         },
         "Item": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Name",
@@ -463,6 +475,7 @@
         },
         "MissingParameter": {
             "type": "structure",
+            "documentation": "<p>The request must contain the specified missing parameter.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -472,6 +485,7 @@
         },
         "NoSuchDomain": {
             "type": "structure",
+            "documentation": "<p>The specified domain does not exist.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -481,6 +495,7 @@
         },
         "NumberDomainAttributesExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many attributes in this domain.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -490,6 +505,7 @@
         },
         "NumberDomainBytesExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many bytes in this domain.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -499,6 +515,7 @@
         },
         "NumberDomainsExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many domains exist per this account.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -508,6 +525,7 @@
         },
         "NumberItemAttributesExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many attributes in this item.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -517,6 +535,7 @@
         },
         "NumberSubmittedAttributesExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many attributes exist in a single call.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -526,6 +545,7 @@
         },
         "NumberSubmittedItemsExceeded": {
             "type": "structure",
+            "documentation": "<p>Too many items exist in a single call.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -560,6 +580,7 @@
         },
         "ReplaceableAttribute": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Name",
@@ -584,6 +605,7 @@
         },
         "ReplaceableItem": {
             "type": "structure",
+            "documentation": "<p></p>",
             "members": [
                 {
                     "name": "Name",
@@ -604,6 +626,7 @@
         },
         "RequestTimeout": {
             "type": "structure",
+            "documentation": "<p>A timeout occurred when attempting to query the specified domain with specified query expression.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -651,6 +674,7 @@
         },
         "TooManyRequestedAttributes": {
             "type": "structure",
+            "documentation": "<p>Too many attributes requested.</p>",
             "members": [
                 {
                     "name": "BoxUsage",
@@ -660,6 +684,7 @@
         },
         "UpdateCondition": {
             "type": "structure",
+            "documentation": "<p> Specifies the conditions under which data should be updated. If an update condition is specified for a request, the data will only be updated if the condition is satisfied. For example, if an attribute with a specific name and value exists, or if a specific attribute doesn't exist. </p>",
             "members": [
                 {
                     "name": "Name",

--- a/libcloudcore/data/aws/ses/service.json
+++ b/libcloudcore/data/aws/ses/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://ses.amazonaws.com/doc/2010-12-01/"
         }
@@ -228,6 +231,7 @@
         },
         "Body": {
             "type": "structure",
+            "documentation": "<p>Represents the body of the message. You can specify text, HTML, or both. If you use both, then the message should display correctly in the widest variety of email clients. </p>",
             "members": [
                 {
                     "name": "Text",
@@ -246,6 +250,7 @@
         },
         "Content": {
             "type": "structure",
+            "documentation": "<p>Represents textual data, plus an optional character set specification.</p> <p>By default, the text must be 7-bit ASCII, due to the constraints of the SMTP protocol. If the text must contain any other characters, then you must also specify a character set. Examples include UTF-8, ISO-8859-1, and Shift_JIS. </p>",
             "members": [
                 {
                     "name": "Data",
@@ -264,6 +269,7 @@
         },
         "DeleteIdentityPolicyRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to delete an authorization policy applying to an identity.</p> <p>This request succeeds regardless of whether the specified policy exists.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -279,10 +285,12 @@
         },
         "DeleteIdentityPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "DeleteIdentityRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to delete an identity from the list of identities for the AWS Account.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -293,10 +301,12 @@
         },
         "DeleteIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "DeleteVerifiedEmailAddressRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to delete an address from the list of verified email addresses.</p>",
             "members": [
                 {
                     "name": "EmailAddress",
@@ -307,6 +317,7 @@
         },
         "Destination": {
             "type": "structure",
+            "documentation": "<p>Represents the destination of the message, consisting of To:, CC:, and BCC: fields.</p> <p> By default, the string must be 7-bit ASCII. If the text must contain any other characters, then you must use MIME encoded-word syntax (RFC 2047) instead of a literal string. MIME encoded-word syntax uses the following form: <code>=?charset?encoding?encoded-text?=</code>. For more information, see <a href=\"http://tools.ietf.org/html/rfc2047\">RFC 2047</a>. </p>",
             "members": [
                 {
                     "name": "ToAddresses",
@@ -326,7 +337,9 @@
             ]
         },
         "DkimAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "Identity",
+            "value": "IdentityDkimAttributes"
         },
         "Domain": {
             "type": "string"
@@ -336,6 +349,7 @@
         },
         "GetIdentityDkimAttributesRequest": {
             "type": "structure",
+            "documentation": "<p>Given a list of verified identities, describes their DKIM attributes. The DKIM attributes of an email address identity includes whether DKIM signing is individually enabled or disabled for that address. The DKIM attributes of a domain name identity includes whether DKIM signing is enabled, as well as the DNS records (tokens) that must remain published in the domain name's DNS.</p>",
             "members": [
                 {
                     "name": "Identities",
@@ -346,6 +360,7 @@
         },
         "GetIdentityDkimAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a list of all the DKIM attributes for the specified identity.</p>",
             "members": [
                 {
                     "name": "DkimAttributes",
@@ -366,6 +381,7 @@
         },
         "GetIdentityNotificationAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Describes whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and specifies whether feedback forwarding is enabled for bounce and complaint notifications.</p>",
             "members": [
                 {
                     "name": "NotificationAttributes",
@@ -376,6 +392,7 @@
         },
         "GetIdentityPoliciesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to retrieve the text of a list of authorization policies applying to an identity. </p>",
             "members": [
                 {
                     "name": "Identity",
@@ -391,6 +408,7 @@
         },
         "GetIdentityPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a map of policy names to policies returned from a successful <code>GetIdentityPolicies</code> request. </p>",
             "members": [
                 {
                     "name": "Policies",
@@ -401,6 +419,7 @@
         },
         "GetIdentityVerificationAttributesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to provide the verification attributes for a list of identities.</p>",
             "members": [
                 {
                     "name": "Identities",
@@ -411,6 +430,7 @@
         },
         "GetIdentityVerificationAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents the verification attributes for a list of identities.</p>",
             "members": [
                 {
                     "name": "VerificationAttributes",
@@ -421,6 +441,7 @@
         },
         "GetSendQuotaResponse": {
             "type": "structure",
+            "documentation": "<p>Represents the user's current activity limits returned from a successful <code>GetSendQuota</code> request. </p>",
             "members": [
                 {
                     "name": "Max24HourSend",
@@ -441,6 +462,7 @@
         },
         "GetSendStatisticsResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a list of <code>SendDataPoint</code> items returned from a successful <code>GetSendStatistics</code> request. This list contains aggregated data from the previous two weeks of sending activity. </p>",
             "members": [
                 {
                     "name": "SendDataPoints",
@@ -454,6 +476,7 @@
         },
         "IdentityDkimAttributes": {
             "type": "structure",
+            "documentation": "<p>Represents the DKIM attributes of a verified email address or a domain.</p>",
             "members": [
                 {
                     "name": "DkimEnabled",
@@ -478,6 +501,7 @@
         },
         "IdentityNotificationAttributes": {
             "type": "structure",
+            "documentation": "<p>Represents the notification attributes of an identity, including whether an identity has Amazon Simple Notification Service (Amazon SNS) topics set for bounce, complaint, and/or delivery notifications, and whether feedback forwarding is enabled for bounce and complaint notifications.</p>",
             "members": [
                 {
                     "name": "BounceTopic",
@@ -506,6 +530,7 @@
         },
         "IdentityVerificationAttributes": {
             "type": "structure",
+            "documentation": "<p>Represents the verification attributes of a single identity.</p>",
             "members": [
                 {
                     "name": "VerificationStatus",
@@ -521,10 +546,12 @@
         },
         "InvalidPolicyException": {
             "type": "structure",
+            "documentation": "Indicates that the provided policy is invalid. Check the error stack for more information about what caused the error.",
             "members": []
         },
         "ListIdentitiesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to list all identities for the AWS Account.</p>",
             "members": [
                 {
                     "name": "IdentityType",
@@ -545,6 +572,7 @@
         },
         "ListIdentitiesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a list of all verified identities for the AWS Account.</p>",
             "members": [
                 {
                     "name": "Identities",
@@ -560,6 +588,7 @@
         },
         "ListIdentityPoliciesRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to list all authorization policies, by name, applying to an identity.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -570,6 +599,7 @@
         },
         "ListIdentityPoliciesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a list of policy names returned from a successful <code>ListIdentityPolicies</code> request. </p>",
             "members": [
                 {
                     "name": "PolicyNames",
@@ -580,6 +610,7 @@
         },
         "ListVerifiedEmailAddressesResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a list of all the email addresses verified for the current user.</p>",
             "members": [
                 {
                     "name": "VerifiedEmailAddresses",
@@ -599,6 +630,7 @@
         },
         "Message": {
             "type": "structure",
+            "documentation": "<p>Represents the message to be sent, composed of a subject and a body.</p>",
             "members": [
                 {
                     "name": "Subject",
@@ -620,13 +652,16 @@
         },
         "MessageRejected": {
             "type": "structure",
+            "documentation": "Indicates that the action failed, and the message could not be sent. Check the error stack for more information about what caused the error.",
             "members": []
         },
         "NextToken": {
             "type": "string"
         },
         "NotificationAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "Identity",
+            "value": "IdentityNotificationAttributes"
         },
         "NotificationTopic": {
             "type": "string"
@@ -635,13 +670,17 @@
             "type": "string"
         },
         "Policy": {
-            "type": "string"
+            "type": "string",
+            "documentation": "JSON representation of a valid policy."
         },
         "PolicyMap": {
-            "type": "map"
+            "type": "map",
+            "key": "PolicyName",
+            "value": "Policy"
         },
         "PolicyName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "name of the policy."
         },
         "PolicyNameList": {
             "type": "list",
@@ -649,6 +688,7 @@
         },
         "PutIdentityPolicyRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to apply an authorization policy to an identity.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -669,10 +709,12 @@
         },
         "PutIdentityPolicyResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "RawMessage": {
             "type": "structure",
+            "documentation": "<p>Represents the raw data of the message.</p>",
             "members": [
                 {
                     "name": "Data",
@@ -686,6 +728,7 @@
         },
         "SendDataPoint": {
             "type": "structure",
+            "documentation": "<p>Represents sending statistics data. Each <code>SendDataPoint</code> contains statistics for a 15-minute period of sending activity. </p>",
             "members": [
                 {
                     "name": "Timestamp",
@@ -720,6 +763,7 @@
         },
         "SendEmailRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to send a single email message.</p> <p>This datatype can be used in application code to compose a message consisting of source, destination, message, reply-to, and return-path parts. This object can then be sent using the <code>SendEmail</code> action. </p>",
             "members": [
                 {
                     "name": "Source",
@@ -760,6 +804,7 @@
         },
         "SendEmailResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a unique message ID returned from a successful <code>SendEmail</code> request. </p>",
             "members": [
                 {
                     "name": "MessageId",
@@ -770,6 +815,7 @@
         },
         "SendRawEmailRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to send a raw email message.</p> <p>This datatype can be used in application code to compose a message consisting of source, destination, and raw message text. This object can then be sent using the <code>SendRawEmail</code> action. </p>",
             "members": [
                 {
                     "name": "Source",
@@ -805,6 +851,7 @@
         },
         "SendRawEmailResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a unique message ID returned from a successful <code>SendRawEmail</code> request. </p>",
             "members": [
                 {
                     "name": "MessageId",
@@ -818,6 +865,7 @@
         },
         "SetIdentityDkimEnabledRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to enable or disable DKIM signing for an identity.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -833,6 +881,7 @@
         },
         "SetIdentityDkimEnabledResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "SetIdentityFeedbackForwardingEnabledRequest": {
@@ -852,10 +901,12 @@
         },
         "SetIdentityFeedbackForwardingEnabledResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "SetIdentityNotificationTopicRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request to set or clear an identity's notification topic.</p>",
             "members": [
                 {
                     "name": "Identity",
@@ -876,13 +927,16 @@
         },
         "SetIdentityNotificationTopicResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         },
         "Timestamp": {
             "type": "timestamp"
         },
         "VerificationAttributes": {
-            "type": "map"
+            "type": "map",
+            "key": "Identity",
+            "value": "IdentityVerificationAttributes"
         },
         "VerificationStatus": {
             "type": "string"
@@ -896,6 +950,7 @@
         },
         "VerifyDomainDkimRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to begin DKIM verification for a domain.</p>",
             "members": [
                 {
                     "name": "Domain",
@@ -906,6 +961,7 @@
         },
         "VerifyDomainDkimResponse": {
             "type": "structure",
+            "documentation": "<p>Represents the DNS records that must be published in the domain name's DNS to complete DKIM setup.</p>",
             "members": [
                 {
                     "name": "DkimTokens",
@@ -916,6 +972,7 @@
         },
         "VerifyDomainIdentityRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to begin domain verification.</p>",
             "members": [
                 {
                     "name": "Domain",
@@ -926,6 +983,7 @@
         },
         "VerifyDomainIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>Represents a token used for domain ownership verification.</p>",
             "members": [
                 {
                     "name": "VerificationToken",
@@ -936,6 +994,7 @@
         },
         "VerifyEmailAddressRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to begin email address verification.</p>",
             "members": [
                 {
                     "name": "EmailAddress",
@@ -946,6 +1005,7 @@
         },
         "VerifyEmailIdentityRequest": {
             "type": "structure",
+            "documentation": "<p>Represents a request instructing the service to begin email address verification.</p>",
             "members": [
                 {
                     "name": "EmailAddress",
@@ -956,6 +1016,7 @@
         },
         "VerifyEmailIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>An empty element. Receiving this element indicates that the request completed successfully.</p>",
             "members": []
         }
     }

--- a/libcloudcore/data/aws/sns/service.json
+++ b/libcloudcore/data/aws/sns/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://sns.amazonaws.com/doc/2010-03-31/"
         }
@@ -259,6 +262,7 @@
         },
         "AuthorizationErrorException": {
             "type": "structure",
+            "documentation": "<p>Indicates that the user has been denied access to the requested resource.</p>",
             "members": [
                 {
                     "name": "message",
@@ -271,6 +275,7 @@
         },
         "ConfirmSubscriptionInput": {
             "type": "structure",
+            "documentation": "Input for ConfirmSubscription action.",
             "members": [
                 {
                     "name": "TopicArn",
@@ -291,6 +296,7 @@
         },
         "ConfirmSubscriptionResponse": {
             "type": "structure",
+            "documentation": "Response for ConfirmSubscriptions action.",
             "members": [
                 {
                     "name": "SubscriptionArn",
@@ -301,6 +307,7 @@
         },
         "CreateEndpointResponse": {
             "type": "structure",
+            "documentation": "<p>Response from CreateEndpoint action.</p>",
             "members": [
                 {
                     "name": "EndpointArn",
@@ -311,6 +318,7 @@
         },
         "CreatePlatformApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Input for CreatePlatformApplication action.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -331,6 +339,7 @@
         },
         "CreatePlatformApplicationResponse": {
             "type": "structure",
+            "documentation": "<p>Response from CreatePlatformApplication action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -341,6 +350,7 @@
         },
         "CreatePlatformEndpointInput": {
             "type": "structure",
+            "documentation": "<p>Input for CreatePlatformEndpoint action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -366,6 +376,7 @@
         },
         "CreateTopicInput": {
             "type": "structure",
+            "documentation": "<p>Input for CreateTopic action.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -376,6 +387,7 @@
         },
         "CreateTopicResponse": {
             "type": "structure",
+            "documentation": "<p>Response from CreateTopic action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -390,6 +402,7 @@
         },
         "DeleteEndpointInput": {
             "type": "structure",
+            "documentation": "<p>Input for DeleteEndpoint action.</p>",
             "members": [
                 {
                     "name": "EndpointArn",
@@ -400,6 +413,7 @@
         },
         "DeletePlatformApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Input for DeletePlatformApplication action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -420,6 +434,7 @@
         },
         "Endpoint": {
             "type": "structure",
+            "documentation": "<p>Endpoint for mobile app and device.</p>",
             "members": [
                 {
                     "name": "EndpointArn",
@@ -435,6 +450,7 @@
         },
         "EndpointDisabledException": {
             "type": "structure",
+            "documentation": "<p>Exception error indicating endpoint disabled.</p>",
             "members": [
                 {
                     "name": "message",
@@ -445,6 +461,7 @@
         },
         "GetEndpointAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetEndpointAttributes action.</p>",
             "members": [
                 {
                     "name": "EndpointArn",
@@ -455,6 +472,7 @@
         },
         "GetEndpointAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Response from GetEndpointAttributes of the EndpointArn.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -465,6 +483,7 @@
         },
         "GetPlatformApplicationAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetPlatformApplicationAttributes action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -475,6 +494,7 @@
         },
         "GetPlatformApplicationAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Response for GetPlatformApplicationAttributes action.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -485,6 +505,7 @@
         },
         "GetSubscriptionAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetSubscriptionAttributes.</p>",
             "members": [
                 {
                     "name": "SubscriptionArn",
@@ -495,6 +516,7 @@
         },
         "GetSubscriptionAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Response for GetSubscriptionAttributes action.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -505,6 +527,7 @@
         },
         "GetTopicAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for GetTopicAttributes action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -515,6 +538,7 @@
         },
         "GetTopicAttributesResponse": {
             "type": "structure",
+            "documentation": "<p>Response for GetTopicAttributes action.</p>",
             "members": [
                 {
                     "name": "Attributes",
@@ -525,6 +549,7 @@
         },
         "InternalErrorException": {
             "type": "structure",
+            "documentation": "<p>Indicates an internal service error.</p>",
             "members": [
                 {
                     "name": "message",
@@ -534,6 +559,7 @@
         },
         "InvalidParameterException": {
             "type": "structure",
+            "documentation": "<p>Indicates that a request parameter does not comply with the associated constraints.</p>",
             "members": [
                 {
                     "name": "message",
@@ -543,6 +569,7 @@
         },
         "InvalidParameterValueException": {
             "type": "structure",
+            "documentation": "<p>Indicates that a request parameter does not comply with the associated constraints.</p>",
             "members": [
                 {
                     "name": "message",
@@ -552,6 +579,7 @@
         },
         "ListEndpointsByPlatformApplicationInput": {
             "type": "structure",
+            "documentation": "<p>Input for ListEndpointsByPlatformApplication action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -567,6 +595,7 @@
         },
         "ListEndpointsByPlatformApplicationResponse": {
             "type": "structure",
+            "documentation": "<p>Response for ListEndpointsByPlatformApplication action.</p>",
             "members": [
                 {
                     "name": "Endpoints",
@@ -590,6 +619,7 @@
         },
         "ListPlatformApplicationsInput": {
             "type": "structure",
+            "documentation": "<p>Input for ListPlatformApplications action.</p>",
             "members": [
                 {
                     "name": "NextToken",
@@ -600,6 +630,7 @@
         },
         "ListPlatformApplicationsResponse": {
             "type": "structure",
+            "documentation": "<p>Response for ListPlatformApplications action.</p>",
             "members": [
                 {
                     "name": "PlatformApplications",
@@ -615,6 +646,7 @@
         },
         "ListSubscriptionsByTopicInput": {
             "type": "structure",
+            "documentation": "<p>Input for ListSubscriptionsByTopic action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -630,6 +662,7 @@
         },
         "ListSubscriptionsByTopicResponse": {
             "type": "structure",
+            "documentation": "<p>Response for ListSubscriptionsByTopic action.</p>",
             "members": [
                 {
                     "name": "Subscriptions",
@@ -645,6 +678,7 @@
         },
         "ListSubscriptionsInput": {
             "type": "structure",
+            "documentation": "Input for ListSubscriptions action.",
             "members": [
                 {
                     "name": "NextToken",
@@ -655,6 +689,7 @@
         },
         "ListSubscriptionsResponse": {
             "type": "structure",
+            "documentation": "<p>Response for ListSubscriptions action</p>",
             "members": [
                 {
                     "name": "Subscriptions",
@@ -680,6 +715,7 @@
         },
         "ListTopicsResponse": {
             "type": "structure",
+            "documentation": "<p>Response for ListTopics action.</p>",
             "members": [
                 {
                     "name": "Topics",
@@ -694,13 +730,18 @@
             ]
         },
         "MapStringToString": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "String"
         },
         "MessageAttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "MessageAttributeValue"
         },
         "MessageAttributeValue": {
             "type": "structure",
+            "documentation": "<p>The user-specified message attribute value. For string data types, the value attribute has the same restrictions on the content as the message body. For more information, see <a href=\"http://docs.aws.amazon.com/sns/latest/api/API_Publish.html\">Publish</a>.</p> <p>Name, type, and value must not be empty or null. In addition, the message body should not be empty or null. All parts of the message attribute, including name, type, and value, are included in the message size restriction, which is currently 256 KB (262,144 bytes). For more information, see <a href=\"http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html\">Using Amazon SNS Message Attributes</a>.</p>",
             "members": [
                 {
                     "name": "DataType",
@@ -721,6 +762,7 @@
         },
         "NotFoundException": {
             "type": "structure",
+            "documentation": "<p>Indicates that the requested resource does not exist.</p>",
             "members": [
                 {
                     "name": "message",
@@ -730,6 +772,7 @@
         },
         "PlatformApplication": {
             "type": "structure",
+            "documentation": "<p>Platform application object.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -745,6 +788,7 @@
         },
         "PlatformApplicationDisabledException": {
             "type": "structure",
+            "documentation": "<p>Exception error indicating platform application disabled.</p>",
             "members": [
                 {
                     "name": "message",
@@ -755,6 +799,7 @@
         },
         "PublishInput": {
             "type": "structure",
+            "documentation": "<p>Input for Publish action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -790,6 +835,7 @@
         },
         "PublishResponse": {
             "type": "structure",
+            "documentation": "<p>Response for Publish action.</p>",
             "members": [
                 {
                     "name": "MessageId",
@@ -800,6 +846,7 @@
         },
         "RemovePermissionInput": {
             "type": "structure",
+            "documentation": "<p>Input for RemovePermission action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -815,6 +862,7 @@
         },
         "SetEndpointAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for SetEndpointAttributes action.</p>",
             "members": [
                 {
                     "name": "EndpointArn",
@@ -830,6 +878,7 @@
         },
         "SetPlatformApplicationAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for SetPlatformApplicationAttributes action.</p>",
             "members": [
                 {
                     "name": "PlatformApplicationArn",
@@ -845,6 +894,7 @@
         },
         "SetSubscriptionAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for SetSubscriptionAttributes action.</p>",
             "members": [
                 {
                     "name": "SubscriptionArn",
@@ -865,6 +915,7 @@
         },
         "SetTopicAttributesInput": {
             "type": "structure",
+            "documentation": "<p>Input for SetTopicAttributes action.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -888,6 +939,7 @@
         },
         "SubscribeInput": {
             "type": "structure",
+            "documentation": "Input for Subscribe action.",
             "members": [
                 {
                     "name": "TopicArn",
@@ -908,6 +960,7 @@
         },
         "SubscribeResponse": {
             "type": "structure",
+            "documentation": "Response for Subscribe action.",
             "members": [
                 {
                     "name": "SubscriptionArn",
@@ -918,6 +971,7 @@
         },
         "Subscription": {
             "type": "structure",
+            "documentation": "<p>A wrapper type for the attributes of an Amazon SNS subscription.</p>",
             "members": [
                 {
                     "name": "SubscriptionArn",
@@ -947,10 +1001,13 @@
             ]
         },
         "SubscriptionAttributesMap": {
-            "type": "map"
+            "type": "map",
+            "key": "attributeName",
+            "value": "attributeValue"
         },
         "SubscriptionLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Indicates that the customer already owns the maximum allowed number of subscriptions.</p>",
             "members": [
                 {
                     "name": "message",
@@ -964,6 +1021,7 @@
         },
         "Topic": {
             "type": "structure",
+            "documentation": "<p>A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a topic's attributes, use <code>GetTopicAttributes</code>.</p>",
             "members": [
                 {
                     "name": "TopicArn",
@@ -973,10 +1031,13 @@
             ]
         },
         "TopicAttributesMap": {
-            "type": "map"
+            "type": "map",
+            "key": "attributeName",
+            "value": "attributeValue"
         },
         "TopicLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Indicates that the customer already owns the maximum allowed number of topics.</p>",
             "members": [
                 {
                     "name": "message",
@@ -990,6 +1051,7 @@
         },
         "UnsubscribeInput": {
             "type": "structure",
+            "documentation": "<p>Input for Unsubscribe action.</p>",
             "members": [
                 {
                     "name": "SubscriptionArn",

--- a/libcloudcore/data/aws/sqs/service.json
+++ b/libcloudcore/data/aws/sqs/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "http://queue.amazonaws.com/doc/2012-11-05/"
         }
@@ -235,7 +238,9 @@
             ]
         },
         "AttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "QueueAttributeName",
+            "value": "String"
         },
         "AttributeNameList": {
             "type": "list",
@@ -243,14 +248,17 @@
         },
         "BatchEntryIdsNotDistinct": {
             "type": "structure",
+            "documentation": "<p>Two or more batch entries have the same <code>Id</code> in the request.</p>",
             "members": []
         },
         "BatchRequestTooLong": {
             "type": "structure",
+            "documentation": "<p>The length of all the messages put together is more than the limit.</p>",
             "members": []
         },
         "BatchResultErrorEntry": {
             "type": "structure",
+            "documentation": "<p>This is used in the responses of batch API to give a detailed description of the result of an action on each entry in the request.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -305,6 +313,7 @@
         },
         "ChangeMessageVisibilityBatchRequestEntry": {
             "type": "structure",
+            "documentation": "<p>Encloses a receipt handle and an entry id for each message in <a>ChangeMessageVisibilityBatch</a>. </p> <important> <p>All of the following parameters are list parameters that must be prefixed with <code>ChangeMessageVisibilityBatchRequestEntry.n</code>, where <code>n</code> is an integer value starting with 1. For example, a parameter list for this action might look like this:</p> </important> <p><code>&amp;ChangeMessageVisibilityBatchRequestEntry.1.Id=change_visibility_msg_2</code></p> <p><code>&amp;ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle=<replaceable>Your_Receipt_Handle</replaceable></code></p> <p><code>&amp;ChangeMessageVisibilityBatchRequestEntry.1.VisibilityTimeout=45</code></p>",
             "members": [
                 {
                     "name": "Id",
@@ -329,6 +338,7 @@
         },
         "ChangeMessageVisibilityBatchResult": {
             "type": "structure",
+            "documentation": "<p> For each message in the batch, the response contains a <a>ChangeMessageVisibilityBatchResultEntry</a> tag if the message succeeds or a <a>BatchResultErrorEntry</a> tag if the message fails. </p>",
             "members": [
                 {
                     "name": "Successful",
@@ -344,6 +354,7 @@
         },
         "ChangeMessageVisibilityBatchResultEntry": {
             "type": "structure",
+            "documentation": "<p>Encloses the id of an entry in <a>ChangeMessageVisibilityBatch</a>.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -394,6 +405,7 @@
         },
         "CreateQueueResult": {
             "type": "structure",
+            "documentation": "<p>Returns the QueueUrl element of the created queue.</p>",
             "members": [
                 {
                     "name": "QueueUrl",
@@ -419,6 +431,7 @@
         },
         "DeleteMessageBatchRequestEntry": {
             "type": "structure",
+            "documentation": "<p>Encloses a receipt handle and an identifier for it.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -438,6 +451,7 @@
         },
         "DeleteMessageBatchResult": {
             "type": "structure",
+            "documentation": "<p> For each message in the batch, the response contains a <a>DeleteMessageBatchResultEntry</a> tag if the message is deleted or a <a>BatchResultErrorEntry</a> tag if the message cannot be deleted. </p>",
             "members": [
                 {
                     "name": "Successful",
@@ -453,6 +467,7 @@
         },
         "DeleteMessageBatchResultEntry": {
             "type": "structure",
+            "documentation": "<p>Encloses the id an entry in <a>DeleteMessageBatch</a>.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -492,6 +507,7 @@
         },
         "EmptyBatchRequest": {
             "type": "structure",
+            "documentation": "<p>Batch request does not contain an entry.</p>",
             "members": []
         },
         "GetQueueAttributesRequest": {
@@ -511,6 +527,7 @@
         },
         "GetQueueAttributesResult": {
             "type": "structure",
+            "documentation": "A list of returned queue attributes.",
             "members": [
                 {
                     "name": "Attributes",
@@ -537,6 +554,7 @@
         },
         "GetQueueUrlResult": {
             "type": "structure",
+            "documentation": "<p>For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/UnderstandingResponses.html\">Responses</a> in the <i>Amazon SQS Developer Guide</i>.</p>",
             "members": [
                 {
                     "name": "QueueUrl",
@@ -550,18 +568,22 @@
         },
         "InvalidAttributeName": {
             "type": "structure",
+            "documentation": "<p>The attribute referred to does not exist.</p>",
             "members": []
         },
         "InvalidBatchEntryId": {
             "type": "structure",
+            "documentation": "<p>The <code>Id</code> of a batch entry in a batch request does not abide by the specification.</p>",
             "members": []
         },
         "InvalidIdFormat": {
             "type": "structure",
+            "documentation": "<p>The receipt handle is not valid for the current version.</p>",
             "members": []
         },
         "InvalidMessageContents": {
             "type": "structure",
+            "documentation": "<p>The message contains characters outside the allowed set.</p>",
             "members": []
         },
         "ListDeadLetterSourceQueuesRequest": {
@@ -576,6 +598,7 @@
         },
         "ListDeadLetterSourceQueuesResult": {
             "type": "structure",
+            "documentation": "A list of your dead letter source queues.",
             "members": [
                 {
                     "name": "queueUrls",
@@ -596,6 +619,7 @@
         },
         "ListQueuesResult": {
             "type": "structure",
+            "documentation": "A list of your queues.",
             "members": [
                 {
                     "name": "QueueUrls",
@@ -606,6 +630,7 @@
         },
         "Message": {
             "type": "structure",
+            "documentation": "<p>An Amazon SQS message.</p>",
             "members": [
                 {
                     "name": "MessageId",
@@ -647,7 +672,9 @@
             ]
         },
         "MessageAttributeMap": {
-            "type": "map"
+            "type": "map",
+            "key": "String",
+            "value": "MessageAttributeValue"
         },
         "MessageAttributeName": {
             "type": "string"
@@ -658,6 +685,7 @@
         },
         "MessageAttributeValue": {
             "type": "structure",
+            "documentation": "<p>The user-specified message attribute value. For string data types, the value attribute has the same restrictions on the content as the message body. For more information, see <a href=\"http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html\">SendMessage</a>.</p> <p>Name, type, and value must not be empty or null. In addition, the message body should not be empty or null. All parts of the message attribute, including name, type, and value, are included in the message size restriction, which is currently 256 KB (262,144 bytes).</p>",
             "members": [
                 {
                     "name": "StringValue",
@@ -696,14 +724,17 @@
         },
         "MessageNotInflight": {
             "type": "structure",
+            "documentation": "<p>The message referred to is not in flight.</p>",
             "members": []
         },
         "OverLimit": {
             "type": "structure",
+            "documentation": "<p>The action that you requested would violate a limit. For example, ReceiveMessage returns this error if the maximum number of messages inflight has already been reached. <a>AddPermission</a> returns this error if the maximum number of permissions for the queue has already been reached. </p>",
             "members": []
         },
         "PurgeQueueInProgress": {
             "type": "structure",
+            "documentation": "<p>Indicates that the specified queue previously received a <code>PurgeQueue</code> request within the last 60 seconds, the time it can take to delete the messages in the queue.</p>",
             "members": []
         },
         "PurgeQueueRequest": {
@@ -721,14 +752,17 @@
         },
         "QueueDeletedRecently": {
             "type": "structure",
+            "documentation": "<p>You must wait 60 seconds after deleting a queue before you can create another with the same name.</p>",
             "members": []
         },
         "QueueDoesNotExist": {
             "type": "structure",
+            "documentation": "<p>The queue referred to does not exist.</p>",
             "members": []
         },
         "QueueNameExists": {
             "type": "structure",
+            "documentation": "<p>A queue already exists with this name. Amazon SQS returns this error only if the request includes attributes whose values differ from those of the existing queue.</p>",
             "members": []
         },
         "QueueUrlList": {
@@ -737,6 +771,7 @@
         },
         "ReceiptHandleIsInvalid": {
             "type": "structure",
+            "documentation": "<p>The receipt handle provided is not valid.</p>",
             "members": []
         },
         "ReceiveMessageRequest": {
@@ -776,6 +811,7 @@
         },
         "ReceiveMessageResult": {
             "type": "structure",
+            "documentation": "A list of received messages.",
             "members": [
                 {
                     "name": "Messages",
@@ -816,6 +852,7 @@
         },
         "SendMessageBatchRequestEntry": {
             "type": "structure",
+            "documentation": "<p>Contains the details of a single Amazon SQS message along with a <code>Id</code>. </p>",
             "members": [
                 {
                     "name": "Id",
@@ -846,6 +883,7 @@
         },
         "SendMessageBatchResult": {
             "type": "structure",
+            "documentation": "<p>For each message in the batch, the response contains a <a>SendMessageBatchResultEntry</a> tag if the message succeeds or a <a>BatchResultErrorEntry</a> tag if the message fails.</p>",
             "members": [
                 {
                     "name": "Successful",
@@ -861,6 +899,7 @@
         },
         "SendMessageBatchResultEntry": {
             "type": "structure",
+            "documentation": "<p>Encloses a message ID for successfully enqueued message of a <a>SendMessageBatch</a>.</p>",
             "members": [
                 {
                     "name": "Id",
@@ -916,6 +955,7 @@
         },
         "SendMessageResult": {
             "type": "structure",
+            "documentation": "<p>The MD5OfMessageBody and MessageId elements.</p>",
             "members": [
                 {
                     "name": "MD5OfMessageBody",
@@ -959,10 +999,12 @@
         },
         "TooManyEntriesInBatchRequest": {
             "type": "structure",
+            "documentation": "<p>Batch request contains more number of entries than permissible.</p>",
             "members": []
         },
         "UnsupportedOperation": {
             "type": "structure",
+            "documentation": "<p>Error code 400. Unsupported operation.</p>",
             "members": []
         }
     }

--- a/libcloudcore/data/aws/ssm/service.json
+++ b/libcloudcore/data/aws/ssm/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -130,10 +134,12 @@
     "shapes": {
         "AssociatedInstances": {
             "type": "structure",
+            "documentation": "<p>You must disassociate a configuration document from all instances before you can delete it.</p>",
             "members": []
         },
         "Association": {
             "type": "structure",
+            "documentation": "<p>Describes an association of a configuration document and an instance.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -149,10 +155,12 @@
         },
         "AssociationAlreadyExists": {
             "type": "structure",
+            "documentation": "<p>The specified association already exists.</p>",
             "members": []
         },
         "AssociationDescription": {
             "type": "structure",
+            "documentation": "<p>Describes an association.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -182,10 +190,12 @@
         },
         "AssociationDoesNotExist": {
             "type": "structure",
+            "documentation": "<p>The specified association does not exist.</p>",
             "members": []
         },
         "AssociationFilter": {
             "type": "structure",
+            "documentation": "<p>Describes a filter.</p>",
             "members": [
                 {
                     "name": "key",
@@ -211,6 +221,7 @@
         },
         "AssociationLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>You can have at most 2,000 active associations.</p>",
             "members": []
         },
         "AssociationList": {
@@ -219,6 +230,7 @@
         },
         "AssociationStatus": {
             "type": "structure",
+            "documentation": "<p>Describes an association status.</p>",
             "members": [
                 {
                     "name": "Date",
@@ -264,6 +276,7 @@
         },
         "CreateAssociationBatchRequestEntry": {
             "type": "structure",
+            "documentation": "<p>Describes the association of a configuration document and an instance.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -425,6 +438,7 @@
         },
         "DocumentAlreadyExists": {
             "type": "structure",
+            "documentation": "<p>The specified configuration document already exists.</p>",
             "members": []
         },
         "DocumentContent": {
@@ -432,6 +446,7 @@
         },
         "DocumentDescription": {
             "type": "structure",
+            "documentation": "<p>Describes a configuration document.</p>",
             "members": [
                 {
                     "name": "Sha1",
@@ -457,6 +472,7 @@
         },
         "DocumentFilter": {
             "type": "structure",
+            "documentation": "<p>Describes a filter.</p>",
             "members": [
                 {
                     "name": "key",
@@ -482,6 +498,7 @@
         },
         "DocumentIdentifier": {
             "type": "structure",
+            "documentation": "<p>Describes the name of a configuration document.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -496,6 +513,7 @@
         },
         "DocumentLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>You can have at most 100 active configuration documents.</p>",
             "members": []
         },
         "DocumentName": {
@@ -509,10 +527,12 @@
         },
         "DuplicateInstanceId": {
             "type": "structure",
+            "documentation": "<p>You cannot specify an instance ID in more than one association.</p>",
             "members": []
         },
         "FailedCreateAssociation": {
             "type": "structure",
+            "documentation": "<p>Describes a failed association.</p>",
             "members": [
                 {
                     "name": "Entry",
@@ -568,14 +588,17 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>An error occurred on the server side.</p>",
             "members": []
         },
         "InvalidDocument": {
             "type": "structure",
+            "documentation": "<p>The configuration document is not valid.</p>",
             "members": []
         },
         "InvalidDocumentContent": {
             "type": "structure",
+            "documentation": "<p>The content for the configuration document is not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -586,10 +609,12 @@
         },
         "InvalidInstanceId": {
             "type": "structure",
+            "documentation": "<p>You must specify the ID of a running instance.</p>",
             "members": []
         },
         "InvalidNextToken": {
             "type": "structure",
+            "documentation": "<p>The specified token is not valid.</p>",
             "members": []
         },
         "ListAssociationsRequest": {
@@ -666,6 +691,7 @@
         },
         "MaxDocumentSizeExceeded": {
             "type": "structure",
+            "documentation": "<p>The size limit of a configuration document is 64 KB.</p>",
             "members": []
         },
         "MaxResults": {
@@ -682,6 +708,7 @@
         },
         "StatusUnchanged": {
             "type": "structure",
+            "documentation": "<p>The updated status is the same as the current status.</p>",
             "members": []
         },
         "String": {
@@ -689,6 +716,7 @@
         },
         "TooManyUpdates": {
             "type": "structure",
+            "documentation": "<p>There are concurrent updates for a resource that supports one update at a time.</p>",
             "members": []
         },
         "UpdateAssociationStatusRequest": {

--- a/libcloudcore/data/aws/storagegateway/service.json
+++ b/libcloudcore/data/aws/storagegateway/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -481,6 +485,7 @@
     "shapes": {
         "ActivateGatewayInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>ActivateGatewayInput$ActivationKey</a> </li> <li> <a>GatewayName</a> </li> <li> <a>ActivateGatewayInput$GatewayRegion</a> </li> <li> <a>ActivateGatewayInput$GatewayTimezone</a> </li> <li> <a>ActivateGatewayInput$GatewayType</a> </li> <li> <a>ActivateGatewayInput$TapeDriveType</a> </li> <li> <a>ActivateGatewayInput$MediumChangerType</a> </li> </ul>",
             "members": [
                 {
                     "name": "ActivationKey",
@@ -520,6 +525,7 @@
         },
         "ActivateGatewayOutput": {
             "type": "structure",
+            "documentation": "<p>AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated gateway. It is a string made of information such as your account, gateway name, and region. This ARN is used to reference the gateway in other API operations as well as resource-based authorization.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -576,6 +582,7 @@
         },
         "AddWorkingStorageInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>AddWorkingStorageInput$DiskIds</a> </li> </ul>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -590,6 +597,7 @@
         },
         "AddWorkingStorageOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway for which working storage was configured.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -649,6 +657,7 @@
         },
         "CancelArchivalInput": {
             "type": "structure",
+            "documentation": "<p>CancelArchivalInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -663,6 +672,7 @@
         },
         "CancelArchivalOutput": {
             "type": "structure",
+            "documentation": "<p>CancelArchivalOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -673,6 +683,7 @@
         },
         "CancelRetrievalInput": {
             "type": "structure",
+            "documentation": "<p>CancelRetrievalInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -687,6 +698,7 @@
         },
         "CancelRetrievalOutput": {
             "type": "structure",
+            "documentation": "<p>CancelRetrievalOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -701,6 +713,7 @@
         },
         "ChapInfo": {
             "type": "structure",
+            "documentation": "<p>Describes Challenge-Handshake Authentication Protocol (CHAP) information that supports authentication between your gateway and iSCSI initiators.</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -804,6 +817,7 @@
         },
         "CreateSnapshotInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>CreateSnapshotInput$SnapshotDescription</a> </li> <li> <a>CreateSnapshotInput$VolumeARN</a> </li> </ul>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -819,6 +833,7 @@
         },
         "CreateSnapshotOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -834,6 +849,7 @@
         },
         "CreateStorediSCSIVolumeInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>CreateStorediSCSIVolumeInput$DiskId</a> </li> <li> <a>CreateStorediSCSIVolumeInput$NetworkInterfaceId</a> </li> <li> <a>CreateStorediSCSIVolumeInput$PreserveExistingData</a> </li> <li> <a>CreateStorediSCSIVolumeInput$SnapshotId</a> </li> <li> <a>CreateStorediSCSIVolumeInput$TargetName</a> </li> </ul>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -868,6 +884,7 @@
         },
         "CreateStorediSCSIVolumeOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -888,6 +905,7 @@
         },
         "CreateTapesInput": {
             "type": "structure",
+            "documentation": "<p>CreateTapesInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -918,6 +936,7 @@
         },
         "CreateTapesOutput": {
             "type": "structure",
+            "documentation": "<p>CreateTapeOutput</p>",
             "members": [
                 {
                     "name": "TapeARNs",
@@ -944,6 +963,7 @@
         },
         "DeleteBandwidthRateLimitOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway whose bandwidth rate information was deleted.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -953,6 +973,7 @@
         },
         "DeleteChapCredentialsInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>DeleteChapCredentialsInput$InitiatorName</a> </li> <li> <a>DeleteChapCredentialsInput$TargetARN</a> </li> </ul>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -968,6 +989,7 @@
         },
         "DeleteChapCredentialsOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -983,6 +1005,7 @@
         },
         "DeleteGatewayInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the id of the gateway to delete.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -992,6 +1015,7 @@
         },
         "DeleteGatewayOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the id of the deleted gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1019,6 +1043,7 @@
         },
         "DeleteTapeArchiveInput": {
             "type": "structure",
+            "documentation": "<p>DeleteTapeArchiveInput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1029,6 +1054,7 @@
         },
         "DeleteTapeArchiveOutput": {
             "type": "structure",
+            "documentation": "<p>DeleteTapeArchiveOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1039,6 +1065,7 @@
         },
         "DeleteTapeInput": {
             "type": "structure",
+            "documentation": "<p>DeleteTapeInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1054,6 +1081,7 @@
         },
         "DeleteTapeOutput": {
             "type": "structure",
+            "documentation": "<p>DeleteTapeOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1064,6 +1092,7 @@
         },
         "DeleteVolumeInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the <a>DeleteVolumeInput$VolumeARN</a> to delete.</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -1074,6 +1103,7 @@
         },
         "DeleteVolumeOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the storage volume that was deleted</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -1084,6 +1114,7 @@
         },
         "DescribeBandwidthRateLimitInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1093,6 +1124,7 @@
         },
         "DescribeBandwidthRateLimitOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1163,6 +1195,7 @@
         },
         "DescribeCachediSCSIVolumesOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "CachediSCSIVolumes",
@@ -1173,6 +1206,7 @@
         },
         "DescribeChapCredentialsInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the Amazon Resource Name (ARN) of the iSCSI volume target.</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -1183,6 +1217,7 @@
         },
         "DescribeChapCredentialsOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing a .</p>",
             "members": [
                 {
                     "name": "ChapCredentials",
@@ -1193,6 +1228,7 @@
         },
         "DescribeGatewayInformationInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the id of the gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1202,6 +1238,7 @@
         },
         "DescribeGatewayInformationOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1246,6 +1283,7 @@
         },
         "DescribeMaintenanceStartTimeInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1280,6 +1318,7 @@
         },
         "DescribeSnapshotScheduleInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the <a>DescribeSnapshotScheduleInput$VolumeARN</a> of the volume.</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -1315,6 +1354,7 @@
         },
         "DescribeStorediSCSIVolumesInput": {
             "type": "structure",
+            "documentation": "<p>A JSON Object containing a list of <a>DescribeStorediSCSIVolumesInput$VolumeARNs</a>.</p>",
             "members": [
                 {
                     "name": "VolumeARNs",
@@ -1334,6 +1374,7 @@
         },
         "DescribeTapeArchivesInput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapeArchivesInput</p>",
             "members": [
                 {
                     "name": "TapeARNs",
@@ -1354,6 +1395,7 @@
         },
         "DescribeTapeArchivesOutput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapeArchivesOutput</p>",
             "members": [
                 {
                     "name": "TapeArchives",
@@ -1369,6 +1411,7 @@
         },
         "DescribeTapeRecoveryPointsInput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapeRecoveryPointsInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1388,6 +1431,7 @@
         },
         "DescribeTapeRecoveryPointsOutput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapeRecoveryPointsOutput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1407,6 +1451,7 @@
         },
         "DescribeTapesInput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapesInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1431,6 +1476,7 @@
         },
         "DescribeTapesOutput": {
             "type": "structure",
+            "documentation": "<p>DescribeTapesOutput</p>",
             "members": [
                 {
                     "name": "Tapes",
@@ -1476,6 +1522,7 @@
         },
         "DescribeVTLDevicesInput": {
             "type": "structure",
+            "documentation": "<p>DescribeVTLDevicesInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1500,6 +1547,7 @@
         },
         "DescribeVTLDevicesOutput": {
             "type": "structure",
+            "documentation": "<p>DescribeVTLDevicesOutput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1519,6 +1567,7 @@
         },
         "DescribeWorkingStorageInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1528,6 +1577,7 @@
         },
         "DescribeWorkingStorageOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1558,6 +1608,7 @@
         },
         "DeviceiSCSIAttributes": {
             "type": "structure",
+            "documentation": "<p>Lists iSCSI information about a VTL device.</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -1583,6 +1634,7 @@
         },
         "DisableGatewayInput": {
             "type": "structure",
+            "documentation": "<p>DisableGatewayInput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1592,6 +1644,7 @@
         },
         "DisableGatewayOutput": {
             "type": "structure",
+            "documentation": "<p>DisableGatewayOutput</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1654,7 +1707,8 @@
             "type": "string"
         },
         "GatewayARN": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>"
         },
         "GatewayId": {
             "type": "string"
@@ -1677,7 +1731,8 @@
             ]
         },
         "GatewayName": {
-            "type": "string"
+            "type": "string",
+            "documentation": "<p>A unique identifier for your gateway. This name becomes part of the gateway Amazon Resources Name (ARN) which is what you use as an input to other operations.</p>"
         },
         "GatewayNetworkInterfaces": {
             "type": "list",
@@ -1711,6 +1766,7 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>An internal server error has occurred during the request. See the error and message fields for more information.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1726,6 +1782,7 @@
         },
         "InvalidGatewayRequestException": {
             "type": "structure",
+            "documentation": "<p>An exception occurred because an invalid gateway request was issued to the service. See the error and message fields for more information.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1747,6 +1804,7 @@
         },
         "ListGatewaysInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing zero or more of the following fields:</p> <ul> <li> <a>ListGatewaysInput$Limit</a> </li> <li> <a>ListGatewaysInput$Marker</a> </li> </ul>",
             "members": [
                 {
                     "name": "Marker",
@@ -1775,6 +1833,7 @@
         },
         "ListLocalDisksInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1797,6 +1856,7 @@
         },
         "ListVolumeInitiatorsInput": {
             "type": "structure",
+            "documentation": "<p>ListVolumeInitiatorsInput</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -1807,6 +1867,7 @@
         },
         "ListVolumeInitiatorsOutput": {
             "type": "structure",
+            "documentation": "<p>ListVolumeInitiatorsOutput</p>",
             "members": [
                 {
                     "name": "Initiators",
@@ -1839,6 +1900,7 @@
         },
         "ListVolumesInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object that contains one or more of the following fields:</p> <ul> <li> <a>ListVolumesInput$Limit</a> </li> <li> <a>ListVolumesInput$Marker</a> </li> </ul>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1884,6 +1946,7 @@
         },
         "NetworkInterface": {
             "type": "structure",
+            "documentation": "<p>Describes a gateway's network interface.</p>",
             "members": [
                 {
                     "name": "Ipv4Address",
@@ -1940,6 +2003,7 @@
         },
         "RetrieveTapeArchiveInput": {
             "type": "structure",
+            "documentation": "<p>RetrieveTapeArchiveInput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1955,6 +2019,7 @@
         },
         "RetrieveTapeArchiveOutput": {
             "type": "structure",
+            "documentation": "<p>RetrieveTapeArchiveOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1965,6 +2030,7 @@
         },
         "RetrieveTapeRecoveryPointInput": {
             "type": "structure",
+            "documentation": "<p>RetrieveTapeRecoveryPointInput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1979,6 +2045,7 @@
         },
         "RetrieveTapeRecoveryPointOutput": {
             "type": "structure",
+            "documentation": "<p>RetrieveTapeRecoveryPointOutput</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -1989,6 +2056,7 @@
         },
         "ShutdownGatewayInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway to shut down.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -1998,6 +2066,7 @@
         },
         "ShutdownGatewayOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway that was shut down.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2013,6 +2082,7 @@
         },
         "StartGatewayInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway to start.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2022,6 +2092,7 @@
         },
         "StartGatewayOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway that was restarted.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2031,6 +2102,7 @@
         },
         "StorageGatewayError": {
             "type": "structure",
+            "documentation": "<p>Provides additional information about an error that was returned by the service as an or. See the <code>errorCode</code> and <code>errorDetails</code> members for more information about the error.</p>",
             "members": [
                 {
                     "name": "errorCode",
@@ -2095,6 +2167,7 @@
         },
         "Tape": {
             "type": "structure",
+            "documentation": "<p>Describes a virtual tape object.</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -2137,6 +2210,7 @@
         },
         "TapeArchive": {
             "type": "structure",
+            "documentation": "<p>Represents a virtual tape that is archived in the virtual tape shelf (VTS).</p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -2188,6 +2262,7 @@
         },
         "TapeRecoveryPointInfo": {
             "type": "structure",
+            "documentation": "<p>Describes a recovery point. </p>",
             "members": [
                 {
                     "name": "TapeARN",
@@ -2238,6 +2313,7 @@
         },
         "UpdateBandwidthRateLimitInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>UpdateBandwidthRateLimitInput$AverageDownloadRateLimitInBitsPerSec</a> </li> <li> <a>UpdateBandwidthRateLimitInput$AverageUploadRateLimitInBitsPerSec</a> </li> </ul>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2257,6 +2333,7 @@
         },
         "UpdateBandwidthRateLimitOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway whose throttle information was updated.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2266,6 +2343,7 @@
         },
         "UpdateChapCredentialsInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>UpdateChapCredentialsInput$InitiatorName</a> </li> <li> <a>UpdateChapCredentialsInput$SecretToAuthenticateInitiator</a> </li> <li> <a>UpdateChapCredentialsInput$SecretToAuthenticateTarget</a> </li> <li> <a>UpdateChapCredentialsInput$TargetARN</a> </li> </ul>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -2291,6 +2369,7 @@
         },
         "UpdateChapCredentialsOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -2323,6 +2402,7 @@
         },
         "UpdateGatewayInformationOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway that was updated.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2332,6 +2412,7 @@
         },
         "UpdateGatewaySoftwareNowInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway to update.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2341,6 +2422,7 @@
         },
         "UpdateGatewaySoftwareNowOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway that was updated.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2350,6 +2432,7 @@
         },
         "UpdateMaintenanceStartTimeInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the following fields:</p> <ul> <li> <a>UpdateMaintenanceStartTimeInput$DayOfWeek</a> </li> <li> <a>UpdateMaintenanceStartTimeInput$HourOfDay</a> </li> <li> <a>UpdateMaintenanceStartTimeInput$MinuteOfHour</a> </li> </ul>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2374,6 +2457,7 @@
         },
         "UpdateMaintenanceStartTimeOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the gateway whose maintenance start time is updated.</p>",
             "members": [
                 {
                     "name": "GatewayARN",
@@ -2383,6 +2467,7 @@
         },
         "UpdateSnapshotScheduleInput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing one or more of the following fields:</p> <ul> <li> <a>UpdateSnapshotScheduleInput$Description</a> </li> <li> <a>UpdateSnapshotScheduleInput$RecurrenceInHours</a> </li> <li> <a>UpdateSnapshotScheduleInput$StartAt</a> </li> <li> <a>UpdateSnapshotScheduleInput$VolumeARN</a> </li> </ul>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -2408,6 +2493,7 @@
         },
         "UpdateSnapshotScheduleOutput": {
             "type": "structure",
+            "documentation": "<p>A JSON object containing the of the updated storage volume.</p>",
             "members": [
                 {
                     "name": "VolumeARN",
@@ -2417,6 +2503,7 @@
         },
         "UpdateVTLDeviceTypeInput": {
             "type": "structure",
+            "documentation": "<p>UpdateVTLDeviceTypeInput</p>",
             "members": [
                 {
                     "name": "VTLDeviceARN",
@@ -2432,6 +2519,7 @@
         },
         "UpdateVTLDeviceTypeOutput": {
             "type": "structure",
+            "documentation": "<p>UpdateVTLDeviceTypeOutput</p>",
             "members": [
                 {
                     "name": "VTLDeviceARN",
@@ -2442,6 +2530,7 @@
         },
         "VTLDevice": {
             "type": "structure",
+            "documentation": "<p> Represents a device object associated with a gateway-VTL. </p>",
             "members": [
                 {
                     "name": "VTLDeviceARN",
@@ -2547,6 +2636,7 @@
         },
         "VolumeiSCSIAttributes": {
             "type": "structure",
+            "documentation": "<p>Lists iSCSI information about a volume.</p>",
             "members": [
                 {
                     "name": "TargetARN",
@@ -2582,7 +2672,9 @@
             "type": "double"
         },
         "errorDetails": {
-            "type": "map"
+            "type": "map",
+            "key": "string",
+            "value": "string"
         },
         "integer": {
             "type": "integer"

--- a/libcloudcore/data/aws/sts/service.json
+++ b/libcloudcore/data/aws/sts/service.json
@@ -1,5 +1,8 @@
 {
     "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ],
         "namespaces": {
             "": "https://sts.amazonaws.com/doc/2011-06-15/"
         }
@@ -134,6 +137,7 @@
         },
         "AssumeRoleResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>AssumeRole</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>",
             "members": [
                 {
                     "name": "Credentials",
@@ -184,6 +188,7 @@
         },
         "AssumeRoleWithSAMLResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>AssumeRoleWithSAML</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>",
             "members": [
                 {
                     "name": "Credentials",
@@ -262,6 +267,7 @@
         },
         "AssumeRoleWithWebIdentityResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>AssumeRoleWithWebIdentity</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>",
             "members": [
                 {
                     "name": "Credentials",
@@ -297,6 +303,7 @@
         },
         "AssumedRoleUser": {
             "type": "structure",
+            "documentation": "<p>The identifiers for the temporary security credentials that the operation returns. </p>",
             "members": [
                 {
                     "name": "AssumedRoleId",
@@ -315,6 +322,7 @@
         },
         "Credentials": {
             "type": "structure",
+            "documentation": "<p>AWS credentials for API authentication.</p>",
             "members": [
                 {
                     "name": "AccessKeyId",
@@ -350,6 +358,7 @@
         },
         "DecodeAuthorizationMessageResponse": {
             "type": "structure",
+            "documentation": "<p>A document that contains additional information about the authorization status of a request from an encoded message that is returned in response to an AWS request. </p>",
             "members": [
                 {
                     "name": "DecodedMessage",
@@ -360,6 +369,7 @@
         },
         "ExpiredTokenException": {
             "type": "structure",
+            "documentation": "<p>The web identity token that was passed is expired or is not valid. Get a new identity token from the identity provider and then retry the request. </p>",
             "members": [
                 {
                     "name": "message",
@@ -369,6 +379,7 @@
         },
         "FederatedUser": {
             "type": "structure",
+            "documentation": "<p>Identifiers for the federated user that is associated with the credentials.</p>",
             "members": [
                 {
                     "name": "FederatedUserId",
@@ -404,6 +415,7 @@
         },
         "GetFederationTokenResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetFederationToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>",
             "members": [
                 {
                     "name": "Credentials",
@@ -444,6 +456,7 @@
         },
         "GetSessionTokenResponse": {
             "type": "structure",
+            "documentation": "<p>Contains the response to a successful <a>GetSessionToken</a> request, including temporary AWS credentials that can be used to make AWS requests. </p>",
             "members": [
                 {
                     "name": "Credentials",
@@ -454,6 +467,7 @@
         },
         "IDPCommunicationErrorException": {
             "type": "structure",
+            "documentation": "<p>The request could not be fulfilled because the non-AWS identity provider (IDP) that was asked to verify the incoming identity token could not be reached. This is often a transient error caused by network conditions. Retry the request a limited number of times so that you don't exceed the request rate. If the error persists, the non-AWS identity provider might be down or not responding. </p>",
             "members": [
                 {
                     "name": "message",
@@ -463,6 +477,7 @@
         },
         "IDPRejectedClaimException": {
             "type": "structure",
+            "documentation": "<p>The identity provider (IdP) reported that authentication failed. This might be because the claim is invalid.</p> <p>If this error is returned for the <code>AssumeRoleWithWebIdentity</code> operation, it can also mean that the claim has expired or has been explicitly revoked. </p>",
             "members": [
                 {
                     "name": "message",
@@ -472,6 +487,7 @@
         },
         "InvalidAuthorizationMessageException": {
             "type": "structure",
+            "documentation": "<p>The error returned if the message passed to <code>DecodeAuthorizationMessage</code> was invalid. This can happen if the token contains invalid characters, such as linebreaks. </p>",
             "members": [
                 {
                     "name": "message",
@@ -481,6 +497,7 @@
         },
         "InvalidIdentityTokenException": {
             "type": "structure",
+            "documentation": "<p>The web identity token that was passed could not be validated by AWS. Get a new identity token from the identity provider and then retry the request. </p>",
             "members": [
                 {
                     "name": "message",
@@ -493,6 +510,7 @@
         },
         "MalformedPolicyDocumentException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the policy document was malformed. The error message describes the specific error.</p>",
             "members": [
                 {
                     "name": "message",
@@ -505,6 +523,7 @@
         },
         "PackedPolicyTooLargeException": {
             "type": "structure",
+            "documentation": "<p>The request was rejected because the policy document was too large. The error message describes how big the policy document is, in packed form, as a percentage of what the API allows.</p>",
             "members": [
                 {
                     "name": "message",

--- a/libcloudcore/data/aws/support/service.json
+++ b/libcloudcore/data/aws/support/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -172,6 +176,7 @@
         },
         "AddAttachmentsToSetResponse": {
             "type": "structure",
+            "documentation": "<p>The ID and expiry time of the attachment set returned by the <a>AddAttachmentsToSet</a> operation.</p>",
             "members": [
                 {
                     "name": "attachmentSetId",
@@ -187,6 +192,7 @@
         },
         "AddCommunicationToCaseRequest": {
             "type": "structure",
+            "documentation": "<p>To be written.</p>",
             "members": [
                 {
                     "name": "caseId",
@@ -212,6 +218,7 @@
         },
         "AddCommunicationToCaseResponse": {
             "type": "structure",
+            "documentation": "<p>The result of the <a>AddCommunicationToCase</a> operation.</p>",
             "members": [
                 {
                     "name": "result",
@@ -225,6 +232,7 @@
         },
         "Attachment": {
             "type": "structure",
+            "documentation": "<p>An attachment to a case communication. The attachment consists of the file name and the content of the file.</p>",
             "members": [
                 {
                     "name": "fileName",
@@ -240,6 +248,7 @@
         },
         "AttachmentDetails": {
             "type": "structure",
+            "documentation": "<p>The file name and ID of an attachment to a case communication. You can use the ID to retrieve the attachment with the <a>DescribeAttachment</a> operation.</p>",
             "members": [
                 {
                     "name": "attachmentId",
@@ -258,6 +267,7 @@
         },
         "AttachmentIdNotFound": {
             "type": "structure",
+            "documentation": "<p>An attachment with the specified ID could not be found.</p>",
             "members": [
                 {
                     "name": "message",
@@ -268,6 +278,7 @@
         },
         "AttachmentLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>The limit for the number of attachment sets created in a short period of time has been exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -282,6 +293,7 @@
         },
         "AttachmentSetExpired": {
             "type": "structure",
+            "documentation": "<p>The expiration time of the attachment set has passed. The set expires 1 hour after it is created.</p>",
             "members": [
                 {
                     "name": "message",
@@ -295,6 +307,7 @@
         },
         "AttachmentSetIdNotFound": {
             "type": "structure",
+            "documentation": "<p>An attachment set with the specified ID could not be found.</p>",
             "members": [
                 {
                     "name": "message",
@@ -305,6 +318,7 @@
         },
         "AttachmentSetSizeLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>A limit for the size of an attachment set has been exceeded. The limits are 3 attachments and 5 MB per attachment.</p>",
             "members": [
                 {
                     "name": "message",
@@ -325,6 +339,7 @@
         },
         "CaseCreationLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>The case creation limit for the account has been exceeded. </p>",
             "members": [
                 {
                     "name": "message",
@@ -335,6 +350,7 @@
         },
         "CaseDetails": {
             "type": "structure",
+            "documentation": "<p>A JSON-formatted object that contains the metadata for a support case. It is contained the response from a <a>DescribeCases</a> request. <b>CaseDetails</b> contains the following fields:</p> <ol> <li> <b>CaseID.</b> The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>.</li> <li> <b>CategoryCode.</b> The category of problem for the AWS Support case. Corresponds to the CategoryCode values returned by a call to <a>DescribeServices</a>.</li> <li> <b>DisplayId.</b> The identifier for the case on pages in the AWS Support Center.</li> <li> <b>Language.</b> The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (\"en\") and Japanese (\"ja\"). Language parameters must be passed explicitly for operations that take them.</li> <li> <b>RecentCommunications.</b> One or more <a>Communication</a> objects. Fields of these objects are <code>Attachments</code>, <code>Body</code>, <code>CaseId</code>, <code>SubmittedBy</code>, and <code>TimeCreated</code>.</li> <li> <b>NextToken.</b> A resumption point for pagination.</li> <li> <b>ServiceCode.</b> The identifier for the AWS service that corresponds to the service code defined in the call to <a>DescribeServices</a>.</li> <li> <b>SeverityCode. </b>The severity code assigned to the case. Contains one of the values returned by the call to <a>DescribeSeverityLevels</a>.</li> <li> <b>Status.</b> The status of the case in the AWS Support Center.</li> <li> <b>Subject.</b> The subject line of the case.</li> <li> <b>SubmittedBy.</b> The email address of the account that submitted the case.</li> <li> <b>TimeCreated.</b> The time the case was created, in ISO-8601 format.</li> </ol>",
             "members": [
                 {
                     "name": "caseId",
@@ -407,6 +423,7 @@
         },
         "CaseIdNotFound": {
             "type": "structure",
+            "documentation": "<p>The requested <code>CaseId</code> could not be located.</p>",
             "members": [
                 {
                     "name": "message",
@@ -424,6 +441,7 @@
         },
         "Category": {
             "type": "structure",
+            "documentation": "<p>A JSON-formatted name/value pair that represents the category name and category code of the problem, selected from the <a>DescribeServices</a> response for each AWS service.</p>",
             "members": [
                 {
                     "name": "code",
@@ -456,6 +474,7 @@
         },
         "Communication": {
             "type": "structure",
+            "documentation": "<p>A communication associated with an AWS Support case. The communication consists of the case ID, the message body, attachment information, the account email address, and the date and time of the communication.</p>",
             "members": [
                 {
                     "name": "caseId",
@@ -543,6 +562,7 @@
         },
         "CreateCaseResponse": {
             "type": "structure",
+            "documentation": "<p>The AWS Support case ID returned by a successful completion of the <a>CreateCase</a> operation. </p>",
             "members": [
                 {
                     "name": "caseId",
@@ -556,6 +576,7 @@
         },
         "DescribeAttachmentLimitExceeded": {
             "type": "structure",
+            "documentation": "<p>The limit for the number of <a>DescribeAttachment</a> requests in a short period of time has been exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -576,6 +597,7 @@
         },
         "DescribeAttachmentResponse": {
             "type": "structure",
+            "documentation": "<p>The content and file name of the attachment returned by the <a>DescribeAttachment</a> operation.</p>",
             "members": [
                 {
                     "name": "attachment",
@@ -636,6 +658,7 @@
         },
         "DescribeCasesResponse": {
             "type": "structure",
+            "documentation": "<p>Returns an array of <a>CaseDetails</a> objects and a <code>NextToken</code> that defines a point for pagination in the result set.</p>",
             "members": [
                 {
                     "name": "cases",
@@ -681,6 +704,7 @@
         },
         "DescribeCommunicationsResponse": {
             "type": "structure",
+            "documentation": "<p>The communications returned by the <a>DescribeCommunications</a> operation.</p>",
             "members": [
                 {
                     "name": "communications",
@@ -711,6 +735,7 @@
         },
         "DescribeServicesResponse": {
             "type": "structure",
+            "documentation": "<p>The list of AWS services returned by the <a>DescribeServices</a> operation.</p>",
             "members": [
                 {
                     "name": "services",
@@ -731,6 +756,7 @@
         },
         "DescribeSeverityLevelsResponse": {
             "type": "structure",
+            "documentation": "<p>The list of severity levels returned by the <a>DescribeSeverityLevels</a> operation.</p>",
             "members": [
                 {
                     "name": "severityLevels",
@@ -751,6 +777,7 @@
         },
         "DescribeTrustedAdvisorCheckRefreshStatusesResponse": {
             "type": "structure",
+            "documentation": "<p>The statuses of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckRefreshStatuses</a> operation.</p>",
             "members": [
                 {
                     "name": "statuses",
@@ -776,6 +803,7 @@
         },
         "DescribeTrustedAdvisorCheckResultResponse": {
             "type": "structure",
+            "documentation": "<p>The result of the Trusted Advisor check returned by the <a>DescribeTrustedAdvisorCheckResult</a> operation.</p>",
             "members": [
                 {
                     "name": "result",
@@ -796,6 +824,7 @@
         },
         "DescribeTrustedAdvisorCheckSummariesResponse": {
             "type": "structure",
+            "documentation": "<p>The summaries of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckSummaries</a> operation.</p>",
             "members": [
                 {
                     "name": "summaries",
@@ -816,6 +845,7 @@
         },
         "DescribeTrustedAdvisorChecksResponse": {
             "type": "structure",
+            "documentation": "<p>Information about the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorChecks</a> operation.</p>",
             "members": [
                 {
                     "name": "checks",
@@ -847,6 +877,7 @@
         },
         "InternalServerError": {
             "type": "structure",
+            "documentation": "<p>An internal server error occurred.</p>",
             "members": [
                 {
                     "name": "message",
@@ -872,6 +903,7 @@
         },
         "RecentCaseCommunications": {
             "type": "structure",
+            "documentation": "<p>The five most recent communications associated with the case.</p>",
             "members": [
                 {
                     "name": "communications",
@@ -897,6 +929,7 @@
         },
         "RefreshTrustedAdvisorCheckResponse": {
             "type": "structure",
+            "documentation": "<p>The current refresh status of a Trusted Advisor check.</p>",
             "members": [
                 {
                     "name": "status",
@@ -917,6 +950,7 @@
         },
         "ResolveCaseResponse": {
             "type": "structure",
+            "documentation": "<p>The status of the case returned by the <a>ResolveCase</a> operation.</p>",
             "members": [
                 {
                     "name": "initialCaseStatus",
@@ -935,6 +969,7 @@
         },
         "Service": {
             "type": "structure",
+            "documentation": "<p>Information about an AWS service returned by the <a>DescribeServices</a> operation. </p>",
             "members": [
                 {
                     "name": "code",
@@ -972,6 +1007,7 @@
         },
         "SeverityLevel": {
             "type": "structure",
+            "documentation": "<p>A code and name pair that represent a severity level that can be applied to a support case. </p>",
             "members": [
                 {
                     "name": "code",
@@ -1016,6 +1052,7 @@
         },
         "TrustedAdvisorCategorySpecificSummary": {
             "type": "structure",
+            "documentation": "<p>The container for summary information that relates to the category of the Trusted Advisor check.</p>",
             "members": [
                 {
                     "name": "costOptimizing",
@@ -1026,6 +1063,7 @@
         },
         "TrustedAdvisorCheckDescription": {
             "type": "structure",
+            "documentation": "<p>The description and metadata for a Trusted Advisor check.</p>",
             "members": [
                 {
                     "name": "id",
@@ -1060,6 +1098,7 @@
         },
         "TrustedAdvisorCheckRefreshStatus": {
             "type": "structure",
+            "documentation": "<p>The refresh status of a Trusted Advisor check. </p>",
             "members": [
                 {
                     "name": "checkId",
@@ -1084,6 +1123,7 @@
         },
         "TrustedAdvisorCheckResult": {
             "type": "structure",
+            "documentation": "<p>The results of a Trusted Advisor check returned by <a>DescribeTrustedAdvisorCheckResult</a>.</p>",
             "members": [
                 {
                     "name": "checkId",
@@ -1118,6 +1158,7 @@
         },
         "TrustedAdvisorCheckSummary": {
             "type": "structure",
+            "documentation": "<p>A summary of a Trusted Advisor check result, including the alert status, last refresh, and number of resources examined.</p>",
             "members": [
                 {
                     "name": "checkId",
@@ -1156,6 +1197,7 @@
         },
         "TrustedAdvisorCostOptimizingSummary": {
             "type": "structure",
+            "documentation": "<p>The estimated cost savings that might be realized if the recommended actions are taken.</p>",
             "members": [
                 {
                     "name": "estimatedMonthlySavings",
@@ -1171,6 +1213,7 @@
         },
         "TrustedAdvisorResourceDetail": {
             "type": "structure",
+            "documentation": "<p>Contains information about a resource identified by a Trusted Advisor check. </p>",
             "members": [
                 {
                     "name": "status",
@@ -1205,6 +1248,7 @@
         },
         "TrustedAdvisorResourcesSummary": {
             "type": "structure",
+            "documentation": "<p>Details about AWS resources that were analyzed in a call to Trusted Advisor <a>DescribeTrustedAdvisorCheckSummaries</a>. </p>",
             "members": [
                 {
                     "name": "resourcesProcessed",

--- a/libcloudcore/data/aws/swf/service.json
+++ b/libcloudcore/data/aws/swf/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -274,6 +278,7 @@
         },
         "ActivityTask": {
             "type": "structure",
+            "documentation": "<p>Unit of work sent to an activity worker.</p>",
             "members": [
                 {
                     "name": "taskToken",
@@ -309,6 +314,7 @@
         },
         "ActivityTaskCancelRequestedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskCancelRequested</code> event.</p>",
             "members": [
                 {
                     "name": "decisionTaskCompletedEventId",
@@ -324,6 +330,7 @@
         },
         "ActivityTaskCanceledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskCanceled</code> event.</p>",
             "members": [
                 {
                     "name": "details",
@@ -349,6 +356,7 @@
         },
         "ActivityTaskCompletedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskCompleted</code> event.</p>",
             "members": [
                 {
                     "name": "result",
@@ -369,6 +377,7 @@
         },
         "ActivityTaskFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskFailed</code> event.</p>",
             "members": [
                 {
                     "name": "reason",
@@ -394,6 +403,7 @@
         },
         "ActivityTaskScheduledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskScheduled</code> event.</p>",
             "members": [
                 {
                     "name": "activityType",
@@ -454,6 +464,7 @@
         },
         "ActivityTaskStartedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskStarted</code> event.</p>",
             "members": [
                 {
                     "name": "identity",
@@ -469,6 +480,7 @@
         },
         "ActivityTaskStatus": {
             "type": "structure",
+            "documentation": "<p>Status information about an activity task.</p>",
             "members": [
                 {
                     "name": "cancelRequested",
@@ -479,6 +491,7 @@
         },
         "ActivityTaskTimedOutEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ActivityTaskTimedOut</code> event.</p>",
             "members": [
                 {
                     "name": "timeoutType",
@@ -507,6 +520,7 @@
         },
         "ActivityType": {
             "type": "structure",
+            "documentation": "<p>Represents an activity type.</p>",
             "members": [
                 {
                     "name": "name",
@@ -522,6 +536,7 @@
         },
         "ActivityTypeConfiguration": {
             "type": "structure",
+            "documentation": "<p>Configuration settings registered with the activity type.</p>",
             "members": [
                 {
                     "name": "defaultTaskStartToCloseTimeout",
@@ -557,6 +572,7 @@
         },
         "ActivityTypeDetail": {
             "type": "structure",
+            "documentation": "<p>Detailed information about an activity type.</p>",
             "members": [
                 {
                     "name": "typeInfo",
@@ -572,6 +588,7 @@
         },
         "ActivityTypeInfo": {
             "type": "structure",
+            "documentation": "<p>Detailed information about an activity type.</p>",
             "members": [
                 {
                     "name": "activityType",
@@ -606,6 +623,7 @@
         },
         "ActivityTypeInfos": {
             "type": "structure",
+            "documentation": "<p>Contains a paginated list of activity type information structures.</p>",
             "members": [
                 {
                     "name": "typeInfos",
@@ -621,6 +639,7 @@
         },
         "CancelTimerDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CancelTimer</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -634,6 +653,7 @@
         },
         "CancelTimerFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CancelTimerFailed</code> event.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -654,6 +674,7 @@
         },
         "CancelWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CancelWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "details",
@@ -667,6 +688,7 @@
         },
         "CancelWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CancelWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "cause",
@@ -688,6 +710,7 @@
         },
         "ChildWorkflowExecutionCanceledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -718,6 +741,7 @@
         },
         "ChildWorkflowExecutionCompletedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ChildWorkflowExecutionCompleted</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -748,6 +772,7 @@
         },
         "ChildWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ChildWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -783,6 +808,7 @@
         },
         "ChildWorkflowExecutionStartedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ChildWorkflowExecutionStarted</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -803,6 +829,7 @@
         },
         "ChildWorkflowExecutionTerminatedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ChildWorkflowExecutionTerminated</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -828,6 +855,7 @@
         },
         "ChildWorkflowExecutionTimedOutEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ChildWorkflowExecutionTimedOut</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -861,6 +889,7 @@
         },
         "CloseStatusFilter": {
             "type": "structure",
+            "documentation": "<p>Used to filter the closed workflow executions in visibility APIs by their close status.</p>",
             "members": [
                 {
                     "name": "status",
@@ -871,6 +900,7 @@
         },
         "CompleteWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CompleteWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "result",
@@ -884,6 +914,7 @@
         },
         "CompleteWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "cause",
@@ -899,6 +930,7 @@
         },
         "ContinueAsNewWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ContinueAsNewWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys. <ul> <li> <code>tag</code>: <i>Optional.</i>. A tag used to identify the workflow execution</li> <li><code>taskList</code>: String constraint. The key is <code>swf:taskList.name</code>.</li> <li><code>workflowType.version</code>: String constraint. The key is <code>swf:workflowType.version</code>.</li> </ul> </li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "input",
@@ -945,6 +977,7 @@
         },
         "ContinueAsNewWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "cause",
@@ -1066,6 +1099,7 @@
         },
         "Decision": {
             "type": "structure",
+            "documentation": "<p>Specifies a decision made by the decider. A decision can be one of these types:</p> <ul> <li> <b>CancelTimer</b>: cancels a previously started timer and records a <code>TimerCanceled</code> event in the history.</li> <li> <b>CancelWorkflowExecution</b>: closes the workflow execution and records a <code>WorkflowExecutionCanceled</code> event in the history.</li> <li> <b>CompleteWorkflowExecution</b>: closes the workflow execution and records a <code>WorkflowExecutionCompleted</code> event in the history .</li> <li> <b>ContinueAsNewWorkflowExecution</b>: closes the workflow execution and starts a new workflow execution of the same type using the same workflow id and a unique run Id. A <code>WorkflowExecutionContinuedAsNew</code> event is recorded in the history.</li> <li> <b>FailWorkflowExecution</b>: closes the workflow execution and records a <code>WorkflowExecutionFailed</code> event in the history.</li> <li> <b>RecordMarker</b>: records a <code>MarkerRecorded</code> event in the history. Markers can be used for adding custom information in the history for instance to let deciders know that they do not need to look at the history beyond the marker event.</li> <li> <b>RequestCancelActivityTask</b>: attempts to cancel a previously scheduled activity task. If the activity task was scheduled but has not been assigned to a worker, then it will be canceled. If the activity task was already assigned to a worker, then the worker will be informed that cancellation has been requested in the response to <a>RecordActivityTaskHeartbeat</a>.</li> <li> <b>RequestCancelExternalWorkflowExecution</b>: requests that a request be made to cancel the specified external workflow execution and records a <code>RequestCancelExternalWorkflowExecutionInitiated</code> event in the history.</li> <li> <b>ScheduleActivityTask</b>: schedules an activity task.</li> <li> <b>SignalExternalWorkflowExecution</b>: requests a signal to be delivered to the specified external workflow execution and records a <code>SignalExternalWorkflowExecutionInitiated</code> event in the history.</li> <li> <b>StartChildWorkflowExecution</b>: requests that a child workflow execution be started and records a <code>StartChildWorkflowExecutionInitiated</code> event in the history. The child workflow execution is a separate workflow execution with its own history.</li> <li> <b>StartTimer</b>: starts a timer for this workflow execution and records a <code>TimerStarted</code> event in the history. This timer will fire after the specified delay and record a <code>TimerFired</code> event.</li> </ul> <p><b>Access Control</b></p> <p>If you grant permission to use <code>RespondDecisionTaskCompleted</code>, you can use IAM policies to express permissions for the list of decisions returned by this action as if they were members of the API. Treating decisions as a pseudo API maintains a uniform conceptual model and helps keep policies readable. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p> <p><b>Decision Failure</b></p> <p>Decisions can fail for several reasons</p> <ul> <li>The ordering of decisions should follow a logical flow. Some decisions might not make sense in the current context of the workflow execution and will therefore fail.</li> <li>A limit on your account was reached.</li> <li>The decision lacks sufficient permissions.</li> </ul> <p>One of the following events might be added to the history to indicate an error. The event attribute's <b>cause</b> parameter indicates the cause. If <b>cause</b> is set to OPERATION_NOT_PERMITTED, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p> <ul> <li> <b>ScheduleActivityTaskFailed</b>: a ScheduleActivityTask decision failed. This could happen if the activity type specified in the decision is not registered, is in a deprecated state, or the decision is not properly configured.</li> <li> <b>RequestCancelActivityTaskFailed</b>: a RequestCancelActivityTask decision failed. This could happen if there is no open activity task with the specified activityId.</li> <li> <b>StartTimerFailed</b>: a StartTimer decision failed. This could happen if there is another open timer with the same timerId.</li> <li> <b>CancelTimerFailed</b>: a CancelTimer decision failed. This could happen if there is no open timer with the specified timerId.</li> <li> <b>StartChildWorkflowExecutionFailed</b>: a StartChildWorkflowExecution decision failed. This could happen if the workflow type specified is not registered, is deprecated, or the decision is not properly configured.</li> <li> <b>SignalExternalWorkflowExecutionFailed</b>: a SignalExternalWorkflowExecution decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</li> <li> <b>RequestCancelExternalWorkflowExecutionFailed</b>: a RequestCancelExternalWorkflowExecution decision failed. This could happen if the <code>workflowID</code> specified in the decision was incorrect.</li> <li> <b>CancelWorkflowExecutionFailed</b>: a CancelWorkflowExecution decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</li> <li> <b>CompleteWorkflowExecutionFailed</b>: a CompleteWorkflowExecution decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</li> <li> <b>ContinueAsNewWorkflowExecutionFailed</b>: a ContinueAsNewWorkflowExecution decision failed. This could happen if there is an unhandled decision task pending in the workflow execution or the ContinueAsNewWorkflowExecution decision was not configured correctly.</li> <li> <b>FailWorkflowExecutionFailed</b>: a FailWorkflowExecution decision failed. This could happen if there is an unhandled decision task pending in the workflow execution.</li> </ul> <p>The preceding error events might occur due to an error in the decider logic, which might put the workflow execution in an unstable state The cause field in the event structure for the error event indicates the cause of the error.</p> <note>A workflow execution may be closed by the decider by returning one of the following decisions when completing a decision task: <code>CompleteWorkflowExecution</code>, <code>FailWorkflowExecution</code>, <code>CancelWorkflowExecution</code> and <code>ContinueAsNewWorkflowExecution</code>. An UnhandledDecision fault will be returned if a workflow closing decision is specified and a signal or activity event had been added to the history while the decision task was being performed by the decider. Unlike the above situations which are logic issues, this fault is always possible because of race conditions in a distributed system. The right action here is to call <a>RespondDecisionTaskCompleted</a> without any decisions. This would result in another decision task with these new events included in the history. The decider should handle the new events and may decide to close the workflow execution.</note> <p><b>How to Code a Decision</b></p> <p>You code a decision by first setting the decision type field to one of the above decision values, and then set the corresponding attributes field shown below:</p> <ul> <li> <a>ScheduleActivityTaskDecisionAttributes</a> </li> <li> <a>RequestCancelActivityTaskDecisionAttributes</a> </li> <li> <a>CompleteWorkflowExecutionDecisionAttributes</a> </li> <li> <a>FailWorkflowExecutionDecisionAttributes</a> </li> <li> <a>CancelWorkflowExecutionDecisionAttributes</a> </li> <li> <a>ContinueAsNewWorkflowExecutionDecisionAttributes</a> </li> <li> <a>RecordMarkerDecisionAttributes</a> </li> <li> <a>StartTimerDecisionAttributes</a> </li> <li> <a>CancelTimerDecisionAttributes</a> </li> <li> <a>SignalExternalWorkflowExecutionDecisionAttributes</a> </li> <li> <a>RequestCancelExternalWorkflowExecutionDecisionAttributes</a> </li> <li> <a>StartChildWorkflowExecutionDecisionAttributes</a> </li> </ul>",
             "members": [
                 {
                     "name": "decisionType",
@@ -1140,6 +1174,7 @@
         },
         "DecisionTask": {
             "type": "structure",
+            "documentation": "<p>A structure that represents a decision task. Decision tasks are sent to deciders in order for them to make decisions.</p>",
             "members": [
                 {
                     "name": "taskToken",
@@ -1180,6 +1215,7 @@
         },
         "DecisionTaskCompletedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>DecisionTaskCompleted</code> event.</p>",
             "members": [
                 {
                     "name": "executionContext",
@@ -1200,6 +1236,7 @@
         },
         "DecisionTaskScheduledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details about the <code>DecisionTaskScheduled</code> event.</p>",
             "members": [
                 {
                     "name": "taskList",
@@ -1220,6 +1257,7 @@
         },
         "DecisionTaskStartedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>DecisionTaskStarted</code> event.</p>",
             "members": [
                 {
                     "name": "identity",
@@ -1235,6 +1273,7 @@
         },
         "DecisionTaskTimedOutEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>DecisionTaskTimedOut</code> event.</p>",
             "members": [
                 {
                     "name": "timeoutType",
@@ -1368,6 +1407,7 @@
         },
         "DomainAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>Returned if the specified domain already exists. You will get this fault even if the existing domain is in deprecated status.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1378,6 +1418,7 @@
         },
         "DomainConfiguration": {
             "type": "structure",
+            "documentation": "<p>Contains the configuration settings of a domain.</p>",
             "members": [
                 {
                     "name": "workflowExecutionRetentionPeriodInDays",
@@ -1388,6 +1429,7 @@
         },
         "DomainDeprecatedFault": {
             "type": "structure",
+            "documentation": "<p>Returned when the specified domain has been deprecated.</p>",
             "members": [
                 {
                     "name": "message",
@@ -1398,6 +1440,7 @@
         },
         "DomainDetail": {
             "type": "structure",
+            "documentation": "<p>Contains details of a domain.</p>",
             "members": [
                 {
                     "name": "domainInfo",
@@ -1411,6 +1454,7 @@
         },
         "DomainInfo": {
             "type": "structure",
+            "documentation": "<p>Contains general information about a domain.</p>",
             "members": [
                 {
                     "name": "name",
@@ -1435,6 +1479,7 @@
         },
         "DomainInfos": {
             "type": "structure",
+            "documentation": "<p>Contains a paginated collection of DomainInfo structures.</p>",
             "members": [
                 {
                     "name": "domainInfos",
@@ -1474,6 +1519,7 @@
         },
         "ExecutionTimeFilter": {
             "type": "structure",
+            "documentation": "<p>Used to filter the workflow executions in visibility APIs by various time-based rules. Each parameter, if specified, defines a rule that must be satisfied by each returned query result. The parameter values are in the <a href=\"https://en.wikipedia.org/wiki/Unix_time\">Unix Time format</a>. For example: <code>\"oldestDate\": 1325376070.</code></p>",
             "members": [
                 {
                     "name": "oldestDate",
@@ -1489,6 +1535,7 @@
         },
         "ExternalWorkflowExecutionCancelRequestedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ExternalWorkflowExecutionCancelRequested</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -1504,6 +1551,7 @@
         },
         "ExternalWorkflowExecutionSignaledEventAttributes": {
             "type": "structure",
+            "documentation": "<p> Provides details of the <code>ExternalWorkflowExecutionSignaled</code> event.</p>",
             "members": [
                 {
                     "name": "workflowExecution",
@@ -1519,6 +1567,7 @@
         },
         "FailWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>FailWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "reason",
@@ -1537,6 +1586,7 @@
         },
         "FailWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>FailWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "cause",
@@ -1585,6 +1635,7 @@
         },
         "History": {
             "type": "structure",
+            "documentation": "<p>Paginated representation of a workflow history for a workflow execution. This is the up to date, complete and authoritative record of the events related to all tasks and events in the life of the workflow execution.</p>",
             "members": [
                 {
                     "name": "events",
@@ -1600,6 +1651,7 @@
         },
         "HistoryEvent": {
             "type": "structure",
+            "documentation": "<p>Event within a workflow execution. A history event can be one of these types:</p> <ul> <li> <b>WorkflowExecutionStarted</b>: The workflow execution was started.</li> <li> <b>WorkflowExecutionCompleted</b>: The workflow execution was closed due to successful completion.</li> <li> <b>WorkflowExecutionFailed</b>: The workflow execution closed due to a failure.</li> <li> <b>WorkflowExecutionTimedOut</b>: The workflow execution was closed because a time out was exceeded.</li> <li> <b>WorkflowExecutionCanceled</b>: The workflow execution was successfully canceled and closed.</li> <li> <b>WorkflowExecutionTerminated</b>: The workflow execution was terminated.</li> <li> <b>WorkflowExecutionContinuedAsNew</b>: The workflow execution was closed and a new execution of the same type was created with the same workflowId.</li> <li> <b>WorkflowExecutionCancelRequested</b>: A request to cancel this workflow execution was made.</li> <li> <b>DecisionTaskScheduled</b>: A decision task was scheduled for the workflow execution.</li> <li> <b>DecisionTaskStarted</b>: The decision task was dispatched to a decider.</li> <li> <b>DecisionTaskCompleted</b>: The decider successfully completed a decision task by calling <a>RespondDecisionTaskCompleted</a>.</li> <li> <b>DecisionTaskTimedOut</b>: The decision task timed out.</li> <li> <b>ActivityTaskScheduled</b>: An activity task was scheduled for execution.</li> <li> <b>ScheduleActivityTaskFailed</b>: Failed to process ScheduleActivityTask decision. This happens when the decision is not configured properly, for example the activity type specified is not registered.</li> <li> <b>ActivityTaskStarted</b>: The scheduled activity task was dispatched to a worker.</li> <li> <b>ActivityTaskCompleted</b>: An activity worker successfully completed an activity task by calling <a>RespondActivityTaskCompleted</a>.</li> <li> <b>ActivityTaskFailed</b>: An activity worker failed an activity task by calling <a>RespondActivityTaskFailed</a>.</li> <li> <b>ActivityTaskTimedOut</b>: The activity task timed out.</li> <li> <b>ActivityTaskCanceled</b>: The activity task was successfully canceled.</li> <li> <b>ActivityTaskCancelRequested</b>: A <code>RequestCancelActivityTask</code> decision was received by the system.</li> <li> <b>RequestCancelActivityTaskFailed</b>: Failed to process RequestCancelActivityTask decision. This happens when the decision is not configured properly.</li> <li> <b>WorkflowExecutionSignaled</b>: An external signal was received for the workflow execution.</li> <li> <b>MarkerRecorded</b>: A marker was recorded in the workflow history as the result of a <code>RecordMarker</code> decision.</li> <li> <b>TimerStarted</b>: A timer was started for the workflow execution due to a <code>StartTimer</code> decision.</li> <li> <b>StartTimerFailed</b>: Failed to process StartTimer decision. This happens when the decision is not configured properly, for example a timer already exists with the specified timer Id.</li> <li> <b>TimerFired</b>: A timer, previously started for this workflow execution, fired.</li> <li> <b>TimerCanceled</b>: A timer, previously started for this workflow execution, was successfully canceled.</li> <li> <b>CancelTimerFailed</b>: Failed to process CancelTimer decision. This happens when the decision is not configured properly, for example no timer exists with the specified timer Id.</li> <li> <b>StartChildWorkflowExecutionInitiated</b>: A request was made to start a child workflow execution.</li> <li> <b>StartChildWorkflowExecutionFailed</b>: Failed to process StartChildWorkflowExecution decision. This happens when the decision is not configured properly, for example the workflow type specified is not registered.</li> <li> <b>ChildWorkflowExecutionStarted</b>: A child workflow execution was successfully started.</li> <li> <b>ChildWorkflowExecutionCompleted</b>: A child workflow execution, started by this workflow execution, completed successfully and was closed.</li> <li> <b>ChildWorkflowExecutionFailed</b>: A child workflow execution, started by this workflow execution, failed to complete successfully and was closed.</li> <li> <b>ChildWorkflowExecutionTimedOut</b>: A child workflow execution, started by this workflow execution, timed out and was closed.</li> <li> <b>ChildWorkflowExecutionCanceled</b>: A child workflow execution, started by this workflow execution, was canceled and closed.</li> <li> <b>ChildWorkflowExecutionTerminated</b>: A child workflow execution, started by this workflow execution, was terminated.</li> <li> <b>SignalExternalWorkflowExecutionInitiated</b>: A request to signal an external workflow was made.</li> <li> <b>ExternalWorkflowExecutionSignaled</b>: A signal, requested by this workflow execution, was successfully delivered to the target external workflow execution.</li> <li> <b>SignalExternalWorkflowExecutionFailed</b>: The request to signal an external workflow execution failed.</li> <li> <b>RequestCancelExternalWorkflowExecutionInitiated</b>: A request was made to request the cancellation of an external workflow execution.</li> <li> <b>ExternalWorkflowExecutionCancelRequested</b>: Request to cancel an external workflow execution was successfully delivered to the target execution.</li> <li> <b>RequestCancelExternalWorkflowExecutionFailed</b>: Request to cancel an external workflow execution failed.</li> </ul>",
             "members": [
                 {
                     "name": "eventTimestamp",
@@ -1862,6 +1914,7 @@
         },
         "LimitExceededFault": {
             "type": "structure",
+            "documentation": "<p>Returned by any operation if a system imposed limitation has been reached. To address this fault you should either clean up unused resources or increase the limit by contacting AWS.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2073,6 +2126,7 @@
         },
         "MarkerRecordedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>MarkerRecorded</code> event.</p>",
             "members": [
                 {
                     "name": "markerName",
@@ -2099,6 +2153,7 @@
         },
         "OperationNotPermittedFault": {
             "type": "structure",
+            "documentation": "<p>Returned when the caller does not have sufficient permissions to invoke the action.</p>",
             "members": [
                 {
                     "name": "message",
@@ -2115,6 +2170,7 @@
         },
         "PendingTaskCount": {
             "type": "structure",
+            "documentation": "<p>Contains the count of tasks in a task list.</p>",
             "members": [
                 {
                     "name": "count",
@@ -2200,6 +2256,7 @@
         },
         "RecordMarkerDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RecordMarker</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "markerName",
@@ -2218,6 +2275,7 @@
         },
         "RecordMarkerFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RecordMarkerFailed</code> event.</p>",
             "members": [
                 {
                     "name": "markerName",
@@ -2366,6 +2424,7 @@
         },
         "RequestCancelActivityTaskDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RequestCancelActivityTask</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "activityId",
@@ -2379,6 +2438,7 @@
         },
         "RequestCancelActivityTaskFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RequestCancelActivityTaskFailed</code> event.</p>",
             "members": [
                 {
                     "name": "activityId",
@@ -2399,6 +2459,7 @@
         },
         "RequestCancelExternalWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RequestCancelExternalWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2422,6 +2483,7 @@
         },
         "RequestCancelExternalWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2456,6 +2518,7 @@
         },
         "RequestCancelExternalWorkflowExecutionInitiatedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2574,6 +2637,7 @@
         },
         "Run": {
             "type": "structure",
+            "documentation": "<p>Specifies the <code>runId</code> of a workflow execution.</p>",
             "members": [
                 {
                     "name": "runId",
@@ -2590,6 +2654,7 @@
         },
         "ScheduleActivityTaskDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ScheduleActivityTask</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys. <ul> <li><code>activityType.name</code>: String constraint. The key is <code>swf:activityType.name</code>.</li> <li><code>activityType.version</code>: String constraint. The key is <code>swf:activityType.version</code>.</li> <li><code>taskList</code>: String constraint. The key is <code>swf:taskList.name</code>.</li> </ul> </li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "activityType",
@@ -2648,6 +2713,7 @@
         },
         "ScheduleActivityTaskFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>ScheduleActivityTaskFailed</code> event.</p>",
             "members": [
                 {
                     "name": "activityType",
@@ -2673,6 +2739,7 @@
         },
         "SignalExternalWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>SignalExternalWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2706,6 +2773,7 @@
         },
         "SignalExternalWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2740,6 +2808,7 @@
         },
         "SignalExternalWorkflowExecutionInitiatedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>SignalExternalWorkflowExecutionInitiated</code> event.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2808,6 +2877,7 @@
         },
         "StartChildWorkflowExecutionDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>StartChildWorkflowExecution</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>Constrain the following parameters by using a <code>Condition</code> element with the appropriate keys. <ul> <li> <code>tagList.member.N</code>: The key is \"swf:tagList.N\" where N is the tag number from 0 to 4, inclusive.</li> <li><code>taskList</code>: String constraint. The key is <code>swf:taskList.name</code>.</li> <li><code>workflowType.name</code>: String constraint. The key is <code>swf:workflowType.name</code>.</li> <li><code>workflowType.version</code>: String constraint. The key is <code>swf:workflowType.version</code>.</li> </ul> </li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "workflowType",
@@ -2866,6 +2936,7 @@
         },
         "StartChildWorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "workflowType",
@@ -2900,6 +2971,7 @@
         },
         "StartChildWorkflowExecutionInitiatedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>StartChildWorkflowExecutionInitiated</code> event.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -2960,6 +3032,7 @@
         },
         "StartTimerDecisionAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>StartTimer</code> decision.</p> <p><b>Access Control</b></p> <p>You can use IAM policies to control this decision's access to Amazon SWF resources as follows:</p> <ul> <li>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains.</li> <li>Use an <code>Action</code> element to allow or deny permission to call this action.</li> <li>You cannot use an IAM policy to constrain this action's parameters.</li> </ul> <p>If the caller does not have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <b>cause</b> parameter will be set to OPERATION_NOT_PERMITTED. For details and example IAM policies, see <a href=\"http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html\">Using IAM to Manage Access to Amazon SWF Workflows</a>.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -2983,6 +3056,7 @@
         },
         "StartTimerFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>StartTimerFailed</code> event.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -3061,6 +3135,7 @@
         },
         "TagFilter": {
             "type": "structure",
+            "documentation": "<p>Used to filter the workflow executions in visibility APIs based on a tag.</p>",
             "members": [
                 {
                     "name": "tag",
@@ -3075,6 +3150,7 @@
         },
         "TaskList": {
             "type": "structure",
+            "documentation": "<p>Represents a task list.</p>",
             "members": [
                 {
                     "name": "name",
@@ -3129,6 +3205,7 @@
         },
         "TimerCanceledEventAttributes": {
             "type": "structure",
+            "documentation": "<p> Provides details of the <code>TimerCanceled</code> event. </p>",
             "members": [
                 {
                     "name": "timerId",
@@ -3149,6 +3226,7 @@
         },
         "TimerFiredEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>TimerFired</code> event.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -3167,6 +3245,7 @@
         },
         "TimerStartedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>TimerStarted</code> event.</p>",
             "members": [
                 {
                     "name": "timerId",
@@ -3198,6 +3277,7 @@
         },
         "TypeAlreadyExistsFault": {
             "type": "structure",
+            "documentation": "<p>Returned if the type already exists in the specified domain. You will get this fault even if the existing type is in deprecated status. You can specify another version if the intent is to create a new distinct version of the type.</p>",
             "members": [
                 {
                     "name": "message",
@@ -3208,6 +3288,7 @@
         },
         "TypeDeprecatedFault": {
             "type": "structure",
+            "documentation": "<p>Returned when the specified activity or workflow type was already deprecated.</p>",
             "members": [
                 {
                     "name": "message",
@@ -3218,6 +3299,7 @@
         },
         "UnknownResourceFault": {
             "type": "structure",
+            "documentation": "<p>Returned when the named resource cannot be found with in the scope of this operation (region or domain). This could happen if the named resource was never created or is no longer available for this operation.</p>",
             "members": [
                 {
                     "name": "message",
@@ -3234,6 +3316,7 @@
         },
         "WorkflowExecution": {
             "type": "structure",
+            "documentation": "<p>Represents a workflow execution.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -3249,6 +3332,7 @@
         },
         "WorkflowExecutionAlreadyStartedFault": {
             "type": "structure",
+            "documentation": "<p>Returned by <a>StartWorkflowExecution</a> when an open execution with the same workflowId is already running in the specified domain.</p>",
             "members": [
                 {
                     "name": "message",
@@ -3262,6 +3346,7 @@
         },
         "WorkflowExecutionCancelRequestedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionCancelRequested</code> event.</p>",
             "members": [
                 {
                     "name": "externalWorkflowExecution",
@@ -3282,6 +3367,7 @@
         },
         "WorkflowExecutionCanceledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionCanceled</code> event.</p>",
             "members": [
                 {
                     "name": "details",
@@ -3297,6 +3383,7 @@
         },
         "WorkflowExecutionCompletedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionCompleted</code> event.</p>",
             "members": [
                 {
                     "name": "result",
@@ -3312,6 +3399,7 @@
         },
         "WorkflowExecutionConfiguration": {
             "type": "structure",
+            "documentation": "<p>The configuration settings for a workflow execution including timeout values, tasklist etc. These configuration settings are determined from the defaults specified when registering the workflow type and those specified when starting the workflow execution.</p>",
             "members": [
                 {
                     "name": "taskStartToCloseTimeout",
@@ -3342,6 +3430,7 @@
         },
         "WorkflowExecutionContinuedAsNewEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionContinuedAsNew</code> event.</p>",
             "members": [
                 {
                     "name": "input",
@@ -3394,6 +3483,7 @@
         },
         "WorkflowExecutionCount": {
             "type": "structure",
+            "documentation": "<p>Contains the count of workflow executions returned from <a>CountOpenWorkflowExecutions</a> or <a>CountClosedWorkflowExecutions</a></p>",
             "members": [
                 {
                     "name": "count",
@@ -3409,6 +3499,7 @@
         },
         "WorkflowExecutionDetail": {
             "type": "structure",
+            "documentation": "<p>Contains details about a workflow execution.</p>",
             "members": [
                 {
                     "name": "executionInfo",
@@ -3439,6 +3530,7 @@
         },
         "WorkflowExecutionFailedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionFailed</code> event.</p>",
             "members": [
                 {
                     "name": "reason",
@@ -3459,6 +3551,7 @@
         },
         "WorkflowExecutionFilter": {
             "type": "structure",
+            "documentation": "<p>Used to filter the workflow executions in visibility APIs by their <code>workflowId</code>.</p>",
             "members": [
                 {
                     "name": "workflowId",
@@ -3469,6 +3562,7 @@
         },
         "WorkflowExecutionInfo": {
             "type": "structure",
+            "documentation": "<p>Contains information about a workflow execution. </p>",
             "members": [
                 {
                     "name": "execution",
@@ -3523,6 +3617,7 @@
         },
         "WorkflowExecutionInfos": {
             "type": "structure",
+            "documentation": "<p>Contains a paginated list of information about workflow executions.</p>",
             "members": [
                 {
                     "name": "executionInfos",
@@ -3538,6 +3633,7 @@
         },
         "WorkflowExecutionOpenCounts": {
             "type": "structure",
+            "documentation": "<p>Contains the counts of open tasks, child workflow executions and timers for a workflow execution.</p>",
             "members": [
                 {
                     "name": "openActivityTasks",
@@ -3563,6 +3659,7 @@
         },
         "WorkflowExecutionSignaledEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionSignaled</code> event.</p>",
             "members": [
                 {
                     "name": "signalName",
@@ -3588,6 +3685,7 @@
         },
         "WorkflowExecutionStartedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of <code>WorkflowExecutionStarted</code> event.</p>",
             "members": [
                 {
                     "name": "input",
@@ -3650,6 +3748,7 @@
         },
         "WorkflowExecutionTerminatedEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionTerminated</code> event.</p>",
             "members": [
                 {
                     "name": "reason",
@@ -3675,6 +3774,7 @@
         },
         "WorkflowExecutionTimedOutEventAttributes": {
             "type": "structure",
+            "documentation": "<p>Provides details of the <code>WorkflowExecutionTimedOut</code> event.</p>",
             "members": [
                 {
                     "name": "timeoutType",
@@ -3696,6 +3796,7 @@
         },
         "WorkflowType": {
             "type": "structure",
+            "documentation": "<p>Represents a workflow type.</p>",
             "members": [
                 {
                     "name": "name",
@@ -3711,6 +3812,7 @@
         },
         "WorkflowTypeConfiguration": {
             "type": "structure",
+            "documentation": "<p>The configuration settings of a workflow type.</p>",
             "members": [
                 {
                     "name": "defaultTaskStartToCloseTimeout",
@@ -3741,6 +3843,7 @@
         },
         "WorkflowTypeDetail": {
             "type": "structure",
+            "documentation": "<p>Contains details about a workflow type.</p>",
             "members": [
                 {
                     "name": "typeInfo",
@@ -3756,6 +3859,7 @@
         },
         "WorkflowTypeFilter": {
             "type": "structure",
+            "documentation": "<p>Used to filter workflow execution query results by type. Each parameter, if specified, defines a rule that must be satisfied by each returned result.</p>",
             "members": [
                 {
                     "name": "name",
@@ -3771,6 +3875,7 @@
         },
         "WorkflowTypeInfo": {
             "type": "structure",
+            "documentation": "<p>Contains information about a workflow type.</p>",
             "members": [
                 {
                     "name": "workflowType",
@@ -3805,6 +3910,7 @@
         },
         "WorkflowTypeInfos": {
             "type": "structure",
+            "documentation": "<p>Contains a paginated list of information structures about workflow types.</p>",
             "members": [
                 {
                     "name": "typeInfos",

--- a/libcloudcore/data/aws/workspaces/service.json
+++ b/libcloudcore/data/aws/workspaces/service.json
@@ -1,5 +1,9 @@
 {
-    "metadata": {},
+    "metadata": {
+        "request-pipeline": [
+            "libcloudcore.serializers.xml:XmlSerializer"
+        ]
+    },
     "endpoints": [
         {
             "when": [
@@ -120,6 +124,7 @@
         },
         "ComputeType": {
             "type": "structure",
+            "documentation": "<p>Contains information about the compute type of a WorkSpace bundle.</p>",
             "members": [
                 {
                     "name": "Name",
@@ -130,6 +135,7 @@
         },
         "CreateWorkspacesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>CreateWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "Workspaces",
@@ -140,6 +146,7 @@
         },
         "CreateWorkspacesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the result of the <a>CreateWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "FailedRequests",
@@ -158,6 +165,7 @@
         },
         "DefaultWorkspaceCreationProperties": {
             "type": "structure",
+            "documentation": "<p>Contains default WorkSpace creation information.</p>",
             "members": [
                 {
                     "name": "EnableWorkDocs",
@@ -188,6 +196,7 @@
         },
         "DescribeWorkspaceBundlesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeWorkspaceBundles</a> operation.</p>",
             "members": [
                 {
                     "name": "BundleIds",
@@ -208,6 +217,7 @@
         },
         "DescribeWorkspaceBundlesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DescribeWorkspaceBundles</a> operation.</p>",
             "members": [
                 {
                     "name": "Bundles",
@@ -223,6 +233,7 @@
         },
         "DescribeWorkspaceDirectoriesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeWorkspaceDirectories</a> operation.</p>",
             "members": [
                 {
                     "name": "DirectoryIds",
@@ -238,6 +249,7 @@
         },
         "DescribeWorkspaceDirectoriesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>DescribeWorkspaceDirectories</a> operation.</p>",
             "members": [
                 {
                     "name": "Directories",
@@ -253,6 +265,7 @@
         },
         "DescribeWorkspacesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>DescribeWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "WorkspaceIds",
@@ -288,6 +301,7 @@
         },
         "DescribeWorkspacesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results for the <a>DescribeWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "Workspaces",
@@ -330,6 +344,7 @@
         },
         "FailedCreateWorkspaceRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information about a WorkSpace that could not be created.</p>",
             "members": [
                 {
                     "name": "WorkspaceRequest",
@@ -366,6 +381,7 @@
         },
         "FailedWorkspaceChangeRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information about a WorkSpace that could not be rebooted (<a>RebootWorkspaces</a>), rebuilt (<a>RebuildWorkspaces</a>), or terminated (<a>TerminateWorkspaces</a>).</p>",
             "members": [
                 {
                     "name": "WorkspaceId",
@@ -386,6 +402,7 @@
         },
         "InvalidParameterValuesException": {
             "type": "structure",
+            "documentation": "<p>One or more parameter values are not valid.</p>",
             "members": [
                 {
                     "name": "message",
@@ -408,6 +425,7 @@
         },
         "RebootRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information used with the <a>RebootWorkspaces</a> operation to reboot a WorkSpace.</p>",
             "members": [
                 {
                     "name": "WorkspaceId",
@@ -422,6 +440,7 @@
         },
         "RebootWorkspacesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>RebootWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "RebootWorkspaceRequests",
@@ -432,6 +451,7 @@
         },
         "RebootWorkspacesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>RebootWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "FailedRequests",
@@ -442,6 +462,7 @@
         },
         "RebuildRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information used with the <a>RebuildWorkspaces</a> operation to rebuild a WorkSpace.</p>",
             "members": [
                 {
                     "name": "WorkspaceId",
@@ -456,6 +477,7 @@
         },
         "RebuildWorkspacesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>RebuildWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "RebuildWorkspaceRequests",
@@ -466,6 +488,7 @@
         },
         "RebuildWorkspacesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>RebuildWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "FailedRequests",
@@ -479,6 +502,7 @@
         },
         "ResourceLimitExceededException": {
             "type": "structure",
+            "documentation": "<p>Your resource limits have been exceeded.</p>",
             "members": [
                 {
                     "name": "message",
@@ -489,6 +513,7 @@
         },
         "ResourceUnavailableException": {
             "type": "structure",
+            "documentation": "<p>The specified resource is not available.</p>",
             "members": [
                 {
                     "name": "message",
@@ -514,6 +539,7 @@
         },
         "TerminateRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information used with the <a>TerminateWorkspaces</a> operation to terminate a WorkSpace.</p>",
             "members": [
                 {
                     "name": "WorkspaceId",
@@ -528,6 +554,7 @@
         },
         "TerminateWorkspacesRequest": {
             "type": "structure",
+            "documentation": "<p>Contains the inputs for the <a>TerminateWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "TerminateWorkspaceRequests",
@@ -538,6 +565,7 @@
         },
         "TerminateWorkspacesResult": {
             "type": "structure",
+            "documentation": "<p>Contains the results of the <a>TerminateWorkspaces</a> operation.</p>",
             "members": [
                 {
                     "name": "FailedRequests",
@@ -551,6 +579,7 @@
         },
         "UserStorage": {
             "type": "structure",
+            "documentation": "<p>Contains information about the user storage for a WorkSpace bundle.</p>",
             "members": [
                 {
                     "name": "Capacity",
@@ -561,6 +590,7 @@
         },
         "Workspace": {
             "type": "structure",
+            "documentation": "<p>Contains information about a WorkSpace.</p>",
             "members": [
                 {
                     "name": "WorkspaceId",
@@ -611,6 +641,7 @@
         },
         "WorkspaceBundle": {
             "type": "structure",
+            "documentation": "<p>Contains information about a WorkSpace bundle.</p>",
             "members": [
                 {
                     "name": "BundleId",
@@ -646,6 +677,7 @@
         },
         "WorkspaceDirectory": {
             "type": "structure",
+            "documentation": "<p>Contains information about an AWS Directory Service directory for use with Amazon WorkSpaces.</p>",
             "members": [
                 {
                     "name": "DirectoryId",
@@ -731,6 +763,7 @@
         },
         "WorkspaceRequest": {
             "type": "structure",
+            "documentation": "<p>Contains information about a WorkSpace creation request.</p>",
             "members": [
                 {
                     "name": "DirectoryId",

--- a/libcloudcore/models/model.py
+++ b/libcloudcore/models/model.py
@@ -26,6 +26,10 @@ class Integer(Shape):
     kind = "integer"
 
 
+class Float(Shape):
+    kind = "float"
+
+
 class String(Shape):
     kind = "string"
 
@@ -162,8 +166,8 @@ class Model(object):
         'string': String,
         'integer': Integer,
         'long': Integer,
-        'float': Integer,
-        'double': Integer,
+        'float': Float,
+        'double': Float,
         'boolean': Boolean,
         'blob': Blob,
         'timestamp': Timestamp,

--- a/libcloudcore/serializers/json.py
+++ b/libcloudcore/serializers/json.py
@@ -33,6 +33,9 @@ class ShapeVisitor(object):
 
 class Parser(ShapeVisitor):
 
+    def visit_boolean(self, shape, value):
+        return value
+
     def visit_string(self, shape, value):
         return value
 
@@ -66,6 +69,9 @@ class Parser(ShapeVisitor):
 
 
 class Serializer(ShapeVisitor):
+
+    def visit_boolean(self, shape, value):
+        return value
 
     def visit_string(self, shape, value):
         return value
@@ -101,18 +107,18 @@ class Serializer(ShapeVisitor):
 
 class JsonSerializer(layer.Layer):
 
-    def serialize(self, operation, shape, **params):
+    def serialize(self, operation, shape, params):
         return json.dumps(Serializer().visit(shape, params))
 
     def deserialize(self, operation, shape, body):
         return Parser().visit(
             shape,
-            json.loads(body.decode("utf-8")),
+            json.loads(body),
         )
 
     def before_call(self, request, operation, **params):
         request.headers['Content-Type'] = 'application/json'
-        request.body = self.serialize(operation, operation.input_shape, **params)
+        request.body = self.serialize(operation, operation.input_shape, params)
         return super(JsonSerializer, self).before_call(
             request,
             operation,
@@ -120,4 +126,4 @@ class JsonSerializer(layer.Layer):
         )
 
     def after_call(self, operation, request, response):
-        return self.deserialize(operation, operation.output_shape, response.body)
+        return self.deserialize(operation, operation.output_shape, response.body.decode("utf-8"))

--- a/libcloudcore/serializers/json.py
+++ b/libcloudcore/serializers/json.py
@@ -126,4 +126,8 @@ class JsonSerializer(layer.Layer):
         )
 
     def after_call(self, operation, request, response):
-        return self.deserialize(operation, operation.output_shape, response.body.decode("utf-8"))
+        return self.deserialize(
+            operation,
+            operation.output_shape,
+            response.body.decode("utf-8"),
+        )

--- a/libcloudcore/serializers/xml.py
+++ b/libcloudcore/serializers/xml.py
@@ -116,7 +116,7 @@ class Serializer(models.Visitor):
     def visit_float(self, shape, name, value):
         # On python 2.7 we need to take care to repr() floats because
         # >>> str(float("-9999.999999999998"))
-        # '-10000.0’
+        # '-10000.0'
         return repr(value)
 
     visit_double = visit_float

--- a/libcloudcore/serializers/xml.py
+++ b/libcloudcore/serializers/xml.py
@@ -20,6 +20,7 @@ import xmltodict
 import dateutil.parser
 
 from .. import models, layer
+from ..utils import force_str
 
 
 class Parser(models.Visitor):
@@ -182,10 +183,10 @@ class XmlSerializer(layer.Layer):
             else:
                 body["@xmlns"] = uri
 
-        return xmltodict.unparse(
+        return force_str(xmltodict.unparse(
             {shape.wire_name: body},
             pretty=True,
-        )
+        ))
 
     def deserialize(self, operation, shape, body):
         payload = xmltodict.parse(

--- a/libcloudcore/serializers/xml.py
+++ b/libcloudcore/serializers/xml.py
@@ -61,7 +61,7 @@ class Parser(models.Visitor):
         return result
 
     def visit_map(self, shape, value):
-        #FIXME: Make Key/Value configurable
+        # FIXME: Make Key/Value configurable
         if not value:
             return {}
         if not isinstance(value, list):
@@ -136,7 +136,7 @@ class Serializer(models.Visitor):
         return nodes
 
     def visit_map(self, shape, name, value):
-        #FIXME: Make Key/Value configurable
+        # FIXME: Make Key/Value configurable
         key_shape = shape.key_shape
         value_shape = shape.value_shape
         if not value:
@@ -211,4 +211,8 @@ class XmlSerializer(layer.Layer):
         )
 
     def after_call(self, operation, request, response):
-        return self.deserialize(operation, operation.output_shape, response.body)
+        return self.deserialize(
+            operation,
+            operation.output_shape,
+            response.body
+        )

--- a/libcloudcore/serializers/xml.py
+++ b/libcloudcore/serializers/xml.py
@@ -114,7 +114,10 @@ class Serializer(models.Visitor):
     visit_long = visit_integer
 
     def visit_float(self, shape, name, value):
-        return value
+        # On python 2.7 we need to take care to repr() floats because
+        # >>> str(float("-9999.999999999998"))
+        # '-10000.0’
+        return repr(value)
 
     visit_double = visit_float
 

--- a/libcloudcore/serializers/xmlrpc.py
+++ b/libcloudcore/serializers/xmlrpc.py
@@ -22,11 +22,12 @@ from .. import layer
 
 class XmlrpcSerializer(layer.Layer):
 
-    def serialize(self, operation, shape, **params):
+    def serialize(self, operation, shape, params):
         args = []
-        for member in operation.input_shape.iter_members():
-            if member.destination == 'body':
-                args.append(params[member.name])
+        if operation.input_shape:
+            for member in operation.input_shape.iter_members():
+                if member.destination == 'body':
+                    args.append(params[member.name])
 
         return xmlrpc_client.dumps(
             tuple(args),
@@ -49,7 +50,7 @@ class XmlrpcSerializer(layer.Layer):
     def before_call(self, request, operation, **params):
         request.method = 'POST'
         request.headers['Content-Type'] = 'text/xml'
-        request.body = self.serialize(operation, operation.input_shape, **params)
+        request.body = self.serialize(operation, operation.input_shape, params)
         return super(XmlrpcSerializer, self).before_call(
             request,
             operation,

--- a/libcloudcore/serializers/xmlrpc.py
+++ b/libcloudcore/serializers/xmlrpc.py
@@ -58,4 +58,8 @@ class XmlrpcSerializer(layer.Layer):
         )
 
     def after_call(self, operation, request, response):
-        return self.deserialize(operation, operation.output_shape, response.body)
+        return self.deserialize(
+            operation,
+            operation.output_shape,
+            response.body,
+        )

--- a/libcloudcore/tests/test_data.py
+++ b/libcloudcore/tests/test_data.py
@@ -17,7 +17,18 @@ import os
 
 import pytest
 
+from hypothesis import given, strategies, Settings
+
+from libcloudcore.exceptions import ParameterError
 from libcloudcore.importer import Importer
+from libcloudcore import models
+
+
+# FIXME: \r is encoded as \n
+# FIXME: \x0b is not a well formed token according to expat
+# xml.parsers.expat.ExpatError: not well-formed (invalid token): line 5, column 16
+# FIXME ditto for \x0c
+PRINTABLE = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n'
 
 
 def find_services():
@@ -29,69 +40,140 @@ def find_services():
             yield os.path.relpath(path, root)
 
 
-def resolve_structure(shape, state):
-    for member in shape.iter_members():
-        resolve_shape(member.shape, state)
-
-
-def resolve_list(shape, state):
-    assert "of" in shape._shape
-    resolve_shape(shape.of, state)
-
-
-def resolve_map(shape, state):
-    pass
-
-
-def resolve_int(shape, state):
-    pass
-
-
-def resolve_boolean(shape, state):
-    pass
-
-
-def resolve_string(shape, state):
-    pass
-
-
-def resolve_blob(shape, state):
-    pass
-
-
-def resolve_timestamp(shape, state):
-    pass
-
-
-def resolve_shape(shape, state):
-    if shape.name in state:
-        return
-    state.add(shape.name)
-    resolvers = {
-        "structure": resolve_structure,
-        "list": resolve_list,
-        "map": resolve_map,
-        "long": resolve_int,
-        "integer": resolve_int,
-        "float": resolve_int,
-        "double": resolve_int,
-        "boolean": resolve_boolean,
-        "string": resolve_string,
-        "blob": resolve_blob,
-        "timestamp": resolve_timestamp,
-    }
-    assert shape.type in tuple(resolvers.keys())
-    return resolvers[shape.type](shape, state)
-
-
-@pytest.mark.parametrize('service', find_services())
-def test_data(service):
+def find_operations():
     session = Importer(__name__)
-    driver = session.get_driver(service)
-    for operation in driver.model.get_operations():
-        if operation.input_shape:
-            assert len(operation.input_shape.name) > 0
-            resolve_shape(operation.input_shape, set())
-        if operation.output_shape:
-            assert len(operation.output_shape.name) > 0
-            resolve_shape(operation.output_shape, set())
+    for service in find_services():
+        if service == "gandi":
+            continue
+        driver = session.get_driver(service)
+        for operation in driver.model.get_operations():
+            yield service, operation.name, driver, operation
+
+
+class StrategyBuilder(models.Visitor):
+
+    def __init__(self):
+        self.active = set()
+
+    def visit(self, shape):
+        assert shape.type != None
+        visit_fn_name = "visit_{}".format(shape.type)
+        try:
+            visit_fn = getattr(self, visit_fn_name)
+        except AttributeError:
+            raise NotImplementedError(visit_fn_name)
+        return visit_fn(shape)
+
+    def visit_string(self, shape):
+        return strategies.text(
+            alphabet=PRINTABLE,
+            min_size=shape.min,
+            max_size=shape.max or 12,
+        )
+
+    def visit_integer(self, shape):
+        return strategies.integers(
+            min_value=shape.min,
+            max_value=shape.max,
+        )
+
+    visit_long = visit_integer
+
+    def visit_float(self, shape):
+        return strategies.floats(
+            min_value=shape.min or -10000,
+            max_value=shape.max or 10000,
+        )
+
+    visit_double = visit_float
+
+    def visit_boolean(self, shape):
+        return strategies.booleans()
+
+    def visit_timestamp(self, shape):
+        from hypothesis.extra.datetime import datetimes
+        return datetimes(
+            min_year=1900,
+            max_year=2100,
+        )
+
+    def visit_blob(self, shape):
+        # FIXME: strategies.binary
+        # xmltodict can't roundtrip b'\x00'
+        return strategies.text(
+            alphabet=PRINTABLE,
+            min_size=shape.min,
+            max_size=shape.max or 50,
+        )
+
+    def visit_list(self, shape):
+        return strategies.lists(
+            self.visit(shape.of),
+            max_size=5,
+        )
+
+    def visit_map(self, shape):
+        if shape.name in self.active:
+            return strategies.fixed_dictionaries({})
+        self.active.add(shape.name)
+        try:
+            return strategies.dictionaries(
+                keys=self.visit(shape.key_shape),
+                values=self.visit(shape.value_shape),
+            )
+        finally:
+            self.active.remove(shape.name)
+
+    def visit_structure(self, shape):
+        if shape.name in self.active:
+            return strategies.fixed_dictionaries({})
+        self.active.add(shape.name)
+        try:
+            structure = {}
+            for member in shape.iter_members():
+                structure[member.name] = self.visit(member.shape)
+            return strategies.fixed_dictionaries(structure)
+        finally:
+            self.active.remove(shape.name)
+
+
+def roundtrip(driver, operation, shape):
+    strategy = StrategyBuilder().visit(shape)
+
+    @given(strategy, settings=Settings(min_satisfying_examples=1))
+    def inner(data):
+        serialized = driver.serialize(
+            operation,
+            shape,
+            data
+        )
+        assert isinstance(serialized, str)
+
+        deserialized = driver.deserialize(
+            operation,
+            shape,
+            serialized
+        )
+        assert data == deserialized
+    return inner()
+
+
+@pytest.mark.parametrize('driver_name,operation_name,driver,operation', find_operations())
+def test_data(driver_name, operation_name, driver, operation):
+    if operation.input_shape:
+        assert len(operation.input_shape.name) > 0
+
+        roundtrip(
+            driver(),
+            operation,
+            operation.input_shape
+        )
+
+    if operation.output_shape:
+        assert len(operation.output_shape.name) > 0
+
+        roundtrip(
+            driver(),
+            operation,
+            operation.output_shape
+        )

--- a/libcloudcore/tests/test_data.py
+++ b/libcloudcore/tests/test_data.py
@@ -48,6 +48,8 @@ def find_operations():
     for service in find_services():
         if service == "gandi":
             continue
+        if service == "aws/dynamodb":
+            continue
         driver = session.get_driver(service)
         for operation in driver.model.get_operations():
             yield service, operation.name, driver, operation
@@ -112,7 +114,7 @@ class StrategyBuilder(models.Visitor):
     def visit_list(self, shape):
         return strategies.lists(
             self.visit(shape.of),
-            max_size=5,
+            max_size=1,
         )
 
     def visit_map(self, shape):
@@ -145,7 +147,7 @@ def roundtrip(driver, operation, shape):
 
     settings = Settings(
         min_satisfying_examples=1,
-        max_examples=10,
+        max_examples=3,
     )
 
     @given(strategy, settings=settings)

--- a/libcloudcore/tests/test_data.py
+++ b/libcloudcore/tests/test_data.py
@@ -26,9 +26,12 @@ from libcloudcore import models
 
 # FIXME: \r is encoded as \n
 # FIXME: \x0b is not a well formed token according to expat
-# xml.parsers.expat.ExpatError: not well-formed (invalid token): line 5, column 16
+# xml.parsers.expat.ExpatError: not well-formed (invalid token)
 # FIXME ditto for \x0c
-PRINTABLE = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n'
+PRINTABLE = (
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKL'
+    'MNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n'
+)
 
 
 def find_services():
@@ -56,7 +59,7 @@ class StrategyBuilder(models.Visitor):
         self.active = set()
 
     def visit(self, shape):
-        assert shape.type != None
+        assert shape.type is not None
         visit_fn_name = "visit_{}".format(shape.type)
         try:
             visit_fn = getattr(self, visit_fn_name)
@@ -149,7 +152,7 @@ def roundtrip(driver, operation, shape):
     def inner(data):
         try:
             driver.validate(shape, data)
-        except exceptions.ParameterError:
+        except ParameterError:
             assume(False)
 
         serialized = driver.serialize(operation, shape, data)
@@ -161,8 +164,8 @@ def roundtrip(driver, operation, shape):
     return inner()
 
 
-@pytest.mark.parametrize('driver_name,operation_name,driver,operation', find_operations())
-def test_data(driver_name, operation_name, driver, operation):
+@pytest.mark.parametrize('d,o,driver,operation', find_operations())
+def test_data(d, o, driver, operation):
     if operation.input_shape:
         assert len(operation.input_shape.name) > 0
 

--- a/libcloudcore/tests/test_serializers_xml.py
+++ b/libcloudcore/tests/test_serializers_xml.py
@@ -71,16 +71,18 @@ class TestXmlSerializer(unittest.TestCase):
         result = self.layer.serialize(
             operation,
             operation.output_shape,
-            HostedZones=[{
-                "Id": "/hostedzone/ZONE_ID",
-                "Name": "www.example.com",
-                "CallerReference": "CALLER_REFERENCE",
-                "Config": {
-                    "Comment": "COMMENT",
-                    "PrivateZone": True,
-                },
-                "ResourceRecordSetCount": 0,
-            }],
+            dict(
+                HostedZones=[{
+                    "Id": "/hostedzone/ZONE_ID",
+                    "Name": "www.example.com",
+                    "CallerReference": "CALLER_REFERENCE",
+                    "Config": {
+                        "Comment": "COMMENT",
+                        "PrivateZone": True,
+                    },
+                    "ResourceRecordSetCount": 0,
+                }],
+            ),
         )
 
         xml = """
@@ -116,9 +118,11 @@ class TestXmlToDictEdges(base.DriverTestCase):
         result = self.driver.serialize(
             operation,
             operation.output_shape,
-            text="TEXT",
-            attr="ATTR",
-            child="CHILD",
+            dict(
+                text="TEXT",
+                attr="ATTR",
+                child="CHILD",
+            ),
         )
         self.assertEqual(xmltodict.parse(result), {
             "TestComplicatedStructure": {

--- a/libcloudcore/tests/test_serializers_xml.py
+++ b/libcloudcore/tests/test_serializers_xml.py
@@ -49,7 +49,8 @@ class TestXmlSerializer(unittest.TestCase):
         </ListHostedZonesByNameResponse>""".strip()
 
         operation = self.model.get_operation("ListHostedZonesByName")
-        self.assertEqual(self.layer._parse_xml(operation, xml), {
+        shape = operation.output_shape
+        self.assertEqual(self.layer.deserialize(operation, shape, xml), {
             "HostedZones": [{
                 "Id": "/hostedzone/ZONE_ID",
                 "Name": "www.example.com",
@@ -67,7 +68,7 @@ class TestXmlSerializer(unittest.TestCase):
     def test_serialize(self):
         operation = self.model.get_operation("ListHostedZonesByName")
 
-        result = self.layer._serialize(
+        result = self.layer.serialize(
             operation,
             operation.output_shape,
             HostedZones=[{
@@ -112,7 +113,7 @@ class TestXmlToDictEdges(base.DriverTestCase):
 
     def test_serialize_complicated_structure(self):
         operation = self.model.get_operation("test_complicated_structure")
-        result = self.driver._serialize(
+        result = self.driver.serialize(
             operation,
             operation.output_shape,
             text="TEXT",

--- a/libcloudcore/validation.py
+++ b/libcloudcore/validation.py
@@ -30,7 +30,7 @@ def _check_type(field, value, types, report):
         report.append(ReportItem(
             field,
             "invalid_type",
-            "passed {} but expected on of ({})".format(
+            "passed {} but expected one of ({})".format(
                 value,
                 ", ".join(str(t) for t in types)
             )
@@ -149,8 +149,20 @@ def _validate_string(field, shape, value, report):
         return
 
 
+def _validate_blob(field, shape, value, report):
+    return True
+
+
 def _validate_integer(field, shape, value, report):
     if not _check_type(field, value, six.integer_types, report):
+        return
+
+    if not _check_range(field, value, shape.min, shape.max, report):
+        return
+
+
+def _validate_float(field, shape, value, report):
+    if not _check_type(field, value, float, report):
         return
 
     if not _check_range(field, value, shape.min, shape.max, report):

--- a/libcloudcore/validation.py
+++ b/libcloudcore/validation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import re
 import six
 from collections import namedtuple
@@ -153,6 +154,11 @@ def _validate_integer(field, shape, value, report):
         return
 
     if not _check_range(field, value, shape.min, shape.max, report):
+        return
+
+
+def _validate_timestamp(field, shape, value, report):
+    if not _check_type(field, value, datetime.datetime, report):
         return
 
 

--- a/libcloudcore/validation.py
+++ b/libcloudcore/validation.py
@@ -173,13 +173,15 @@ def validate_shape(shape, value):
 
 class Validation(Layer):
 
-    def before_call(self, request, operation, **params):
-        report = validate_shape(operation.input_shape, params)
+    def validate(self, shape, params):
+        report = validate_shape(shape, params)
         if report:
             raise ParameterError("\n".join(
                 "{}: {}".format(r.field, r.message) for r in report,
             ))
 
+    def before_call(self, request, operation, **params):
+        self.validate(operation.input_shape, params)
         return super(Validation, self).before_call(
             request,
             operation,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,7 @@ py==1.4.28
 pyflakes==0.9.2
 pytest==2.7.1
 httpbin
+hypothesis
+pytz
 
 -e .


### PR DESCRIPTION
For all supported services/operations we should be able to take test data that conforms to the schema, serialize it, deserialize it and have the same data on the other side.

This does not ensure that the serialized form is actually valid, but it instead compliments other tests that do that and makes sure that our code can handle a wide range of inputs without exploding.
